### PR TITLE
Clarify Caddy config in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ using the configuration and Tuwunel can be deployed without a reverse proxy. Exa
 `/etc/caddy/Caddyfile` configuration with [Element](https://github.com/element-hq/element-web/releases)
 unzipped to `/var/www/element`:
 ```
-https://tuwunel.me:8448 {
-	reverse_proxy http://127.0.0.1:8008
+tuwunel.me, tuwunel.me:8448 {
+    reverse_proxy localhost:8008
 }
-https://tuwunel.me:443 {
-	root * /var/www/element/
-	file_server
+web.tuwunel.me {
+    root * /var/www/element/
+    file_server
 }
 ```
 `caddy reload --config /etc/caddy/Caddyfile`
@@ -75,7 +75,7 @@ granted server admin.
 
  🤗 Did you find this and other documentation helpful? We would love to hear feedback about setting
  up Tuwunel.
-	
+
 
 ### Migrating to Tuwunel
 

--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -153,7 +153,7 @@ and enter this (substitute for your server name).
 ```caddyfile
 your.server.name, your.server.name:8448 {
     # TCP reverse_proxy
-    reverse_proxy 127.0.0.1:6167
+    reverse_proxy localhost:8008
     # UNIX socket
     #reverse_proxy unix//run/tuwunel/tuwunel.sock
 }


### PR DESCRIPTION
The issue was highlighted in #138. It has simple solution, so I decided for first time contribution ^^.

My PR updates Caddy config example in README.md and syncs it with generic deployment doc page. 

I used my own configuration which is working good on ARM64 Tuwunel server. I can easily access Matrix server with all features working fine and federation is working too.

Every error mentioned in #138 can't be replicated. 