### PR TITLE
Typing indicators

### DIFF
--- a/src/api/client/sync/v3.rs
+++ b/src/api/client/sync/v3.rs
@@ -840,7 +840,7 @@ async fn load_joined_room(
 			let typings = services
 				.rooms
 				.typing
-				.typings_all(room_id, sender_user)
+				.typings_event_for_user(room_id, sender_user)
 				.await?;
 
 			Ok(vec![serde_json::from_str(&serde_json::to_string(&typings)?)?])

--- a/src/service/rooms/typing/mod.rs
+++ b/src/service/rooms/typing/mod.rs
@@ -195,17 +195,15 @@ impl Service {
 	}
 
 	/// Returns a new typing EDU.
-	pub async fn typings_all(
+	pub async fn typing_users_for_user(
 		&self,
 		room_id: &RoomId,
 		sender_user: &UserId,
-	) -> Result<SyncEphemeralRoomEvent<ruma::events::typing::TypingEventContent>> {
+	) -> Result<Vec<OwnedUserId>> {
 		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
 
 		let Some(typing_indicators) = room_typing_indicators else {
-			return Ok(SyncEphemeralRoomEvent {
-				content: ruma::events::typing::TypingEventContent { user_ids: Vec::new() },
-			});
+			return Ok(Vec::new());
 		};
 
 		let user_ids: Vec<_> = typing_indicators
@@ -222,8 +220,20 @@ impl Service {
 			.collect()
 			.await;
 
+		Ok(user_ids)
+	}
+
+	pub async fn typings_event_for_user(
+		&self,
+		room_id: &RoomId,
+		sender_user: &UserId,
+	) -> Result<SyncEphemeralRoomEvent<ruma::events::typing::TypingEventContent>> {
 		Ok(SyncEphemeralRoomEvent {
-			content: ruma::events::typing::TypingEventContent { user_ids },
+			content: ruma::events::typing::TypingEventContent {
+				user_ids: self
+					.typing_users_for_user(room_id, sender_user)
+					.await?,
+			},
 		})
 	}
 


### PR DESCRIPTION
closes: #99 

This is technically working ATM, but a little janky. 

- Element often makes 2 calls to `/sync` and the second clears the typing indicators. If you wait long enough it'll call `/sync` again and store the typing indicator. However if the other client does anything it'll be cleared immediately.

- This kind of avoids the todo_rooms APIs since for some reason it'll only make requests for 1 of the 2 test rooms I have.