### PR TITLE
Fix UIA password flow not advertised for LDAP users

### DIFF
--- a/src/api/router/auth/uiaa.rs
+++ b/src/api/router/auth/uiaa.rs
@@ -32,7 +32,7 @@ where
 				.unwrap_or(false)
 		})
 		.unwrap_or(false)
-		.await;
+		.await || (cfg!(feature = "ldap") && services.config.ldap.enable);
 
 	//TODO: UIAA for SSO.
 	let sso_flow = [AuthType::Sso];


### PR DESCRIPTION
Fix "No appropriate authentication flow found" error for LDAP users trying to reset the password.
Advertise the password flow when LDAP is enabled.