### PR TITLE
add federation-upload options

### DIFF
--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1623,6 +1623,16 @@ pub struct Config {
 	#[serde(default, with = "serde_regex")]
 	pub prevent_media_downloads_from: RegexSet,
 
+	/// Policy for handling media from federated servers.
+	///
+	/// - "download": download and store locally (current behavior, default)
+	/// - "proxy": forward the content to the requesting client without saving
+	/// - "drop": reject the content with an error
+	///
+	/// default: "download"
+	#[serde(default)]
+	pub federation_media_policy: FederationMediaPolicy,
+
 	/// List of forbidden server names via regex patterns that we will block
 	/// incoming AND outgoing federation with, and block client room joins /
 	/// remote user invites.
@@ -3419,3 +3429,18 @@ fn default_max_join_attempts_per_join_request() -> usize { 3 }
 fn default_sso_grant_session_duration() -> Option<u64> { Some(300) }
 
 fn default_redaction_retention_seconds() -> u64 { 5_184_000 }
+
+/// Policy for handling media from federated servers.
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FederationMediaPolicy {
+	/// Current behavior: download and store the file locally.
+	#[default]
+	Download,
+
+	/// Return the file to the client without saving it locally.
+	Proxy,
+
+	/// Reject the file entirely if it exceeds max_request_size.
+	Drop,
+}

--- a/src/service/media/remote.rs
+++ b/src/service/media/remote.rs
@@ -14,7 +14,7 @@ use ruma::{
 	},
 };
 use tuwunel_core::{
-	Err, Error, Result, debug_warn, err, implement,
+	Err, Error, Result, config::FederationMediaPolicy, debug_warn, err, implement,
 	utils::content_disposition::make_content_disposition,
 };
 
@@ -208,6 +208,37 @@ async fn handle_thumbnail_file(
 		None,
 	);
 
+	let max_size = self.services.server.config.max_request_size;
+	if content.file.len() > max_size {
+		match self
+			.services
+			.server
+			.config
+			.federation_media_policy
+		{
+			// drop the media
+			| FederationMediaPolicy::Drop => {
+				return Err!(Request(TooLarge(
+					"Remote media exceeds this server's max_request_size"
+				)));
+			},
+			// Return the file to the client without saving it locally
+			| FederationMediaPolicy::Proxy => {
+				debug_warn!(
+					%mxc, size = content.file.len(), %max_size,
+					"Remote media exceeds max_request_size, proxying without saving"
+				);
+				return Ok(FileMeta {
+					content: Some(content.file),
+					content_type: content.content_type.map(Into::into),
+					content_disposition: Some(content_disposition),
+				});
+			},
+			// Download and store the file locally
+			| FederationMediaPolicy::Download => {},
+		}
+	}
+
 	self.upload_thumbnail(
 		mxc,
 		user,
@@ -236,6 +267,37 @@ async fn handle_content_file(
 		content.content_type.as_deref(),
 		None,
 	);
+
+	let max_size = self.services.server.config.max_request_size;
+	if content.file.len() > max_size {
+		match self
+			.services
+			.server
+			.config
+			.federation_media_policy
+		{
+			// drop the media
+			| FederationMediaPolicy::Drop => {
+				return Err!(Request(TooLarge(
+					"Remote media exceeds this server's max_request_size"
+				)));
+			},
+			// Return the file to the client without saving it locally
+			| FederationMediaPolicy::Proxy => {
+				debug_warn!(
+					%mxc, size = content.file.len(), %max_size,
+					"Remote media exceeds max_request_size, proxying without saving"
+				);
+				return Ok(FileMeta {
+					content: Some(content.file),
+					content_type: content.content_type.map(Into::into),
+					content_disposition: Some(content_disposition),
+				});
+			},
+			// Download and store the file locally
+			| FederationMediaPolicy::Download => {},
+		}
+	}
 
 	self.create(
 		mxc,
@@ -389,6 +451,34 @@ pub async fn fetch_remote_thumbnail_legacy(
 		.await?;
 
 	let dim = Dim::from_ruma(body.width, body.height, body.method.clone())?;
+
+	let max_size = self.services.server.config.max_request_size;
+	if response.file.len() > max_size {
+		match self
+			.services
+			.server
+			.config
+			.federation_media_policy
+		{
+			// Drop the media
+			| FederationMediaPolicy::Drop => {
+				return Err!(Request(TooLarge(
+					"Remote media exceeds this server's max_request_size"
+				)));
+			},
+			// Return the file to the client without saving it locally
+			| FederationMediaPolicy::Proxy => {
+				debug_warn!(
+					%mxc, size = response.file.len(), %max_size,
+					"Remote media exceeds max_request_size, proxying without saving"
+				);
+				return Ok(response);
+			},
+			// Download and store the file locally
+			| FederationMediaPolicy::Download => {},
+		}
+	}
+
 	self.upload_thumbnail(
 		&mxc,
 		None,
@@ -429,6 +519,33 @@ pub async fn fetch_remote_content_legacy(
 		response.content_type.as_deref(),
 		None,
 	);
+
+	let max_size = self.services.server.config.max_request_size;
+	if response.file.len() > max_size {
+		match self
+			.services
+			.server
+			.config
+			.federation_media_policy
+		{
+			// Drop the media
+			| FederationMediaPolicy::Drop => {
+				return Err!(Request(TooLarge(
+					"Remote media exceeds this server's max_request_size"
+				)));
+			},
+			// Return the file to the client without saving it locally
+			| FederationMediaPolicy::Proxy => {
+				debug_warn!(
+					%mxc, size = response.file.len(), %max_size,
+					"Remote media exceeds max_request_size, proxying without saving"
+				);
+				return Ok(response);
+			},
+			// Download and store the file locally
+			| FederationMediaPolicy::Download => {},
+		}
+	}
 
 	self.create(
 		mxc,

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1399,6 +1399,15 @@
 #
 #prevent_media_downloads_from = []
 
+# Policy for handling media from federated servers that exceeds this
+# server's `max_request_size`.
+#
+# - "download": download and store locally (current behavior, default)
+# - "proxy": forward the content to the requesting client without saving
+# - "drop": reject the content with an error
+#
+#federation_media_policy = "download"
+
 # List of forbidden server names via regex patterns that we will block
 # incoming AND outgoing federation with, and block client room joins /
 # remote user invites.


### PR DESCRIPTION
#334 [[Feature request] Manage federated upload sizes](https://github.com/matrix-construct/tuwunel/issues/334)
now the server can proxy/drop/download the federation server media by max_requeset_size instead of always download them.