### PR TITLE
Change away from deprecated variable in MatrixRTC setup

### DIFF
--- a/docs/matrix_rtc.md
+++ b/docs/matrix_rtc.md
@@ -19,7 +19,7 @@ services:
     image: ghcr.io/element-hq/lk-jwt-service:latest
     container_name: matrix-rtc-jwt
     environment:
-      - LIVEKIT_JWT_PORT=8081
+      - LIVEKIT_JWT_BIND=:8081
       - LIVEKIT_URL=wss://matrix-rtc.yourdomain.com
       - LIVEKIT_KEY=mrtckey
       - LIVEKIT_SECRET=mrtcsecret


### PR DESCRIPTION
When you start a server with the current docs config you get this warning

```
matrix-rtc-jwt  | 2026/02/02 14:39:42 !!! LIVEKIT_JWT_PORT is deprecated, please use LIVEKIT_JWT_BIND instead !!!
```