### PR TITLE
Stop storing media in shared caches

### DIFF
--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -40,7 +40,7 @@ pub struct Service {
 pub const MXC_LENGTH: usize = 32;
 
 /// Cache control for immutable objects.
-pub const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
+pub const CACHE_CONTROL_IMMUTABLE: &str = "private,max-age=31536000,immutable";
 
 /// Default cross-origin resource policy.
 pub const CORP_CROSS_ORIGIN: &str = "cross-origin";


### PR DESCRIPTION
Cache-Control=public leads to everyone being able to GET media from some shared cache (e.g. Cloudflare's)

I thought about making this a config option, because this will lead to more bandwidth usage on some servers. For now, if this is concerning to someone, they can always overwrite that behaviour by using cache rules on their proxies.
