### PR TITLE
Send monotonic time to systemd after `reload` notification

### DIFF
--- a/src/router/run.rs
+++ b/src/router/run.rs
@@ -65,7 +65,7 @@ pub(crate) async fn start(server: Arc<Server>) -> Result<Arc<Services>> {
 	let services = Services::build(server).await?.start().await?;
 
 	#[cfg(all(feature = "systemd", target_os = "linux"))]
-	sd_notify::notify(true, &[sd_notify::NotifyState::Ready])
+	sd_notify::notify(false, &[sd_notify::NotifyState::Ready])
 		.expect("failed to notify systemd of ready state");
 
 	debug!("Started");

--- a/src/service/config/mod.rs
+++ b/src/service/config/mod.rs
@@ -49,13 +49,16 @@ impl Deref for Service {
 fn handle_reload(&self) -> Result {
 	if self.server.config.config_reload_signal {
 		#[cfg(all(feature = "systemd", target_os = "linux"))]
-		sd_notify::notify(true, &[sd_notify::NotifyState::Reloading])
-			.expect("failed to notify systemd of reloading state");
+		sd_notify::notify(false, &[
+			sd_notify::NotifyState::Reloading,
+			sd_notify::NotifyState::monotonic_usec_now().expect("failed to get monotonic time"),
+		])
+		.expect("failed to notify systemd of reloading state");
 
 		self.reload(iter::empty())?;
 
 		#[cfg(all(feature = "systemd", target_os = "linux"))]
-		sd_notify::notify(true, &[sd_notify::NotifyState::Ready])
+		sd_notify::notify(false, &[sd_notify::NotifyState::Ready])
 			.expect("failed to notify systemd of ready state");
 	}
 


### PR DESCRIPTION
Also removes unsetting `NOTIFY_SOCKET` on every call, since that makes every call after the first silently fail.

Thanks @rexbron for noticing the monotonic time thing
