### PR TITLE
fix: return m.change_password capability based on login_with_password config

### DIFF
--- a/src/api/client/capabilities.rs
+++ b/src/api/client/capabilities.rs
@@ -6,8 +6,9 @@ use ruma::{
 	api::client::discovery::{
 		get_capabilities,
 		get_capabilities::v3::{
-			Capabilities, GetLoginTokenCapability, ProfileFieldsCapability, RoomVersionStability,
-			RoomVersionsCapability, ThirdPartyIdChangesCapability,
+			Capabilities, ChangePasswordCapability, GetLoginTokenCapability,
+			ProfileFieldsCapability, RoomVersionStability, RoomVersionsCapability,
+			ThirdPartyIdChangesCapability,
 		},
 	},
 };
@@ -47,6 +48,10 @@ pub(crate) async fn get_capabilities_route(
 	};
 
 	capabilities.profile_fields = ProfileFieldsCapability::new(true).into();
+
+	capabilities.change_password = ChangePasswordCapability {
+		enabled: services.server.config.login_with_password,
+	};
 
 	capabilities.set(
 		"org.matrix.msc4267.forget_forced_upon_leave",


### PR DESCRIPTION
Sets the `m.change_password` capability based on the `login_with_password` config option. By default, the capability returns `enabled: true`, but now it will correctly return `enabled: false` when password login is disabled (e.g., SSO-only setups).

This allows clients to correctly determine whether password changes are supported.