### PR TITLE
rm version field from turn docker compose example

### DIFF
--- a/docs/turn.md
+++ b/docs/turn.md
@@ -51,7 +51,6 @@ called `docker-compose.yml` and run `docker compose up -d` in the same
 directory.
 
 ```yml
-version: 3
 services:
     turn:
       container_name: coturn-server


### PR DESCRIPTION
It was giving errors because the docs put 3 as a number and not a string.
When fixed, it still gave me warnings saying that field is obsolete and saying to remove it, so yea