### PR TITLE
Fix tests in nix and re-enable

### DIFF
--- a/nix/pkgs/main/default.nix
+++ b/nix/pkgs/main/default.nix
@@ -202,8 +202,25 @@ craneLib.buildPackage ( commonAttrs // {
     env = buildDepsOnlyEnv;
   });
 
-  # Disabled due to integration test failing to find /etc/resolv.conf
-  doCheck = false;
+  nativeCheckInputs = [
+    pkgsBuildHost.libredirect.hook
+  ];
+
+  preCheck =
+    let
+      fakeResolvConf = pkgsBuildHost.writeTextFile {
+        name = "resolv.conf";
+        text = ''
+          nameserver 0.0.0.0
+        '';
+      };
+    in
+    ''
+      export NIX_REDIRECTS="/etc/resolv.conf=${fakeResolvConf}"
+      export TUWUNEL_DATABASE_PATH="$(mktemp -d)/smoketest.db"
+    '';
+  doCheck = true;
+
   doBenchmark = false;
 
   cargoExtraArgs = "--no-default-features --locked "


### PR DESCRIPTION
Fix the tests in the nix build and re-enable them.

This mirrors the fix we used in nixpkgs: https://github.com/NixOS/nixpkgs/commit/5efa5790dc6e1cc2ec684c61ca1fffd6a3f0ca71

I tested by running `nix build .#default`.