### PR TITLE
Add an option to read SSO client secret from a file

### DIFF
--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -288,6 +288,35 @@ pub fn check(config: &Config) -> Result {
 		));
 	}
 
+	for (i, provider) in config.identity_provider.iter().enumerate() {
+		if provider.client_secret.is_some() {
+			continue;
+		}
+
+		let Some(secret_path) = &provider.client_secret_file else {
+			return Err!(Config(
+				"client_secret",
+				"Either client secret or a client secret file must be set on identity provider \
+				 №{i}."
+			));
+		};
+
+		let Ok(secret) = std::fs::read_to_string(secret_path) else {
+			return Err!(Config(
+				"client_secret_file",
+				"Client secret file was specified but failed to be read at identity provider \
+				 №{i}"
+			));
+		};
+
+		if secret.is_empty() {
+			return Err!(Config(
+				"client_secret_file",
+				"Client secret file was specified but is empty on identity provider №{i}"
+			));
+		}
+	}
+
 	Ok(())
 }
 

--- a/src/service/oauth/mod.rs
+++ b/src/service/oauth/mod.rs
@@ -97,9 +97,11 @@ pub async fn revoke_token(&self, (provider, session): (&Provider, &Session)) -> 
 		client_secret: &'a str,
 	}
 
+	let client_secret = provider.get_client_secret().await?;
+
 	let query = RevokeQuery {
 		client_id: &provider.client_id,
-		client_secret: &provider.client_secret,
+		client_secret: &client_secret,
 	};
 
 	let url = provider
@@ -130,9 +132,11 @@ pub async fn request_token(
 		redirect_uri: Option<&'a str>,
 	}
 
+	let client_secret = provider.get_client_secret().await?;
+
 	let query = TokenQuery {
 		client_id: &provider.client_id,
-		client_secret: &provider.client_secret,
+		client_secret: &client_secret,
 		grant_type: "authorization_code",
 		code,
 		code_verifier: session.code_verifier.as_deref(),


### PR DESCRIPTION
Issue raised in the support room. For [NixOS users who don't want their secret be publicly readable](https://matrix.to/#/!l2xV0sd51lraysuRcsWVECge4NULaH3g-ou95vgDgiM/$kL5uGUDFiv3ToHlvhqREPZ23AqwdnqXUlN6EkG-ZN7s?via=cwt.grin.hu&via=matrix.org&via=tuwunel.love).