### PR TITLE
Fix SSO/LDAP user origin overwritten by set_password

### DIFF
--- a/src/service/users/mod.rs
+++ b/src/service/users/mod.rs
@@ -236,13 +236,17 @@ impl Service {
 			}
 		}
 
+		let is_sentinel = password.is_some_and(|p| p == "*");
+
 		match password.map(utils::hash::password) {
 			| None => {
 				self.db.userid_password.insert(user_id, b"");
 			},
 			| Some(Ok(hash)) => {
 				self.db.userid_password.insert(user_id, hash);
-				self.db.userid_origin.insert(user_id, "password");
+				if !is_sentinel {
+					self.db.userid_origin.insert(user_id, "password");
+				}
 			},
 			| Some(Err(e)) => {
 				return Err!(Request(InvalidParam(


### PR DESCRIPTION
## Summary

`set_password()` unconditionally overwrites `userid_origin` to `"password"` whenever the password hash succeeds. This clobbers the origin set by `create()` for SSO and LDAP users, which use the sentinel password `"*"`.

**Code path:**
1. `create(user_id, password: Some("*"), origin: Some("sso"))` — sets `userid_origin = "sso"` ✓
2. `create()` calls `self.set_password(user_id, Some("*"))` 
3. `set_password()` hashes `"*"` successfully → overwrites `userid_origin = "password"` ✗

**Impact:** The UIA SSO bypass in `uiaa.rs` checks `users.origin(sender_user) == "sso"`. Since origin is always `"password"`, SSO users can never pass this check. They are prompted for a password they don't have when performing UIA-protected operations (device deletion, etc.), and the SSO bypass never triggers.

**Verified by inspecting a live Tuwunel database** (v1.5.0, commit 5110b9e) — all users including those created via SSO have `origin = "password"`.

## Fix

Skip the `userid_origin` overwrite when the password is the sentinel value `"*"`, preserving the origin already set by `create()`.

```diff
+		let is_sentinel = password.is_some_and(|p| p == "*");
+
 		match password.map(utils::hash::password) {
 			| None => {
 				self.db.userid_password.insert(user_id, b"");
 			},
 			| Some(Ok(hash)) => {
 				self.db.userid_password.insert(user_id, hash);
-				self.db.userid_origin.insert(user_id, "password");
+				if !is_sentinel {
+					self.db.userid_origin.insert(user_id, "password");
+				}
 			},
```

## Notes

- Existing SSO/LDAP users with incorrect `origin = "password"` in the database will need a migration or manual fix to correct their origin values
- An alternative approach would be to pass the `origin` parameter through to `set_password()` and let it decide, but the sentinel check is less invasive