### PR TITLE
Make server bot / user name configurable.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ You can reinvite yourself to the admin room through the following methods:
 argument once to invite yourslf to the admin room on startup
 - Use the Tuwunel console/CLI to run the `users make_user_admin` command
 - Or specify the `emergency_password` config option to allow you to temporarily
-log into the server account (`@conduit`) from a web client
+log into the server account (`@conduit` or `@tuwunel`) from a web client
 
 ## General potential issues
 

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -69,10 +69,10 @@ impl crate::Service for Service {
 			admin_alias: OwnedRoomAliasId::try_from(format!("#admins:{}", &args.server.name))
 				.expect("#admins:server_name is valid alias name"),
 			server_user: UserId::parse_with_server_name(
-				String::from("conduit"),
+				&config.server_user,
 				&args.server.name,
 			)
-			.expect("@conduit:server_name is valid"),
+			.expect("server user is valid"),
 			turn_secret,
 			registration_token,
 		}))


### PR DESCRIPTION
This is the proposal for fixing #117 bei making the server bot/user name configurable after finding out that the original proposal was not well analyzed (in respect to existing databases).

Basically now it can be decided if to use  either 'conduit' or 'tuwunel' as name. Why only two? not really necessary, but to keep it in line with having a well defined one (the old 'conduit') only a second choice is added. Also, the validation helps to ensure that not '@' prefixes are used or an empty string, which would raise a panic due to usage of the function  `parse_with_server_name` in Ruma.

I hope it is acceptable.