### PR TITLE
Fix #97 - LDAP-authenticated client cannot unauthorize sessions

### DIFF
--- a/src/service/uiaa/mod.rs
+++ b/src/service/uiaa/mod.rs
@@ -93,6 +93,7 @@ pub fn create(
 }
 
 #[implement(Service)]
+#[allow(clippy::useless_let_if_seq)]
 pub async fn try_auth(
 	&self,
 	user_id: &UserId,


### PR DESCRIPTION
This PR fixes #97 - tries password authentication with LDAP if it's enabled and local password authentication failed