### PR TITLE
packaging: Move unit alias to install section

### DIFF
--- a/arch/tuwunel.service
+++ b/arch/tuwunel.service
@@ -4,7 +4,6 @@ Wants=network-online.target
 After=network-online.target
 Documentation=https://tuwunel.chat/
 RequiresMountsFor=/var/lib/private/tuwunel
-Alias=matrix-tuwunel.service
 
 [Service]
 DynamicUser=yes
@@ -77,3 +76,4 @@ StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target
+Alias=matrix-tuwunel.service

--- a/debian/tuwunel.service
+++ b/debian/tuwunel.service
@@ -2,7 +2,6 @@
 Description=Tuwunel Matrix homeserver
 Wants=network-online.target
 After=network-online.target
-Alias=matrix-tuwunel.service
 Documentation=https://tuwunel.chat/
 
 [Service]
@@ -64,3 +63,4 @@ StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target
+Alias=matrix-tuwunel.service

--- a/rpm/tuwunel.service
+++ b/rpm/tuwunel.service
@@ -2,7 +2,6 @@
 Description=Tuwunel Matrix homeserver
 Wants=network-online.target
 After=network-online.target
-Alias=matrix-tuwunel.service
 Documentation=https://tuwunel.chat/
 
 [Service]
@@ -63,3 +62,4 @@ StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target
+Alias=matrix-tuwunel.service


### PR DESCRIPTION
Otherwise there will be

```console
systemd[1]: /usr/lib/systemd/system/tuwunel.service:5: Unknown key 'Alias' in section [Unit], ignoring.
```

on startup. See `systemd.unit(5)`.