### PR TITLE
Add support for S3 storage provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,10 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -1937,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +1978,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1996,6 +2006,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2633,6 +2667,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3117,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +3820,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3742,6 +3833,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3749,12 +3841,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -5415,6 +5509,7 @@ dependencies = [
  "maplit",
  "nix 0.31.2",
  "num-traits",
+ "object_store",
  "rand 0.8.5",
  "regex",
  "reqwest 0.13.1",
@@ -5526,6 +5621,7 @@ dependencies = [
  "loole",
  "lru-cache",
  "maplit",
+ "object_store",
  "rand 0.8.5",
  "regex",
  "reqwest 0.13.1",
@@ -5867,6 +5963,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5978,10 +6087,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,12 @@ features = [
 [workspace.dependencies.num-traits]
 version = "0.2"
 
+[workspace.dependencies.object_store]
+version = "0.13.1"
+features = [
+	"aws"
+]
+
 [workspace.dependencies.opentelemetry]
 version = "0.31"
 

--- a/src/admin/media/commands.rs
+++ b/src/admin/media/commands.rs
@@ -281,8 +281,8 @@ pub(super) async fn get_remote_file(
 		.await?;
 
 	// Grab the length of the content before clearing it to not flood the output
-	let len = result.content.as_ref().expect("content").len();
-	result.content.as_mut().expect("content").clear();
+	let len = result.content.len();
+	result.content.clear();
 
 	self.write_str(&format!("```\n{result:#?}\nreceived {len} bytes for file content.\n```"))
 		.await
@@ -307,8 +307,8 @@ pub(super) async fn get_remote_thumbnail(
 		.await?;
 
 	// Grab the length of the content before clearing it to not flood the output
-	let len = result.content.as_ref().expect("content").len();
-	result.content.as_mut().expect("content").clear();
+	let len = result.content.len();
+	result.content.clear();
 
 	self.write_str(&format!("```\n{result:#?}\nreceived {len} bytes for file content.\n```"))
 		.await

--- a/src/api/client/media.rs
+++ b/src/api/client/media.rs
@@ -22,7 +22,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::{
 	Services,
-	media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, FileMeta, MXC_LENGTH},
+	media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, MXC_LENGTH, Media},
 };
 
 use crate::Ruma;
@@ -177,7 +177,7 @@ pub(crate) async fn get_content_thumbnail_route(
 		media_id: &body.media_id,
 	};
 
-	let FileMeta {
+	let Media {
 		content,
 		content_type,
 		content_disposition,
@@ -213,7 +213,7 @@ pub(crate) async fn get_content_route(
 		media_id: &body.media_id,
 	};
 
-	let FileMeta {
+	let Media {
 		content,
 		content_type,
 		content_disposition,
@@ -249,7 +249,7 @@ pub(crate) async fn get_content_as_filename_route(
 		media_id: &body.media_id,
 	};
 
-	let FileMeta {
+	let Media {
 		content,
 		content_type,
 		content_disposition,
@@ -318,8 +318,8 @@ async fn fetch_thumbnail(
 	user: &UserId,
 	timeout_ms: Duration,
 	dim: &Dim,
-) -> Result<FileMeta> {
-	let FileMeta {
+) -> Result<Media> {
+	let Media {
 		content,
 		content_type,
 		content_disposition,
@@ -331,7 +331,7 @@ async fn fetch_thumbnail(
 		None,
 	));
 
-	Ok(FileMeta {
+	Ok(Media {
 		content,
 		content_type,
 		content_disposition,
@@ -344,12 +344,12 @@ async fn fetch_file(
 	user: &UserId,
 	timeout_ms: Duration,
 	filename: Option<&str>,
-) -> Result<FileMeta> {
-	let FileMeta {
+) -> Result<Media> {
+	let Media {
 		content,
 		content_type,
 		content_disposition,
-	} = fetch_file_meta(services, mxc, user, timeout_ms).await?;
+	} = fetch_media(services, mxc, user, timeout_ms).await?;
 
 	let content_disposition = Some(make_content_disposition(
 		content_disposition.as_ref(),
@@ -357,7 +357,7 @@ async fn fetch_file(
 		filename,
 	));
 
-	Ok(FileMeta {
+	Ok(Media {
 		content,
 		content_type,
 		content_disposition,
@@ -370,13 +370,13 @@ async fn fetch_thumbnail_meta(
 	user: &UserId,
 	timeout_ms: Duration,
 	dim: &Dim,
-) -> Result<FileMeta> {
-	if let Some(filemeta) = services
+) -> Result<Media> {
+	if let Some(media) = services
 		.media
 		.get_thumbnail_with_timeout(mxc, dim, timeout_ms)
 		.await?
 	{
-		return Ok(filemeta);
+		return Ok(media);
 	}
 
 	if services.globals.server_is_ours(mxc.server_name) {
@@ -389,18 +389,18 @@ async fn fetch_thumbnail_meta(
 		.await
 }
 
-async fn fetch_file_meta(
+async fn fetch_media(
 	services: &Services,
 	mxc: &Mxc<'_>,
 	user: &UserId,
 	timeout_ms: Duration,
-) -> Result<FileMeta> {
-	if let Some(filemeta) = services
+) -> Result<Media> {
+	if let Some(media) = services
 		.media
 		.get_with_timeout(mxc, timeout_ms)
 		.await?
 	{
-		return Ok(filemeta);
+		return Ok(media);
 	}
 
 	if services.globals.server_is_ours(mxc.server_name) {

--- a/src/api/client/media.rs
+++ b/src/api/client/media.rs
@@ -184,7 +184,7 @@ pub(crate) async fn get_content_thumbnail_route(
 	} = fetch_thumbnail(&services, &mxc, user, body.timeout_ms, &dim).await?;
 
 	Ok(get_content_thumbnail::v1::Response {
-		file: content.expect("entire file contents"),
+		file: content,
 		content_type: content_type.map(Into::into),
 		cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
 		cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
@@ -220,7 +220,7 @@ pub(crate) async fn get_content_route(
 	} = fetch_file(&services, &mxc, user, body.timeout_ms, None).await?;
 
 	Ok(get_content::v1::Response {
-		file: content.expect("entire file contents"),
+		file: content,
 		content_type: content_type.map(Into::into),
 		cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
 		cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),
@@ -256,7 +256,7 @@ pub(crate) async fn get_content_as_filename_route(
 	} = fetch_file(&services, &mxc, user, body.timeout_ms, Some(&body.filename)).await?;
 
 	Ok(get_content_as_filename::v1::Response {
-		file: content.expect("entire file contents"),
+		file: content,
 		content_type: content_type.map(Into::into),
 		cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
 		cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),

--- a/src/api/client/media_legacy.rs
+++ b/src/api/client/media_legacy.rs
@@ -162,7 +162,7 @@ pub(crate) async fn get_content_legacy_route(
 			);
 
 			Ok(get_content::v3::Response {
-				file: content.expect("entire file contents"),
+				file: content,
 				content_type: content_type.map(Into::into),
 				content_disposition: Some(content_disposition),
 				cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
@@ -257,7 +257,7 @@ pub(crate) async fn get_content_as_filename_legacy_route(
 			);
 
 			Ok(get_content_as_filename::v3::Response {
-				file: content.expect("entire file contents"),
+				file: content,
 				content_type: content_type.map(Into::into),
 				content_disposition: Some(content_disposition),
 				cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
@@ -352,7 +352,7 @@ pub(crate) async fn get_content_thumbnail_legacy_route(
 			);
 
 			Ok(get_content_thumbnail::v3::Response {
-				file: content.expect("entire file contents"),
+				file: content,
 				content_type: content_type.map(Into::into),
 				cross_origin_resource_policy: Some(CORP_CROSS_ORIGIN.into()),
 				cache_control: Some(CACHE_CONTROL_IMMUTABLE.into()),

--- a/src/api/client/media_legacy.rs
+++ b/src/api/client/media_legacy.rs
@@ -14,7 +14,7 @@ use tuwunel_core::{
 	Err, Result, err,
 	utils::{content_disposition::make_content_disposition, math::ruma_from_usize},
 };
-use tuwunel_service::media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, FileMeta};
+use tuwunel_service::media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, Media};
 
 use crate::{Ruma, RumaResponse, client::create_content_route};
 
@@ -150,7 +150,7 @@ pub(crate) async fn get_content_legacy_route(
 		.get_with_timeout(&mxc, body.timeout_ms)
 		.await?
 	{
-		| Some(FileMeta {
+		| Some(Media {
 			content,
 			content_type,
 			content_disposition,
@@ -245,7 +245,7 @@ pub(crate) async fn get_content_as_filename_legacy_route(
 		.get_with_timeout(&mxc, body.timeout_ms)
 		.await?
 	{
-		| Some(FileMeta {
+		| Some(Media {
 			content,
 			content_type,
 			content_disposition,
@@ -340,7 +340,7 @@ pub(crate) async fn get_content_thumbnail_legacy_route(
 		.get_thumbnail_with_timeout(&mxc, &dim, body.timeout_ms)
 		.await?
 	{
-		| Some(FileMeta {
+		| Some(Media {
 			content,
 			content_type,
 			content_disposition,

--- a/src/api/server/media.rs
+++ b/src/api/server/media.rs
@@ -7,7 +7,7 @@ use ruma::{
 	},
 };
 use tuwunel_core::{Err, Result, utils::content_disposition::make_content_disposition};
-use tuwunel_service::media::{Dim, FileMeta};
+use tuwunel_service::media::{Dim, Media};
 
 use crate::Ruma;
 
@@ -30,7 +30,7 @@ pub(crate) async fn get_content_route(
 		media_id: &body.media_id,
 	};
 
-	let Some(FileMeta {
+	let Some(Media {
 		content,
 		content_type,
 		content_disposition,
@@ -73,7 +73,7 @@ pub(crate) async fn get_content_thumbnail_route(
 		media_id: &body.media_id,
 	};
 
-	let Some(FileMeta {
+	let Some(Media {
 		content,
 		content_type,
 		content_disposition,

--- a/src/api/server/media.rs
+++ b/src/api/server/media.rs
@@ -42,7 +42,7 @@ pub(crate) async fn get_content_route(
 	let content_disposition =
 		make_content_disposition(content_disposition.as_ref(), content_type.as_deref(), None);
 	let content = Content {
-		file: content.expect("entire file contents"),
+		file: content,
 		content_type: content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
 	};
@@ -85,7 +85,7 @@ pub(crate) async fn get_content_thumbnail_route(
 	let content_disposition =
 		make_content_disposition(content_disposition.as_ref(), content_type.as_deref(), None);
 	let content = Content {
-		file: content.expect("entire file contents"),
+		file: content,
 		content_type: content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
 	};

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -80,6 +80,7 @@ libloading.workspace = true
 libloading.optional = true
 log.workspace = true
 num-traits.workspace = true
+object_store.workspace = true
 rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -57,7 +57,7 @@ use crate::{
 ### https://tuwunel.chat/configuration.html
 "#,
 	ignore = "catchall well_known tls blurhashing allow_invalid_tls_certificates ldap jwt \
-	          appservice identity_provider"
+	          appservice identity_provider s3_provider"
 )]
 pub struct Config {
 	/// The server_name is the pretty name of this server. It is used as a
@@ -2317,6 +2317,10 @@ pub struct Config {
 
 	// external structure; separate section
 	#[serde(default)]
+	pub s3_provider: Option<S3Provider>,
+
+	// external structure; separate section
+	#[serde(default)]
 	pub ldap: LdapConfig,
 
 	// external structure; separate section
@@ -2950,6 +2954,35 @@ mod identity_provider_serde {
 			Ok(ret)
 		}
 	}
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[config_example_generator(
+	filename = "tuwunel-example.toml",
+	section = "global.s3_provider"
+)]
+pub struct S3Provider {
+	/// The endpoint of the S3 provider, including the scheme. You should only
+	/// use http when testing and not in production.
+	///
+	/// example: "https://s3.us-east-1.amazonaws.com"
+	#[allow(rustdoc::bare_urls)] // The URL is not meant to be clickable
+	pub endpoint: Option<String>,
+
+	/// The region of the S3 bucket.
+	pub region: Option<String>,
+
+	/// The name of the S3 bucket.
+	pub bucket: String,
+
+	/// The path in the S3 bucket to place media assets in.
+	pub path: Option<String>,
+
+	/// The access key for the S3 bucket.
+	pub key: String,
+
+	/// The secret access key for the S3 bucket.
+	pub secret: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -76,6 +76,8 @@ pub enum Error {
 	#[error(transparent)]
 	JsTryFromInt(#[from] ruma::JsTryFromIntError), // js_int re-export
 	#[error(transparent)]
+	ObjectStore(#[from] object_store::Error),
+	#[error(transparent)]
 	Path(#[from] axum::extract::rejection::PathRejection),
 	#[error("Mutex poisoned: {0}")]
 	Poison(Cow<'static, str>),

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -101,6 +101,7 @@ ldap3.optional = true
 log.workspace = true
 loole.workspace = true
 lru-cache.workspace = true
+object_store.workspace = true
 rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/src/service/media/data.rs
+++ b/src/service/media/data.rs
@@ -22,9 +22,9 @@ pub(crate) struct Data {
 }
 
 #[derive(Debug)]
-pub(super) struct Metadata {
-	pub(super) content_disposition: Option<ContentDisposition>,
-	pub(super) content_type: Option<String>,
+pub struct Metadata {
+	pub content_disposition: Option<ContentDisposition>,
+	pub content_type: Option<String>,
 	pub(super) key: Vec<u8>,
 }
 

--- a/src/service/media/migrations.rs
+++ b/src/service/media/migrations.rs
@@ -33,8 +33,8 @@ pub(crate) async fn migrate_sha256_media(services: &Services) -> Result {
 		.raw_keys()
 		.ignore_err()
 		.ready_for_each(|key| {
-			let old = services.media.get_media_file_b64(key);
-			let new = services.media.get_media_file_sha256(key);
+			let old = services.media.get_media_path_b64(key);
+			let new = services.media.get_media_path_sha256(key);
 			debug!(?key, ?old, ?new, num = changes.len(), "change");
 			changes.push((old, new));
 		})
@@ -80,8 +80,8 @@ pub(crate) async fn checkup_sha256_media(services: &Services) -> Result {
 		.collect();
 
 	for key in media.db.get_all_media_keys().await {
-		let new_path = media.get_media_file_sha256(&key).into_os_string();
-		let old_path = media.get_media_file_b64(&key).into_os_string();
+		let new_path = media.get_media_path_sha256(&key).into_os_string();
+		let old_path = media.get_media_path_b64(&key).into_os_string();
 		if let Err(e) = handle_media_check(&dbs, config, &files, &key, &new_path, &old_path).await
 		{
 			error!(

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -284,7 +284,7 @@ impl Service {
 		{
 			| Ok(Metadata { content_disposition, content_type, key }) => {
 				let mut content = Vec::with_capacity(8192);
-				let path = self.get_media_file(&key);
+				let path = self.get_media_path_sha256(&key);
 				BufReader::new(fs::File::open(path).await?)
 					.read_to_end(&mut content)
 					.await?;
@@ -450,7 +450,7 @@ impl Service {
 				continue;
 			}
 
-			let path = self.get_media_file(&key);
+			let path = self.get_media_path_sha256(&key);
 
 			let file_metadata = match fs::metadata(path.clone()).await {
 				| Ok(file_metadata) => file_metadata,
@@ -526,8 +526,8 @@ impl Service {
 	}
 
 	async fn remove_media_file(&self, key: &[u8]) -> Result {
-		let path = self.get_media_file(key);
-		let legacy = self.get_media_file_b64(key);
+		let path = self.get_media_path_sha256(key);
+		let legacy = self.get_media_path_b64(key);
 		debug!(?key, ?path, ?legacy, "Removing media file");
 
 		let file_rm = fs::remove_file(&path);
@@ -543,12 +543,12 @@ impl Service {
 	}
 
 	async fn create_media_file(&self, key: &[u8]) -> Result<fs::File> {
-		let path = self.get_media_file(key);
+		let path = self.get_media_path_sha256(key);
 		debug!(?key, ?path, "Creating media file");
 
 		let file = fs::File::create(&path).await?;
 		if self.services.server.config.media_compat_file_link {
-			let legacy = self.get_media_file_b64(key);
+			let legacy = self.get_media_path_b64(key);
 			if let Err(e) = fs::symlink(&path, &legacy).await {
 				debug_error!(
 					key = ?encode_key(key), ?path, ?legacy,
@@ -570,27 +570,29 @@ impl Service {
 
 	#[inline]
 	#[must_use]
-	pub fn get_media_file(&self, key: &[u8]) -> PathBuf { self.get_media_file_sha256(key) }
-
-	/// new SHA256 file name media function. requires database migrated. uses
-	/// SHA256 hash of the base64 key as the file name
-	#[must_use]
-	pub fn get_media_file_sha256(&self, key: &[u8]) -> PathBuf {
+	pub fn get_media_path_sha256(&self, key: &[u8]) -> PathBuf {
 		let mut r = self.get_media_dir();
-		// Using the hash of the base64 key as the filename
-		// This is to prevent the total length of the path from exceeding the maximum
-		// length in most filesystems
-		let digest = <sha2::Sha256 as sha2::Digest>::digest(key);
-		let encoded = encode_key(&digest);
-		r.push(encoded);
+		r.push(self.get_media_name_sha256(key));
 		r
 	}
 
-	/// old base64 file name media function
-	/// This is the old version of `get_media_file` that uses the full base64
-	/// key as the filename.
+	/// new SHA256 file name media function. requires database migrated. uses
+	/// SHA256 hash of the base64 key as the file name
+	#[inline]
 	#[must_use]
-	pub fn get_media_file_b64(&self, key: &[u8]) -> PathBuf {
+	pub fn get_media_name_sha256(&self, key: &[u8]) -> String {
+		// Using the hash of the base64 key as the filename prevents the total
+		// length of the path from exceeding the maximum length in most
+		// filesystems
+		let digest = <sha2::Sha256 as sha2::Digest>::digest(key);
+		encode_key(&digest)
+	}
+
+	/// old base64 file name media function
+	/// This is the old version of `get_media_path_sha256` that uses the full
+	/// base64 key as the filename.
+	#[must_use]
+	pub fn get_media_path_b64(&self, key: &[u8]) -> PathBuf {
 		let mut r = self.get_media_dir();
 		let encoded = encode_key(key);
 		r.push(encoded);

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -35,7 +35,7 @@ use self::data::{Data, Metadata};
 pub use self::thumbnail::Dim;
 
 #[derive(Debug)]
-pub struct FileMeta {
+pub struct Media {
 	pub content: Vec<u8>,
 	pub content_type: Option<String>,
 	pub content_disposition: Option<ContentDisposition>,
@@ -275,8 +275,8 @@ impl Service {
 		Ok(deletion_count)
 	}
 
-	/// Downloads a file.
-	pub async fn get(&self, mxc: &Mxc<'_>) -> Result<Option<FileMeta>> {
+	/// Downloads a media file.
+	pub async fn get(&self, mxc: &Mxc<'_>) -> Result<Option<Media>> {
 		match self
 			.db
 			.search_file_metadata(mxc, &Dim::default())
@@ -289,7 +289,7 @@ impl Service {
 					.read_to_end(&mut content)
 					.await?;
 
-				Ok(Some(FileMeta {
+				Ok(Some(Media {
 					content,
 					content_type,
 					content_disposition,
@@ -304,7 +304,7 @@ impl Service {
 		&self,
 		mxc: &Mxc<'_>,
 		timeout_duration: Duration,
-	) -> Result<Option<FileMeta>> {
+	) -> Result<Option<Media>> {
 		if let Some(meta) = self.get(mxc).await? {
 			return Ok(Some(meta));
 		}
@@ -337,7 +337,7 @@ impl Service {
 		mxc: &Mxc<'_>,
 		dim: &Dim,
 		timeout_duration: Duration,
-	) -> Result<Option<FileMeta>> {
+	) -> Result<Option<Media>> {
 		if let Some(meta) = self.get_thumbnail(mxc, dim).await? {
 			return Ok(Some(meta));
 		}

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -561,15 +561,10 @@ impl Service {
 	}
 
 	#[inline]
-	pub async fn get_metadata(&self, mxc: &Mxc<'_>) -> Option<FileMeta> {
+	pub async fn get_metadata(&self, mxc: &Mxc<'_>) -> Option<Metadata> {
 		self.db
 			.search_file_metadata(mxc, &Dim::default())
 			.await
-			.map(|metadata| FileMeta {
-				content_disposition: metadata.content_disposition,
-				content_type: metadata.content_type,
-				content: None,
-			})
 			.ok()
 	}
 

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -15,6 +15,11 @@ use std::{
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use http::StatusCode;
+use object_store::{
+	ObjectStoreExt, PutPayload,
+	aws::{AmazonS3, AmazonS3Builder},
+	path::Path,
+};
 use ruma::{
 	Mxc, OwnedMxcUri, OwnedUserId, UserId,
 	api::client::error::{ErrorKind, RetryAfter},
@@ -54,6 +59,7 @@ pub struct Service {
 	services: Arc<crate::services::OnceServices>,
 	url_preview_mutex: MutexMap<String, ()>,
 	mxc_state: MXCState,
+	s3: Option<AmazonS3>,
 }
 
 /// generated MXC ID (`media-id`) length
@@ -68,6 +74,25 @@ pub const CORP_CROSS_ORIGIN: &str = "cross-origin";
 #[async_trait]
 impl crate::Service for Service {
 	fn build(args: &crate::Args<'_>) -> Result<Arc<Self>> {
+		let s3 = match &args.server.config.s3_provider {
+			| Some(b) => {
+				let mut builder = AmazonS3Builder::new()
+					.with_allow_http(true)
+					.with_bucket_name(b.bucket.clone())
+					.with_access_key_id(b.key.clone())
+					.with_secret_access_key(b.secret.clone());
+				if let Some(endpoint) = &b.endpoint {
+					builder = builder.with_endpoint(endpoint.clone());
+				}
+				if let Some(region) = &b.region {
+					builder = builder.with_region(region.clone());
+				}
+				let result = builder.build()?;
+				Some(result)
+			},
+			| _ => None,
+		};
+
 		Ok(Arc::new(Self {
 			db: Data::new(args.db),
 			services: args.services.clone(),
@@ -76,6 +101,7 @@ impl crate::Service for Service {
 				notifiers: Mutex::new(HashMap::new()),
 				ratelimiter: Mutex::new(HashMap::new()),
 			},
+			s3,
 		}))
 	}
 
@@ -215,10 +241,7 @@ impl Service {
 		)?;
 
 		//TODO: Dangling metadata in database if creation fails
-		let mut f = self.create_media_file(&key).await?;
-		f.write_all(file).await?;
-
-		Ok(())
+		self.create_media_file(&key, file).await
 	}
 
 	/// Deletes a file in the database and from the media directory via an MXC
@@ -227,7 +250,7 @@ impl Service {
 			| Ok(keys) => {
 				for key in keys {
 					trace!(?mxc, "MXC Key: {key:?}");
-					debug_info!(?mxc, "Deleting from filesystem");
+					debug_info!(?mxc, "Deleting from storage provider");
 
 					if let Err(e) = self.remove_media_file(&key).await {
 						debug_error!(?mxc, "Failed to remove media file: {e}");
@@ -277,25 +300,37 @@ impl Service {
 
 	/// Downloads a media file.
 	pub async fn get(&self, mxc: &Mxc<'_>) -> Result<Option<Media>> {
-		match self
+		let meta = self
 			.db
 			.search_file_metadata(mxc, &Dim::default())
 			.await
-		{
-			| Ok(Metadata { content_disposition, content_type, key }) => {
-				let mut content = Vec::with_capacity(8192);
-				let path = self.get_media_path_sha256(&key);
-				BufReader::new(fs::File::open(path).await?)
-					.read_to_end(&mut content)
-					.await?;
+			.ok();
 
-				Ok(Some(Media {
-					content,
-					content_type,
-					content_disposition,
-				}))
-			},
-			| _ => Ok(None),
+		let Some(Metadata { content_type, content_disposition, key }) = meta else {
+			return Ok(None);
+		};
+
+		if let Some(s3) = &self.s3 {
+			let path = self.get_s3_path_sha256(&key);
+			let result = s3.get(&path).await?;
+			let bytes = result.bytes().await?;
+			Ok(Some(Media {
+				content: bytes.to_vec(),
+				content_type,
+				content_disposition,
+			}))
+		} else {
+			let mut content = Vec::with_capacity(8192);
+			let path = self.get_media_path_sha256(&key);
+			BufReader::new(fs::File::open(path).await?)
+				.read_to_end(&mut content)
+				.await?;
+
+			Ok(Some(Media {
+				content,
+				content_type,
+				content_disposition,
+			}))
 		}
 	}
 
@@ -450,38 +485,59 @@ impl Service {
 				continue;
 			}
 
-			let path = self.get_media_path_sha256(&key);
+			let file_created_at = if let Some(s3) = &self.s3 {
+				let path = self.get_s3_path_sha256(&key);
 
-			let file_metadata = match fs::metadata(path.clone()).await {
-				| Ok(file_metadata) => file_metadata,
-				| Err(e) => {
-					error!(
-						"Failed to obtain file metadata for MXC {mxc} at file path \
-						 \"{path:?}\", skipping: {e}"
-					);
-					continue;
-				},
+				let file_metadata = match s3.head(&path).await {
+					| Ok(file_metadata) => file_metadata,
+					| Err(e) => {
+						error!(
+							"Failed to obtain S3 file metadata for MXC {mxc} at file path \
+							 \"{path:?}\", skipping: {e}"
+						);
+						continue;
+					},
+				};
+
+				trace!(%mxc, ?path, "S3 file metadata: {file_metadata:?}");
+				SystemTime::from(file_metadata.last_modified)
+			} else {
+				let path = self.get_media_path_sha256(&key);
+
+				let file_metadata = match fs::metadata(path.clone()).await {
+					| Ok(file_metadata) => file_metadata,
+					| Err(e) => {
+						error!(
+							"Failed to obtain local file metadata for MXC {mxc} at file path \
+							 \"{path:?}\", skipping: {e}"
+						);
+						continue;
+					},
+				};
+
+				trace!(%mxc, ?path, "Local file metadata: {file_metadata:?}");
+
+				match file_metadata.modified() {
+					| Ok(value) => value,
+					| Err(err) => {
+						error!(
+							"Failed to obtain last modification time for MXC {mxc} at file path \
+							 \"{path:?}\" {err:?}. Skipping..."
+						);
+						continue;
+					},
+				}
 			};
 
-			trace!(%mxc, ?path, "File metadata: {file_metadata:?}");
+			debug!("File created at: {file_created_at:?}");
 
-			let file_modified_at = match file_metadata.modified() {
-				| Ok(value) => value,
-				| Err(err) => {
-					error!("Could not delete MXC {mxc} at path {path:?}: {err:?}. Skipping...");
-					continue;
-				},
-			};
-
-			debug!("File modified at: {file_modified_at:?}");
-
-			if file_modified_at <= time && older_than {
+			if file_created_at <= time && older_than {
 				debug!(
 					"File is older than user duration, pushing to list of file paths and keys \
 					 to delete."
 				);
 				remote_mxcs.push(mxc.to_string());
-			} else if file_modified_at >= time && newer_than {
+			} else if file_created_at >= time && newer_than {
 				debug!(
 					"File is newer than user duration, pushing to list of file paths and keys \
 					 to delete."
@@ -526,38 +582,56 @@ impl Service {
 	}
 
 	async fn remove_media_file(&self, key: &[u8]) -> Result {
-		let path = self.get_media_path_sha256(key);
-		let legacy = self.get_media_path_b64(key);
-		debug!(?key, ?path, ?legacy, "Removing media file");
+		if let Some(s3) = &self.s3 {
+			let path = self.get_s3_path_sha256(key);
+			debug!(?key, ?path, "Deleting media file in s3");
 
-		let file_rm = fs::remove_file(&path);
-		let legacy_rm = fs::remove_file(&legacy);
-		let (file_rm, legacy_rm) = tokio::join!(file_rm, legacy_rm);
-		if let Err(e) = legacy_rm
-			&& self.services.server.config.media_compat_file_link
-		{
-			debug_error!(?key, ?legacy, "Failed to remove legacy media symlink: {e}");
+			s3.delete(&path).await?;
+			Ok(())
+		} else {
+			let path = self.get_media_path_sha256(key);
+			let legacy = self.get_media_path_b64(key);
+			debug!(?key, ?path, ?legacy, "Removing local media file");
+
+			let file_rm = fs::remove_file(&path);
+			let legacy_rm = fs::remove_file(&legacy);
+			let (file_rm, legacy_rm) = tokio::join!(file_rm, legacy_rm);
+			if let Err(e) = legacy_rm
+				&& self.services.server.config.media_compat_file_link
+			{
+				debug_error!(?key, ?legacy, "Failed to remove legacy media symlink: {e}");
+			}
+
+			Ok(file_rm?)
 		}
-
-		Ok(file_rm?)
 	}
 
-	async fn create_media_file(&self, key: &[u8]) -> Result<fs::File> {
-		let path = self.get_media_path_sha256(key);
-		debug!(?key, ?path, "Creating media file");
+	async fn create_media_file(&self, key: &[u8], file: &[u8]) -> Result {
+		if let Some(s3) = &self.s3 {
+			let path = self.get_s3_path_sha256(key);
+			debug!(?key, ?path, "Creating media file in s3");
 
-		let file = fs::File::create(&path).await?;
-		if self.services.server.config.media_compat_file_link {
-			let legacy = self.get_media_path_b64(key);
-			if let Err(e) = fs::symlink(&path, &legacy).await {
-				debug_error!(
-					key = ?encode_key(key), ?path, ?legacy,
-					"Failed to create legacy media symlink: {e}"
-				);
+			s3.put(&path, PutPayload::from(file.to_vec()))
+				.await?;
+		} else {
+			let path = self.get_media_path_sha256(key);
+			debug!(?key, ?path, "Creating local media file");
+
+			let mut f = fs::File::create(&path).await?;
+			if self.services.server.config.media_compat_file_link {
+				let legacy = self.get_media_path_b64(key);
+				if let Err(e) = fs::symlink(&path, &legacy).await {
+					debug_error!(
+						key = ?encode_key(key), ?path, ?legacy,
+						"Failed to create legacy media symlink: {e}"
+					);
+				}
 			}
+
+			f.write_all(file).await?;
 		}
 
-		Ok(file)
+		Ok(())
 	}
 
 	#[inline]
@@ -566,6 +640,18 @@ impl Service {
 			.search_file_metadata(mxc, &Dim::default())
 			.await
 			.ok()
+	}
+
+	#[inline]
+	#[must_use]
+	pub fn get_s3_path_sha256(&self, key: &[u8]) -> Path {
+		let file_name = self.get_media_name_sha256(key);
+		let s3 = self.services.config.s3_provider.as_ref();
+		if let Some(path) = s3.and_then(|b| b.path.clone()) {
+			Path::from_iter([path, file_name])
+		} else {
+			Path::from(file_name)
+		}
 	}
 
 	#[inline]

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -36,7 +36,7 @@ pub use self::thumbnail::Dim;
 
 #[derive(Debug)]
 pub struct FileMeta {
-	pub content: Option<Vec<u8>>,
+	pub content: Vec<u8>,
 	pub content_type: Option<String>,
 	pub content_disposition: Option<ContentDisposition>,
 }
@@ -290,7 +290,7 @@ impl Service {
 					.await?;
 
 				Ok(Some(FileMeta {
-					content: Some(content),
+					content,
 					content_type,
 					content_disposition,
 				}))

--- a/src/service/media/remote.rs
+++ b/src/service/media/remote.rs
@@ -218,7 +218,7 @@ async fn handle_thumbnail_file(
 	)
 	.await
 	.map(|()| FileMeta {
-		content: Some(content.file),
+		content: content.file,
 		content_type: content.content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
 	})
@@ -246,7 +246,7 @@ async fn handle_content_file(
 	)
 	.await
 	.map(|()| FileMeta {
-		content: Some(content.file),
+		content: content.file,
 		content_type: content.content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
 	})
@@ -298,7 +298,7 @@ async fn location_request(&self, location: &str) -> Result<FileMeta> {
 		.map(Vec::from)
 		.map_err(Into::into)
 		.map(|content| FileMeta {
-			content: Some(content),
+			content,
 			content_type: content_type.clone(),
 			content_disposition: Some(make_content_disposition(
 				content_disposition.as_ref(),

--- a/src/service/media/remote.rs
+++ b/src/service/media/remote.rs
@@ -18,7 +18,7 @@ use tuwunel_core::{
 	utils::content_disposition::make_content_disposition,
 };
 
-use super::{Dim, FileMeta};
+use super::{Dim, Media};
 
 #[implement(super::Service)]
 pub async fn fetch_remote_thumbnail(
@@ -28,7 +28,7 @@ pub async fn fetch_remote_thumbnail(
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
 	dim: &Dim,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	self.check_fetch_authorized(mxc)?;
 
 	let result = self
@@ -53,7 +53,7 @@ pub async fn fetch_remote_content(
 	user: Option<&UserId>,
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	self.check_fetch_authorized(mxc)?;
 
 	let result = self
@@ -79,7 +79,7 @@ async fn fetch_thumbnail_authenticated(
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
 	dim: &Dim,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	use federation::authenticated_media::get_content_thumbnail::v1::{Request, Response};
 
 	let request = Request {
@@ -110,7 +110,7 @@ async fn fetch_content_authenticated(
 	user: Option<&UserId>,
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	use federation::authenticated_media::get_content::v1::{Request, Response};
 
 	let request = Request {
@@ -137,7 +137,7 @@ async fn fetch_thumbnail_unauthenticated(
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
 	dim: &Dim,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	use media::get_content_thumbnail::v3::{Request, Response};
 
 	let request = Request {
@@ -172,7 +172,7 @@ async fn fetch_content_unauthenticated(
 	user: Option<&UserId>,
 	server: Option<&ServerName>,
 	timeout_ms: Duration,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	use media::get_content::v3::{Request, Response};
 
 	let request = Request {
@@ -201,7 +201,7 @@ async fn handle_thumbnail_file(
 	user: Option<&UserId>,
 	dim: &Dim,
 	content: Content,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	let content_disposition = make_content_disposition(
 		content.content_disposition.as_ref(),
 		content.content_type.as_deref(),
@@ -217,7 +217,7 @@ async fn handle_thumbnail_file(
 		&content.file,
 	)
 	.await
-	.map(|()| FileMeta {
+	.map(|()| Media {
 		content: content.file,
 		content_type: content.content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
@@ -230,7 +230,7 @@ async fn handle_content_file(
 	mxc: &Mxc<'_>,
 	user: Option<&UserId>,
 	content: Content,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	let content_disposition = make_content_disposition(
 		content.content_disposition.as_ref(),
 		content.content_type.as_deref(),
@@ -245,7 +245,7 @@ async fn handle_content_file(
 		&content.file,
 	)
 	.await
-	.map(|()| FileMeta {
+	.map(|()| Media {
 		content: content.file,
 		content_type: content.content_type.map(Into::into),
 		content_disposition: Some(content_disposition),
@@ -258,7 +258,7 @@ async fn handle_location(
 	mxc: &Mxc<'_>,
 	user: Option<&UserId>,
 	location: &str,
-) -> Result<FileMeta> {
+) -> Result<Media> {
 	self.location_request(location)
 		.await
 		.map_err(|error| {
@@ -269,7 +269,7 @@ async fn handle_location(
 }
 
 #[implement(super::Service)]
-async fn location_request(&self, location: &str) -> Result<FileMeta> {
+async fn location_request(&self, location: &str) -> Result<Media> {
 	let response = self
 		.services
 		.client
@@ -297,7 +297,7 @@ async fn location_request(&self, location: &str) -> Result<FileMeta> {
 		.await
 		.map(Vec::from)
 		.map_err(Into::into)
-		.map(|content| FileMeta {
+		.map(|content| Media {
 			content,
 			content_type: content_type.clone(),
 			content_disposition: Some(make_content_disposition(

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -14,7 +14,7 @@ use tokio::{
 };
 use tuwunel_core::{Result, checked, err, implement};
 
-use super::{FileMeta, data::Metadata};
+use super::{Media, data::Metadata};
 
 /// Dimension specification for a thumbnail.
 #[derive(Debug)]
@@ -60,7 +60,7 @@ impl super::Service {
 	/// For width,height <= 96 the server uses another thumbnailing algorithm
 	/// which crops the image afterwards.
 	#[tracing::instrument(skip(self), name = "thumbnail", level = "debug")]
-	pub async fn get_thumbnail(&self, mxc: &Mxc<'_>, dim: &Dim) -> Result<Option<FileMeta>> {
+	pub async fn get_thumbnail(&self, mxc: &Mxc<'_>, dim: &Dim) -> Result<Option<Media>> {
 		// 0, 0 because that's the original file
 		let dim = dim.normalized();
 
@@ -83,7 +83,7 @@ impl super::Service {
 /// Using saved thumbnail
 #[implement(super::Service)]
 #[tracing::instrument(name = "saved", level = "debug", skip(self, data))]
-async fn get_thumbnail_saved(&self, data: Metadata) -> Result<Option<FileMeta>> {
+async fn get_thumbnail_saved(&self, data: Metadata) -> Result<Option<Media>> {
 	let mut content = Vec::new();
 	let path = self.get_media_file(&data.key);
 	fs::File::open(path)
@@ -91,7 +91,7 @@ async fn get_thumbnail_saved(&self, data: Metadata) -> Result<Option<FileMeta>> 
 		.read_to_end(&mut content)
 		.await?;
 
-	Ok(Some(into_filemeta(data, content)))
+	Ok(Some(into_media(data, content)))
 }
 
 /// Generate a thumbnail
@@ -103,7 +103,7 @@ async fn get_thumbnail_generate(
 	mxc: &Mxc<'_>,
 	dim: &Dim,
 	data: Metadata,
-) -> Result<Option<FileMeta>> {
+) -> Result<Option<Media>> {
 	let mut content = Vec::new();
 	let path = self.get_media_file(&data.key);
 	fs::File::open(path)
@@ -113,11 +113,11 @@ async fn get_thumbnail_generate(
 
 	let Ok(image) = image::load_from_memory(&content) else {
 		// Couldn't parse file to generate thumbnail, send original
-		return Ok(Some(into_filemeta(data, content)));
+		return Ok(Some(into_media(data, content)));
 	};
 
 	if dim.width > image.width() || dim.height > image.height() {
-		return Ok(Some(into_filemeta(data, content)));
+		return Ok(Some(into_media(data, content)));
 	}
 
 	let mut thumbnail_bytes = Vec::new();
@@ -139,7 +139,7 @@ async fn get_thumbnail_generate(
 	let mut f = self.create_media_file(&thumbnail_key).await?;
 	f.write_all(&thumbnail_bytes).await?;
 
-	Ok(Some(into_filemeta(data, thumbnail_bytes)))
+	Ok(Some(into_media(data, thumbnail_bytes)))
 }
 
 #[cfg(not(feature = "media_thumbnail"))]
@@ -150,7 +150,7 @@ async fn get_thumbnail_generate(
 	_mxc: &Mxc<'_>,
 	_dim: &Dim,
 	data: Metadata,
-) -> Result<Option<FileMeta>> {
+) -> Result<Option<Media>> {
 	self.get_thumbnail_saved(data).await
 }
 
@@ -175,8 +175,8 @@ fn thumbnail_generate(
 	Ok(thumbnail)
 }
 
-fn into_filemeta(data: Metadata, content: Vec<u8>) -> FileMeta {
-	FileMeta {
+fn into_media(data: Metadata, content: Vec<u8>) -> Media {
+	Media {
 		content,
 		content_type: data.content_type,
 		content_disposition: data.content_disposition,

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -85,7 +85,7 @@ impl super::Service {
 #[tracing::instrument(name = "saved", level = "debug", skip(self, data))]
 async fn get_thumbnail_saved(&self, data: Metadata) -> Result<Option<Media>> {
 	let mut content = Vec::new();
-	let path = self.get_media_file(&data.key);
+	let path = self.get_media_path_sha256(&data.key);
 	fs::File::open(path)
 		.await?
 		.read_to_end(&mut content)
@@ -105,7 +105,7 @@ async fn get_thumbnail_generate(
 	data: Metadata,
 ) -> Result<Option<Media>> {
 	let mut content = Vec::new();
-	let path = self.get_media_file(&data.key);
+	let path = self.get_media_path_sha256(&data.key);
 	fs::File::open(path)
 		.await?
 		.read_to_end(&mut content)

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -177,7 +177,7 @@ fn thumbnail_generate(
 
 fn into_filemeta(data: Metadata, content: Vec<u8>) -> FileMeta {
 	FileMeta {
-		content: Some(content),
+		content,
 		content_type: data.content_type,
 		content_disposition: data.content_disposition,
 	}

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -7,11 +7,9 @@
 
 use std::{cmp, num::Saturating as Sat};
 
+use object_store::ObjectStoreExt;
 use ruma::{Mxc, UInt, UserId, http_headers::ContentDisposition, media::Method};
-use tokio::{
-	fs,
-	io::{AsyncReadExt, AsyncWriteExt},
-};
+use tokio::{fs, io::AsyncReadExt};
 use tuwunel_core::{Result, checked, err, implement};
 
 use super::{Media, data::Metadata};
@@ -40,9 +38,7 @@ impl super::Service {
 				.create_file_metadata(mxc, user, dim, content_disposition, content_type)?;
 
 		//TODO: Dangling metadata in database if creation fails
-		let mut f = self.create_media_file(&key).await?;
-		f.write_all(file).await?;
-
+		self.create_media_file(&key, file).await?;
 		Ok(())
 	}
 
@@ -84,14 +80,21 @@ impl super::Service {
 #[implement(super::Service)]
 #[tracing::instrument(name = "saved", level = "debug", skip(self, data))]
 async fn get_thumbnail_saved(&self, data: Metadata) -> Result<Option<Media>> {
-	let mut content = Vec::new();
-	let path = self.get_media_path_sha256(&data.key);
-	fs::File::open(path)
-		.await?
-		.read_to_end(&mut content)
-		.await?;
+	if let Some(s3) = &self.s3 {
+		let path = self.get_s3_path_sha256(&data.key);
+		let result = s3.get(&path).await?;
+		let bytes = result.bytes().await?;
+		Ok(Some(into_media(data, bytes.to_vec())))
+	} else {
+		let mut content = Vec::new();
+		let path = self.get_media_path_sha256(&data.key);
+		fs::File::open(path)
+			.await?
+			.read_to_end(&mut content)
+			.await?;
 
-	Ok(Some(into_media(data, content)))
+		Ok(Some(into_media(data, content)))
+	}
 }
 
 /// Generate a thumbnail
@@ -104,20 +107,17 @@ async fn get_thumbnail_generate(
 	dim: &Dim,
 	data: Metadata,
 ) -> Result<Option<Media>> {
-	let mut content = Vec::new();
-	let path = self.get_media_path_sha256(&data.key);
-	fs::File::open(path)
-		.await?
-		.read_to_end(&mut content)
-		.await?;
+	let Some(media) = self.get(mxc).await? else {
+		return tuwunel_core::Err!("Could not find original media.");
+	};
 
-	let Ok(image) = image::load_from_memory(&content) else {
+	let Ok(image) = image::load_from_memory(&media.content) else {
 		// Couldn't parse file to generate thumbnail, send original
-		return Ok(Some(into_media(data, content)));
+		return Ok(Some(into_media(data, media.content)));
 	};
 
 	if dim.width > image.width() || dim.height > image.height() {
-		return Ok(Some(into_media(data, content)));
+		return Ok(Some(into_media(data, media.content)));
 	}
 
 	let mut thumbnail_bytes = Vec::new();
@@ -136,9 +136,8 @@ async fn get_thumbnail_generate(
 		data.content_type.as_deref(),
 	)?;
 
-	let mut f = self.create_media_file(&thumbnail_key).await?;
-	f.write_all(&thumbnail_bytes).await?;
-
+	self.create_media_file(&thumbnail_key, &thumbnail_bytes)
+		.await?;
 	Ok(Some(into_media(data, thumbnail_bytes)))
 }
 

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2475,6 +2475,37 @@
 
 
 
+#[global.s3_provider]
+
+# The endpoint of the S3 provider, including the scheme. You should only
+# use http when testing and not in production.
+#
+# example: "https://s3.us-east-1.amazonaws.com"
+#
+#endpoint =
+
+# The region of the S3 bucket.
+#
+#region =
+
+# The name of the S3 bucket.
+#
+#bucket =
+
+# The path in the S3 bucket to place media assets in.
+#
+#path =
+
+# The access key for the S3 bucket.
+#
+#key =
+
+# The secret access key for the S3 bucket.
+#
+#secret =
+
+
+
 #[global.appservice.<ID>]
 
 # The URL for the application service.


### PR DESCRIPTION
When defined in the configuration, S3 object storage is used instead of the local filesystem for storing media. It is implemented by downloading the media from the bucket and then sending it to the user. This is kind of what is done today if you use s3fs with Tuwunel, except it doesn't do any additional work that s3fs can do like caching.

In the future, it would be nice to send the user a redirect as suggested by MSC3860 instead of relaying the data. However, ruma doesn't appear to support this kind of response so I've left that out for now.

A few changes not directly related to S3:
- Renamed `FileMeta` to `Media`, which feels more accurate to me.
- Admin file info command now returns metadata directly, which allows us to make `Media.content` non-nullable.
- Disambiguates the difference between media file name and path functions.
- ~~Fixed bounds being treated incorrectly for `!admin media delete-past-remote-media`~~ Moved to #375

Closes #21.