### PR TITLE
Update Matrix RTC docs for readability and to add instructions for the inbuilt Livekit TURN server

### DIFF
--- a/docs/matrix_rtc.md
+++ b/docs/matrix_rtc.md
@@ -299,6 +299,7 @@ turn:
 ```
 It is strongly recommended that you use `network_mode: "host"`; however if it is necessary to specify port mappings, the following ports should be added to `matrix-rtc-livekit` in your `compose.yaml`:
 ```
+ports:
       - 3478:3478/udp
       - 50300-65535:50300-65535/udp
 ```
@@ -314,6 +315,7 @@ Some WebRTC software will not accept certificates provided by Let's Encrypt. It 
 3. Add the certificates as volumes for `matrix-rtc-livekit` in your `compose.yaml`.
 For example:
 ```
+volumes:
       - ./certs/privkey.pem:/certs/privkey.pem:ro
       - ./certs/fullchain.pem:/certs/fullchain.pem:ro
 ```
@@ -332,6 +334,7 @@ turn:
 ```
 5. It is strongly recommended that you use `network_mode: "host"`; however if it is necessary to specify port mappings, the following ports should be added to `matrix-rtc-livekit` in your `compose.yaml`:
 ```
+ports:
       - 3478:3478/udp
       - 5349:5349/tcp
       - 50300-65535:50300-65535/udp


### PR DESCRIPTION
This pull request primarily adds documentation for using the TURN server built into Livekit.

It also adds updates to the readability of some of the variables that must be changed when setting up Matrix RTC using the guide, and suggests the use of `network_mode: "host"` for livekit.

Finally, it replaces the deprecated `LIVEKIT_JWT_PORT` with  the new `LIVEKIT_JWT_BIND`. Sorry @Xerusion I couldn't work out how to build on top of your PR.