### PR TITLE
added user_id in user registration notice

### DIFF
--- a/src/api/client/register.rs
+++ b/src/api/client/register.rs
@@ -381,7 +381,7 @@ pub(crate) async fn register_route(
 	if body.appservice_info.is_none() && (!is_guest || services.config.log_guest_registrations) {
 		let mut notice = String::from(if is_guest { "New guest user" } else { "New user" });
 
-		write!(notice, " registered on this server from IP {client}")?;
+		write!(notice, " \"{user_id}\" registered on this server from IP {client}")?;
 
 		if let Some(device_name) = body.initial_device_display_name.as_deref() {
 			write!(notice, " with device name {device_name}")?;


### PR DESCRIPTION
Simple and short PR for convernience. 

I often have to run command in the admin rooms for new users using their  ID, It would be convenient to have their name directly in the notice sent to the admin room. Currently I have to repeat `!admin users list` and try to find where is the new user in that list each time. 