### PR TITLE
Add an option to fix the pathological space usage of RocksDB on btrfs.

### DIFF
--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1350,6 +1350,20 @@ pub struct Config {
 	#[serde(default)]
 	pub rocksdb_never_drop_columns: bool,
 
+	/// Configures RocksDB to not preallocate WAL logs.
+	///
+	/// Normally, RocksDB allocates certain types of files by calling
+	/// fallocate, writing the file contents, then truncating the logs to the
+	/// proper size. This causes pathological disk space usage on btrfs due
+	/// how it interacts with its Copy-on-Write implementation.
+	///
+	/// It is recommended to set this to false if you run the server on btrfs,
+	/// and not touch it otherwise.
+	///
+	/// default: true
+	#[serde(default = "true_fn")]
+	pub rocksdb_allow_fallocate: bool,
+
 	/// This is a password that can be configured that will let you login to the
 	/// server bot account (currently `@conduit`) for emergency troubleshooting
 	/// purposes such as recovering/recreating your admin room, or inviting

--- a/src/database/engine/db_opts.rs
+++ b/src/database/engine/db_opts.rs
@@ -4,6 +4,7 @@ use rocksdb::{Cache, DBRecoveryMode, Env, LogLevel, Options, statistics::StatsLe
 use tuwunel_core::{Config, Result, utils};
 
 use super::{cf_opts::cache_size_f64, logger::handle as handle_log};
+use crate::util::map_err;
 
 /// Create database-wide options suitable for opening the database. This also
 /// sets our default column options in case of opening a column with the same
@@ -57,6 +58,10 @@ pub(crate) fn db_options(config: &Config, env: &Env, row_cache: &Cache) -> Resul
 	opts.set_wal_size_limit_mb(1024);
 	opts.set_max_total_wal_size(1024 * 1024 * 512);
 	opts.set_writable_file_max_buffer_size(1024 * 1024 * 2);
+	if !config.rocksdb_allow_fallocate {
+		opts.set_options_from_string("allow_fallocate=false")
+			.map_err(map_err)?;
+	}
 
 	// Misc
 	opts.set_disable_auto_compactions(!config.rocksdb_compaction);

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1142,6 +1142,18 @@
 #
 #rocksdb_never_drop_columns = false
 
+# Configures RocksDB to not preallocate WAL logs.
+#
+# Normally, RocksDB allocates certain types of files by calling
+# fallocate, writing the file contents, then truncating the logs to the
+# proper size. This causes pathological disk space usage on btrfs due
+# how it interacts with its Copy-on-Write implementation.
+#
+# It is recommended to set this to false if you run the server on btrfs,
+# and not touch it otherwise.
+#
+#rocksdb_allow_fallocate = true
+
 # This is a password that can be configured that will let you login to the
 # server bot account (currently `@conduit`) for emergency troubleshooting
 # purposes such as recovering/recreating your admin room, or inviting


### PR DESCRIPTION
This option avoids creating [bookend extants](https://github.com/btrfs/btrfs-dev-docs/blob/471c5699336e043114d4bca02adcd57d9dab9c44/data-extent-reference-counts.md). This is the solution recommended by the rocksdb devs. (see: [comments in options.h](https://github.com/facebook/rocksdb/blob/feffb67303b7d8f38fd91acb9a5b6f6f06c068c3/include/rocksdb/options.h#L1086-L1095))