### PR TITLE
change create.rs

### DIFF
--- a/src/api/client/room/create.rs
+++ b/src/api/client/room/create.rs
@@ -244,22 +244,23 @@ pub(crate) async fn create_room_route(
 		.await?;
 
 	// 5.3 Guest Access
-	services
-		.timeline
-		.build_and_append_pdu(
-			PduBuilder::state(
-				String::new(),
-				&RoomGuestAccessEventContent::new(match preset {
-					| RoomPreset::PublicChat => GuestAccess::Forbidden,
-					| _ => GuestAccess::CanJoin,
-				}),
-			),
-			sender_user,
-			&room_id,
-			&state_lock,
-		)
-		.boxed()
-		.await?;
+	// Only send for non-public presets (matching Synapse's behavior where
+	// guest_can_join is true for private_chat and trusted_private_chat only)
+	if preset != RoomPreset::PublicChat {
+		services
+			.timeline
+			.build_and_append_pdu(
+				PduBuilder::state(
+					String::new(),
+					&RoomGuestAccessEventContent::new(GuestAccess::CanJoin),
+				),
+				sender_user,
+				&room_id,
+				&state_lock,
+			)
+			.boxed()
+			.await?;
+	}
 
 	// 6. Events listed in initial_state
 	let mut is_encrypted = false;


### PR DESCRIPTION
in the synapse [room.py](https://github.com/element-hq/synapse/blob/develop/synapse/handlers/room.py#L1690) line 1690
```python
        if config["guest_can_join"]:
            if (EventTypes.GuestAccess, "") not in initial_state:
                guest_access_event, guest_access_context = await create_event(
                    EventTypes.GuestAccess,
                    {EventContentFields.GUEST_ACCESS: GuestAccess.CAN_JOIN},
                    True,
                )
                events_to_send.append((guest_access_event, guest_access_context))
```

it says that: only `guest_can_join == true`, it will create and return `guest_access` event.

in the past tuwunel `create.rs` line 246 : it will create and return `guest_access` anyway.

```rust
	// 5.3 Guest Access
	services
		.timeline
		.build_and_append_pdu(
			PduBuilder::state(
				String::new(),
				&RoomGuestAccessEventContent::new(match preset {
					| RoomPreset::PublicChat => GuestAccess::Forbidden,
					| _ => GuestAccess::CanJoin,
				}),
			),
			sender_user,
			&room_id,
			&state_lock,
		)
		.boxed()
		.await?;
```