### PR TITLE
Change Docker port mapping from 8448 to 8008

### DIFF
--- a/docs/deploying/docker-compose.yml
+++ b/docs/deploying/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         image: jevolk/tuwunel:latest
         restart: unless-stopped
         ports:
-            - 8448:6167
+            - 8008:6167
         volumes:
             - db:/var/lib/tuwunel
             #- ./tuwunel.toml:/etc/tuwunel.toml


### PR DESCRIPTION
all the reverse docker examples use proxy pass to 8008. 
AFAIK both 443 and 8448 should be proxy passed to the instance listening on port 8008.