### PR TITLE
fix: device_lists.changed never included in /sync responses after

### DIFF
--- a/src/api/client/sync/v5/extensions/e2ee.rs
+++ b/src/api/client/sync/v5/extensions/e2ee.rs
@@ -43,7 +43,6 @@ pub(super) async fn collect(
 		.collect::<HashSet<_>>()
 		.map(|changed| (changed, HashSet::new()));
 
-	let (changed, left) = (HashSet::new(), HashSet::new());
 	let (changed, left) = services
 		.state_cache
 		.rooms_joined(sender_user)


### PR DESCRIPTION
Fixes #377