### PR TITLE
Fix mistake in matrix_rtc.md for serving .well-known from tuwunel.

### DIFF
--- a/docs/matrix_rtc.md
+++ b/docs/matrix_rtc.md
@@ -68,7 +68,7 @@ keys:
 type = "livekit"
 livekit_service_url = "https://matrix-rtc.yourdomain.com"
 ```
-4. Close the file.
+3. Close the file.
 
 #### 3.2. .well-known served independently
 ***Follow this step if you serve your .well-known/matrix files directly. Otherwise follow Step 3.1***


### PR DESCRIPTION
Updates matrix-rtc.md to match the example provided in tuwunel-example.toml.

The pull request opened just now contained a typo.