### PR TITLE
Fixed nix cached shasum for rust-toolchain.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         file = ./rust-toolchain.toml;
 
         # See also `rust-toolchain.toml`
-        sha256 = "sha256-X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
+        sha256 = "sha256-Qxt8XAuaUR2OMdKbN4u8dBJOhSHxS+uS06Wl9+flVEk=";
       };
 
       mkScope = pkgs: pkgs.lib.makeScope pkgs.newScope (self: {


### PR DESCRIPTION
This is a small fix to fix up the hash stored in the nix flake, making it possible to compile through nix again!\
(sending this PR in myself, as it has been broken for a few weeks, and I've hoped that someone else fixes this before me)

When updating the `rust-toolchain.toml` file, please remember to also update it's corresponding hash in the nix flake if possible.