### PR TITLE
Fix and rename media delete range

### DIFF
--- a/src/admin/media/commands.rs
+++ b/src/admin/media/commands.rs
@@ -167,27 +167,22 @@ pub(super) async fn delete_list(&self) -> Result {
 }
 
 #[admin_command]
-pub(super) async fn delete_past_remote_media(
+pub(super) async fn delete_range(
 	&self,
 	duration: String,
-	before: bool,
-	after: bool,
+	older_than: bool,
+	newer_than: bool,
 	yes_i_want_to_delete_local_media: bool,
 ) -> Result {
-	if before && after {
-		return Err!("Please only pick one argument, --before or --after.",);
+	if older_than == newer_than {
+		return Err!("Please pick only one of --older_than or --newer_than.",);
 	}
 
 	let duration = parse_timepoint_ago(&duration)?;
 	let deleted_count = self
 		.services
 		.media
-		.delete_all_remote_media_at_after_time(
-			duration,
-			before,
-			after,
-			yes_i_want_to_delete_local_media,
-		)
+		.delete_range(duration, older_than, newer_than, yes_i_want_to_delete_local_media)
 		.await?;
 
 	self.write_str(&format!("Deleted {deleted_count} total files."))

--- a/src/admin/media/mod.rs
+++ b/src/admin/media/mod.rs
@@ -30,20 +30,19 @@ pub(super) enum MediaCommand {
 	DeleteList,
 
 	/// - Deletes all remote (and optionally local) media created before or
-	///   after [duration] time using filesystem metadata first created at date,
-	///   or fallback to last modified date. This will always ignore errors by
-	///   default.
-	DeletePastRemoteMedia {
+	///   after [duration] time using filesystem metadata last modified at date.
+	//    This will always ignore errors by default.
+	DeleteRange {
 		/// - The relative time (e.g. 30s, 5m, 7d) within which to search
 		duration: String,
 
 		/// - Only delete media created before [duration] ago
 		#[arg(long, short)]
-		before: bool,
+		older_than: bool,
 
 		/// - Only delete media created after [duration] ago
 		#[arg(long, short)]
-		after: bool,
+		newer_than: bool,
 
 		/// - Long argument to additionally delete local media
 		#[arg(long)]

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -406,13 +406,13 @@ impl Service {
 		Ok(mxcs)
 	}
 
-	/// Deletes all remote only media files in the given at or after
-	/// time/duration. Returns a usize with the amount of media files deleted.
-	pub async fn delete_all_remote_media_at_after_time(
+	/// Deletes all media files before or after the given time. Returns a usize
+	/// with the number of media files deleted.
+	pub async fn delete_range(
 		&self,
 		time: SystemTime,
-		before: bool,
-		after: bool,
+		older_than: bool,
+		newer_than: bool,
 		yes_i_want_to_delete_local_media: bool,
 	) -> Result<usize> {
 		let all_keys = self.db.get_all_media_keys().await;
@@ -465,7 +465,7 @@ impl Service {
 
 			trace!(%mxc, ?path, "File metadata: {file_metadata:?}");
 
-			let file_created_at = match file_metadata.modified() {
+			let file_modified_at = match file_metadata.modified() {
 				| Ok(value) => value,
 				| Err(err) => {
 					error!("Could not delete MXC {mxc} at path {path:?}: {err:?}. Skipping...");
@@ -473,18 +473,18 @@ impl Service {
 				},
 			};
 
-			debug!("File created at: {file_created_at:?}");
+			debug!("File modified at: {file_modified_at:?}");
 
-			if file_created_at >= time && before {
+			if file_modified_at <= time && older_than {
 				debug!(
-					"File is within (before) user duration, pushing to list of file paths and \
-					 keys to delete."
+					"File is older than user duration, pushing to list of file paths and keys \
+					 to delete."
 				);
 				remote_mxcs.push(mxc.to_string());
-			} else if file_created_at <= time && after {
+			} else if file_modified_at >= time && newer_than {
 				debug!(
-					"File is not within (after) user duration, pushing to list of file paths \
-					 and keys to delete."
+					"File is newer than user duration, pushing to list of file paths and keys \
+					 to delete."
 				);
 				remote_mxcs.push(mxc.to_string());
 			}


### PR DESCRIPTION
Fixes incorrectly treated bounds in the media range deletion command, by disallowing the use of the command without specifying a range as well as flipping the bounds check so that it now deletes the correct range.

Since users use this command and the behavior is opposite of what it used to be, the command and its arguments were both renamed to avoid accidental deletion of media. The documentation was also updated to remove the erroneous suggestion that the file's creation time is considered.