### PR TITLE
Fix off-by-one in sync v5

### DIFF
--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -286,6 +286,7 @@ where
 		let ranges = list.ranges.clone();
 		for mut range in ranges {
 			range.0 = uint!(0);
+			range.1 = range.1.checked_add(uint!(1)).unwrap_or(range.1);
 			range.1 = range
 				.1
 				.clamp(range.0, UInt::try_from(active_rooms.len()).unwrap_or(UInt::MAX));


### PR DESCRIPTION
Simplified sliding sync specifies ranges to be inclusive while rust ranges are exclusive.