### PR TITLE
docs(docker): use the default port in docker run command

### DIFF
--- a/docs/deploying/docker.md
+++ b/docs/deploying/docker.md
@@ -26,7 +26,7 @@ OCI images for tuwunel are available in the registries listed below.
 When you have the image you can simply run it with
 
 ```bash
-docker run -d -p 8448:6167 \
+docker run -d -p 8448:8008 \
     -v db:/var/lib/tuwunel/ \
     -e TUWUNEL_SERVER_NAME="your.server.name" \
     -e TUWUNEL_ALLOW_REGISTRATION=false \


### PR DESCRIPTION
## Summary

This PR addresses an issue in the `docker run` documentation.
Currently, the example command maps the port to `6167`, but it's missing `TUWUNEL_PORT=6167` to override the default port `8008`.
This change fixes the example by aligning it with the default port `8008`.

https://github.com/matrix-construct/tuwunel/blob/94162974f95f40cf2689c430c2684d98064d08f0/src/core/config/mod.rs#L3064

## Context

I looked into the history of the port configurations.

1. The very first example in conduit used port `14004` (https://github.com/matrix-construct/tuwunel/commit/95047272e85b2f3fcce03e1bd75d93bb18cca256), though the underlying Rocket framework defaulted to `8000`.

2. The example was later updated from `14004` to `6167` (https://github.com/matrix-construct/tuwunel/commit/3bdaf6e79e5ba0f893055c4744d0c107fbfbef77).

3. When refactoring to Axum, the default of `8000` was maintained (https://github.com/matrix-construct/tuwunel/commit/1f7b3fa4acd13ea4962ba93c5bc96bd8aa9f44b3).

4. With the addition of multi-port support (https://github.com/matrix-construct/tuwunel/commit/67b307c75b41aa5c91f9892cbb49a529f7082b4d), the internal default was changed to `8008`, matching Synapse and Dendrite.

## Proposed Changes

I suppose we can remove all `6167` references and update them to the default `8008`, which makes the docs cleaner.

I'm sorry if you have kept `6167` on purpose, as you should already noticed this inconsistency.