### PR TITLE
Route ephemeral events to appservices with receive_ephemeral

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,10 +4,4 @@ The release pipeline `Main` (main.yml) and its subroutines defined in the other 
 description for the underlying self-hosted build system in  `/docker`. In other words, this is a sort of
 terminal, a "thin-client" with a display and a keyboard for our docker mainframe. We minimize
 vendor-lockin and duplication with other services by limiting everything here to only what is
-essential for driving the docker builder.
-
-Though we slightly relax the above by specifying details of the actual CI pipeline, the 
-control-flow logic to go from some input event to some output or release here. This gives us
-better integration  with github, like granular progress indications by breaking up operations
-as individual jobs and workflows within the pipeline. This means we'll have duplicate logic
-with other services, but only as it relates to high-level control flow.
+essential for driving the docker builder. See: [documentation](../../docs/development/testing/workflows.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Enterprise JWT](authentication/jwt.md)
   - [Identity Providers](authentication/providers.md)
     - [Authelia](authentication/providers/authelia.md)
+    - [Authentik](authentication/providers/authentik.md)
     - [Keycloak](authentication/providers/keycloak.md)
 - [Multimedia and Storage](media.md)
   - [Storage Providers](media/storage.md)

--- a/docs/authentication/providers.md
+++ b/docs/authentication/providers.md
@@ -8,6 +8,7 @@ maps their identity to a Matrix account.
 ### Provider guides
 
 - [Authelia](providers/authelia.md)
+- [Authentik](providers/authentik.md)
 - [Keycloak](providers/keycloak.md)
 - _Please contribute documentation for yours here!_
 

--- a/docs/authentication/providers/authentik.md
+++ b/docs/authentication/providers/authentik.md
@@ -1,0 +1,165 @@
+# Authentik
+
+> [!IMPORTANT]
+> This guide is based on Authentik version 2026.2.2
+
+## Authentik configuration
+
+Create a provider and application for tuwunel. From the Admin interface, select
+**Applications** > **Applications** > **Create with Provider**.
+
+Go through each step of the "New application dialog":
+
+### Application
+
+- Application name: select the user-facing name of your server on the Authentik
+  side
+- Slug: this will be part of the `base_url` in your tuwunel configuration
+
+### Choose a provider
+
+Select **OAuth2/OpenID Provider**.
+
+### Configure provider
+
+1. Provider Name: this can be left to the default value
+1. Authorization flow: if you have not created custom flows, either of the two
+   built-in flows can be used depending on desired behaviour
+1. **Client ID** and **Client secret**: these will be generated for you. Save
+   these values as you will need them in your tuwunel configuration
+1. **Redirect URIs/Origins**: set this to
+   `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`
+   replacing `<your.matrix.example.com>` with tuwunel's public (sub)domain and
+   `<client_id>` with the value from the previous step
+1. Other values can be left as default
+
+### Configure bindings
+
+Optional: set policies if you want to restrict access to tuwunel to only certain
+of your Authentik users.
+
+### Review and Submit Application
+
+Verify all information is correct and press "Submit".
+
+## Tuwunel configuration
+
+Add the following to your `tuwunel.toml`:
+
+```toml
+[[global.identity_provider]]
+brand = "Authentik"
+client_id = "<client_id>" # Replace with the Client ID from Authentik
+client_secret = "<client_secret>" # Replace with the Client secret from Authentik
+callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>" # Replace with the same Callback URL you configure in Authentik
+issuer_url = "https://<your.authentik.example.com>/application/o/<slug>" # Replace with your Authentik (sub)domain and the slug you selected above
+base_path = "/application/o/<slug>" # Replace with the slug you selected above
+
+# Optional items
+#name = "Authentik"
+#unique_id_fallbacks = false # prevent randomly generated matrix usernames if none are available
+```
+
+See the
+[Authentik OAuth 2.0/OIDC documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/)
+for full details on the provider side.
+
+## Setting up different Authentik and tuwunel usernames
+
+By default, tuwunel will assign the localpart of a username [based on
+Authentik's userinfo][user-ids-from-claims]. By default, the user's Authentik
+username will be served as the `preferred_username` to tuwunel. For example,
+user `foo` would be assigned the account `@foo:example.com` if it is available.
+
+[user-ids-from-claims]:
+    ../providers.md#how-tuwunel-derives-matrix-user-ids-from-claims
+
+This behaviour can be modified using a custom Authentik mapping.
+
+> [!NOTE]
+> For example, this configuration would allow Authentik user `foo` to receive
+> the matrix username `@bar:example.com`.
+
+### Create a custom mapping for tuwunel
+
+From the Authentik Admin interface, select **Customization** > **Property
+Mappings** > **Create**.
+
+When prompted to select a type, choose **Scope Mapping**.
+
+In the "Create Scope Mapping" dialog, set the Scope name to `profile`.
+
+In "Expression", provide a Python expression that will return a dictionary of
+userinfo entries. For example, to return a custom user attribute
+`matrix_localpart` as the preferred username if it is set, enter:
+
+```python
+if "matrix_localpart" in request.user.attributes:
+  return {
+    "name": request.user.name,
+    "given_name": request.user.name,
+    "preferred_username": request.user.attributes["matrix_localpart"],
+    "nickname": request.user.attributes["matrix_localpart"],
+    "groups": [group.name for group in request.user.ak_groups.all()],
+}
+else:
+  return {
+    "name": request.user.name,
+    "given_name": request.user.name,
+    "preferred_username": request.user.username,
+    "nickname": request.user.username,
+    "groups": [group.name for group in request.user.ak_groups.all()],
+}
+```
+
+Take note of the **Name** you selected and click **Finish**.
+
+### Replace the default profile mapping in your tuwunel provider
+
+From the Admin interface, select **Applications** > **Providers** and click on
+the "Edit" icon for your tuwunel provider.
+
+Expand the **Advanced protocol settings** section and scroll to **Scope**.
+
+In **Available Scopes**, search for the **Name** of your custom mapping, select
+it, and add it to the **Selected Scopes** with the right arrow (`>`).
+
+In **Selected Scopes**, remove the
+`authentik default OAuth Mapping: OpenID 'profile'` by selecting it and moving
+it out with the left arrow (`<`).
+
+Complete the dialog by clicking **Update**.
+
+### Assign a custom attribute to a user
+
+From the Admin interface, select **Directory** > **Users** and click on the
+desired user. Under **Actions**, click **Edit**.
+
+Under **Attributes**, add a custom attribute:
+
+```yaml
+matrix_localpart: bar
+```
+
+Complete the dialog by clicking **Update**.
+
+> [!TIP]
+> Users can be allowed to set a custom attribute themselves using a custom
+> Prompt within a Stage Configuration flow, but this is beyond the scope of this
+> guide.
+
+### Test the custom mapping
+
+From the Admin interface, select **Applications** > **Providers**, click on the
+link of your tuwunel provider, then click **Preview**.
+
+Under **Preview for user**, select user `foo`.
+
+The JWT payload should contain the custom matrix localpart:
+
+```json
+{
+    "preferred_username": "bar",
+    "nickname": "bar"
+}
+``

--- a/docs/authentication/providers/authentik.md
+++ b/docs/authentication/providers/authentik.md
@@ -1,109 +1,110 @@
 # Authentik
 
-> [!IMPORTANT]
-> This guide is based on Authentik version 2026.2.2
+[Authentik](https://goauthentik.io/) is a self-hostable identity provider that
+speaks OpenID Connect.
+
+> [!NOTE]
+> This guide was written against `Authentik 2025.10`; the flow is the same on
+> all later versions through at least `2026.2`.
 
 ## Authentik configuration
 
-Create a provider and application for tuwunel. From the Admin interface, select
-**Applications** > **Applications** > **Create with Provider**.
+From the admin interface, navigate to **Applications** > **Applications** and
+select **Create with Provider**. Review the items below and click **Submit**.
 
-Go through each step of the "New application dialog":
+##### Application
 
-### Application
+- **Application name**: the user-facing name shown to your users on the
+  Authentik side.
+- **Slug**: appears in the issuer URL on the tuwunel side. Pick something
+  short and stable, such as `tuwunel`.
 
-- Application name: select the user-facing name of your server on the Authentik
-  side
-- Slug: this will be part of the `base_url` in your tuwunel configuration
-
-### Choose a provider
+##### Provider
 
 Select **OAuth2/OpenID Provider**.
 
-### Configure provider
+- **Authorization flow**: any built-in flow is fine if you have not created
+  custom ones.
+- **Client ID** and **Client Secret**: Authentik generates these. Save both
+  values — tuwunel needs them.
+- **Redirect URIs/Origins**: set this to
+  `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`,
+  substituting your Matrix server's public hostname and the **Client ID** from
+  the previous step.
+- All other fields can stay at their defaults.
 
-1. Provider Name: this can be left to the default value
-1. Authorization flow: if you have not created custom flows, either of the two
-   built-in flows can be used depending on desired behaviour
-1. **Client ID** and **Client secret**: these will be generated for you. Save
-   these values as you will need them in your tuwunel configuration
-1. **Redirect URIs/Origins**: set this to
-   `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`
-   replacing `<your.matrix.example.com>` with tuwunel's public (sub)domain and
-   `<client_id>` with the value from the previous step
-1. Other values can be left as default
+##### Bindings
 
-### Configure bindings
+Optional. Add policies here to restrict tuwunel access to a subset of your
+Authentik users.
 
-Optional: set policies if you want to restrict access to tuwunel to only certain
-of your Authentik users.
-
-### Review and Submit Application
-
-Verify all information is correct and press "Submit".
 
 ## Tuwunel configuration
 
-Add the following to your `tuwunel.toml`:
+Add an `[[global.identity_provider]]` entry to your `tuwunel.toml`:
 
 ```toml
 [[global.identity_provider]]
 brand = "Authentik"
-client_id = "<client_id>" # Replace with the Client ID from Authentik
-client_secret = "<client_secret>" # Replace with the Client secret from Authentik
-callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>" # Replace with the same Callback URL you configure in Authentik
-issuer_url = "https://<your.authentik.example.com>/application/o/<slug>" # Replace with your Authentik (sub)domain and the slug you selected above
-base_path = "/application/o/<slug>" # Replace with the slug you selected above
-
-# Optional items
-#name = "Authentik"
-#unique_id_fallbacks = false # prevent randomly generated matrix usernames if none are available
+client_id = "<client_id>"
+client_secret = "<client_secret>"
+issuer_url = "https://<your.authentik.example.com>/application/o/<slug>/"
+callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>"
 ```
 
-See the
-[Authentik OAuth 2.0/OIDC documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/)
-for full details on the provider side.
+`issuer_url` is the application's slug-based path with a trailing slash. This
+is the value Authentik returns as the `iss` claim in issued tokens, and tuwunel
+discovers all other endpoints from
+`<issuer_url>.well-known/openid-configuration` automatically.
 
-## Setting up different Authentik and tuwunel usernames
+If your Authentik instance reports a different `iss` — for example when running
+behind a path prefix, or with a non-default **Issuer Mode** on the provider —
+override discovery directly:
 
-By default, tuwunel will assign the localpart of a username [based on
-Authentik's userinfo][user-ids-from-claims]. By default, the user's Authentik
-username will be served as the `preferred_username` to tuwunel. For example,
-user `foo` would be assigned the account `@foo:example.com` if it is available.
+```toml
+discovery_url = "https://<your.authentik.example.com>/application/o/<slug>/.well-known/openid-configuration"
+```
+
+> [!TIP]
+> For the full set of identity provider options see the
+> [providers reference](../providers.md). For the Authentik side, see the
+> [OAuth2/OpenID Connect provider documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/).
+
+## Customising the Matrix localpart
+
+By default tuwunel derives a new user's Matrix localpart from the
+`preferred_username` claim Authentik returns — see
+[How tuwunel derives Matrix user IDs from claims][user-ids-from-claims]. The
+default Authentik mapping populates `preferred_username` with the user's
+Authentik username, so user `foo` becomes `@foo:example.com`.
 
 [user-ids-from-claims]:
     ../providers.md#how-tuwunel-derives-matrix-user-ids-from-claims
 
-This behaviour can be modified using a custom Authentik mapping.
+To decouple the two — for example to give Authentik user `foo` the localpart
+`@bar:example.com` — replace Authentik's default `profile` scope with a custom
+property mapping that returns the localpart you want.
 
-> [!NOTE]
-> For example, this configuration would allow Authentik user `foo` to receive
-> the matrix username `@bar:example.com`.
+### Create a custom property mapping
 
-### Create a custom mapping for tuwunel
+In the admin interface, navigate to **Customization** > **Property Mappings**
+and select **Create**. Choose **Scope Mapping**, then set the **Scope name** to
+`profile`.
 
-From the Authentik Admin interface, select **Customization** > **Property
-Mappings** > **Create**.
-
-When prompted to select a type, choose **Scope Mapping**.
-
-In the "Create Scope Mapping" dialog, set the Scope name to `profile`.
-
-In "Expression", provide a Python expression that will return a dictionary of
-userinfo entries. For example, to return a custom user attribute
-`matrix_localpart` as the preferred username if it is set, enter:
+In **Expression**, return a dictionary that exposes the desired localpart as
+`preferred_username`. The example below uses a per-user `matrix_localpart`
+attribute when set, falling back to the Authentik username:
 
 ```python
 if "matrix_localpart" in request.user.attributes:
-  return {
-    "name": request.user.name,
-    "given_name": request.user.name,
-    "preferred_username": request.user.attributes["matrix_localpart"],
-    "nickname": request.user.attributes["matrix_localpart"],
-    "groups": [group.name for group in request.user.ak_groups.all()],
-}
-else:
-  return {
+    return {
+        "name": request.user.name,
+        "given_name": request.user.name,
+        "preferred_username": request.user.attributes["matrix_localpart"],
+        "nickname": request.user.attributes["matrix_localpart"],
+        "groups": [group.name for group in request.user.ak_groups.all()],
+    }
+return {
     "name": request.user.name,
     "given_name": request.user.name,
     "preferred_username": request.user.username,
@@ -112,54 +113,40 @@ else:
 }
 ```
 
-Take note of the **Name** you selected and click **Finish**.
+Note the **Name** you give the mapping, then click **Finish**.
 
-### Replace the default profile mapping in your tuwunel provider
+### Replace the default profile mapping
 
-From the Admin interface, select **Applications** > **Providers** and click on
-the "Edit" icon for your tuwunel provider.
+In **Applications** > **Providers**, edit your tuwunel provider, expand
+**Advanced protocol settings**, and find the **Scopes** field.
 
-Expand the **Advanced protocol settings** section and scroll to **Scope**.
+Move your new mapping from **Available Scopes** into **Selected Scopes** with
+the right arrow (`>`), then move `authentik default OAuth Mapping: OpenID
+'profile'` out with the left arrow (`<`). Click **Update**.
 
-In **Available Scopes**, search for the **Name** of your custom mapping, select
-it, and add it to the **Selected Scopes** with the right arrow (`>`).
+### Set the attribute on a user
 
-In **Selected Scopes**, remove the
-`authentik default OAuth Mapping: OpenID 'profile'` by selecting it and moving
-it out with the left arrow (`<`).
-
-Complete the dialog by clicking **Update**.
-
-### Assign a custom attribute to a user
-
-From the Admin interface, select **Directory** > **Users** and click on the
-desired user. Under **Actions**, click **Edit**.
-
-Under **Attributes**, add a custom attribute:
+In **Directory** > **Users**, edit the user and add to **Attributes**:
 
 ```yaml
 matrix_localpart: bar
 ```
 
-Complete the dialog by clicking **Update**.
+Click **Update**.
 
 > [!TIP]
-> Users can be allowed to set a custom attribute themselves using a custom
-> Prompt within a Stage Configuration flow, but this is beyond the scope of this
-> guide.
+> Users can be allowed to set the attribute themselves through a custom prompt
+> in a Stage Configuration flow. See Authentik's documentation for details.
 
-### Test the custom mapping
+### Verify
 
-From the Admin interface, select **Applications** > **Providers**, click on the
-link of your tuwunel provider, then click **Preview**.
-
-Under **Preview for user**, select user `foo`.
-
-The JWT payload should contain the custom matrix localpart:
+In **Applications** > **Providers**, open your provider and click **Preview**.
+Select the user under **Preview for user**; the JWT payload should contain the
+customised localpart:
 
 ```json
 {
     "preferred_username": "bar",
     "nickname": "bar"
 }
-``
+```

--- a/docs/development/testing/complement.md
+++ b/docs/development/testing/complement.md
@@ -74,12 +74,6 @@ docker/bake.sh complement-tester complement-testee && \
 The argument to `complement.sh` becomes the `complement_run` regex, passed to
 Go's test runner via `-run`.
 
-##### Keep a failed run's containers for inspection
-
-```bash
-complement_dirty=1 docker/complement.sh
-```
-
 ##### View logs from the last run
 
 ```bash

--- a/docs/development/testing/workflows.md
+++ b/docs/development/testing/workflows.md
@@ -36,10 +36,10 @@ The `init` job runs before everything else. It has two responsibilities:
    | Runner | Reserved space | Max space |
    |---|---|---|
    | `het` | 192 GB | 384 GB |
-   | `aws` | 48 GB | 64 GB |
+   | `aws` | 48 GB  | 64 GB  |
    | `gcp` | 160 GB | 192 GB |
 
-2. **Emit 40+ output variables** that all downstream jobs consume as inputs.
+2. **Emit output variables** that all downstream jobs consume as inputs.
    These control which matrix dimensions to test, which phases to enable, and
    metadata like the pages URL and release upload URL.
 

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -18,11 +18,10 @@ use tuwunel_core::{
 		Event,
 		pdu::{PduCount, PduId, RawPduId},
 	},
-	warn,
+	trace, warn,
 };
 
 use self::data::{Data, ReceiptItem};
-use crate::sending::EduBuf;
 
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
@@ -49,23 +48,26 @@ impl Service {
 		room_id: &RoomId,
 		event: &ReceiptEvent,
 	) {
+		// update local
 		self.db
 			.readreceipt_update(user_id, room_id, event)
 			.await;
 
 		// update appservices
-		let edu = EphemeralData::Receipt(ReceiptEvent {
-			content: event.content.clone(),
-			room_id: room_id.to_owned(),
-		});
-		let mut buf = EduBuf::new();
-		serde_json::to_writer(&mut buf, &edu).expect("Serialized EphemeralData::Receipt");
-		let _: Result = self
-			.services
+		self.services
 			.sending
-			.send_edu_appservice_room(room_id, buf)
-			.await;
+			.send_edu_room_appservices(room_id, |buf| {
+				let edu = EphemeralData::Receipt(ReceiptEvent {
+					content: event.content.clone(),
+					room_id: room_id.to_owned(),
+				});
 
+				Ok(serde_json::to_writer(buf, &edu)?)
+			})
+			.await
+			.expect("edu serialization or flush failed");
+
+		// update federation
 		if self.services.globals.user_is_local(user_id) {
 			self.services
 				.sending
@@ -220,7 +222,8 @@ where
 	}
 
 	let content = ReceiptEventContent::from_iter(json);
-	tuwunel_core::trace!(?content);
+
+	trace!(?content);
 	Raw::from_json(
 		serde_json::value::to_raw_value(&SyncEphemeralRoomEvent { content })
 			.expect("received valid json"),

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use futures::{Stream, TryFutureExt, try_join};
 use ruma::{
 	OwnedEventId, OwnedUserId, RoomId, UserId,
+	api::appservice::event::push_events::v1::EphemeralData,
 	events::{
 		AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent,
 		receipt::{ReceiptEvent, ReceiptEventContent, Receipts},
@@ -21,6 +22,7 @@ use tuwunel_core::{
 };
 
 use self::data::{Data, ReceiptItem};
+use crate::sending::EduBuf;
 
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
@@ -49,6 +51,19 @@ impl Service {
 	) {
 		self.db
 			.readreceipt_update(user_id, room_id, event)
+			.await;
+
+		// update appservices
+		let edu = EphemeralData::Receipt(ReceiptEvent {
+			content: event.content.clone(),
+			room_id: room_id.to_owned(),
+		});
+		let mut buf = EduBuf::new();
+		serde_json::to_writer(&mut buf, &edu).expect("Serialized EphemeralData::Receipt");
+		let _: Result = self
+			.services
+			.sending
+			.send_edu_appservice_room(room_id, buf)
 			.await;
 
 		if self.services.globals.user_is_local(user_id) {

--- a/src/service/rooms/typing/mod.rs
+++ b/src/service/rooms/typing/mod.rs
@@ -3,7 +3,11 @@ use std::{collections::BTreeMap, sync::Arc};
 use futures::StreamExt;
 use ruma::{
 	OwnedRoomId, OwnedUserId, RoomId, UserId,
-	api::federation::transactions::edu::{Edu, TypingContent},
+	api::{
+		appservice::event::push_events::v1::EphemeralData,
+		federation::transactions::edu::{Edu, TypingContent},
+	},
+	events::{EphemeralRoomEvent, typing::TypingEventContent},
 };
 use tokio::sync::{RwLock, broadcast};
 use tuwunel_core::{
@@ -65,6 +69,9 @@ impl Service {
 			trace!("receiver found what it was looking for and is no longer interested");
 		}
 
+		// update appservices
+		self.appservice_send(room_id).await?;
+
 		// update federation
 		if self.services.globals.user_is_local(user_id) {
 			self.federation_send(room_id, user_id, true)
@@ -99,6 +106,9 @@ impl Service {
 		{
 			trace!("receiver found what it was looking for and is no longer interested");
 		}
+
+		// update appservices
+		self.appservice_send(room_id).await?;
 
 		// update federation
 		if self.services.globals.user_is_local(user_id) {
@@ -160,6 +170,9 @@ impl Service {
 				trace!("receiver found what it was looking for and is no longer interested");
 			}
 
+			// update appservices
+			self.appservice_send(room_id).await?;
+
 			// update federation
 			for user in &removable {
 				if self.services.globals.user_is_local(user) {
@@ -181,6 +194,36 @@ impl Service {
 			.get(room_id)
 			.copied()
 			.unwrap_or(0))
+	}
+
+	/// Returns the typing content with all typing users in the room.
+	async fn typings_content(&self, room_id: &RoomId) -> TypingEventContent {
+		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
+
+		let Some(typing_indicators) = room_typing_indicators else {
+			return TypingEventContent { user_ids: Vec::new() };
+		};
+
+		TypingEventContent {
+			user_ids: typing_indicators.into_keys().collect(),
+		}
+	}
+
+	/// Sends a typing EDU to all appservices interested in the room.
+	async fn appservice_send(&self, room_id: &RoomId) -> Result {
+		let content = self.typings_content(room_id).await;
+		let edu =
+			EphemeralData::Typing(EphemeralRoomEvent { content, room_id: room_id.to_owned() });
+
+		let mut buf = EduBuf::new();
+		serde_json::to_writer(&mut buf, &edu).expect("Serialized EphemeralData::Typing");
+
+		self.services
+			.sending
+			.send_edu_appservice_room(room_id, buf)
+			.await?;
+
+		Ok(())
 	}
 
 	/// Returns a new typing EDU.

--- a/src/service/rooms/typing/mod.rs
+++ b/src/service/rooms/typing/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt, TryStreamExt, future::try_join};
 use ruma::{
 	OwnedRoomId, OwnedUserId, RoomId, UserId,
 	api::{
@@ -12,7 +12,7 @@ use ruma::{
 use tokio::sync::{RwLock, broadcast};
 use tuwunel_core::{
 	Result, Server, debug_info, trace,
-	utils::{self, IterStream},
+	utils::{self, BoolExt, IterStream},
 };
 
 use crate::sending::EduBuf;
@@ -56,10 +56,13 @@ impl Service {
 			.insert(user_id.to_owned(), timeout);
 
 		let count = self.services.globals.next_count();
+
 		self.last_typing_update
 			.write()
 			.await
 			.insert(room_id.to_owned(), *count);
+
+		drop(count);
 
 		if self
 			.typing_update_sender
@@ -70,15 +73,19 @@ impl Service {
 		}
 
 		// update appservices
-		self.appservice_send(room_id).await?;
+		let appservice_send = self.appservice_send(room_id);
 
 		// update federation
-		if self.services.globals.user_is_local(user_id) {
-			self.federation_send(room_id, user_id, true)
-				.await?;
-		}
+		let federation_send = self
+			.services
+			.globals
+			.user_is_local(user_id)
+			.then_async(|| self.federation_send(room_id, user_id, true))
+			.map(Option::transpose);
 
-		Ok(())
+		try_join(appservice_send, federation_send)
+			.await
+			.map(|_| ())
 	}
 
 	/// Removes a user from typing before the timeout is reached.
@@ -94,10 +101,13 @@ impl Service {
 			.remove(user_id);
 
 		let count = self.services.globals.next_count();
+
 		self.last_typing_update
 			.write()
 			.await
 			.insert(room_id.to_owned(), *count);
+
+		drop(count);
 
 		if self
 			.typing_update_sender
@@ -108,15 +118,19 @@ impl Service {
 		}
 
 		// update appservices
-		self.appservice_send(room_id).await?;
+		let appservice_send = self.appservice_send(room_id);
 
 		// update federation
-		if self.services.globals.user_is_local(user_id) {
-			self.federation_send(room_id, user_id, false)
-				.await?;
-		}
+		let federation_send = self
+			.services
+			.globals
+			.user_is_local(user_id)
+			.then_async(|| self.federation_send(room_id, user_id, false))
+			.map(Option::transpose);
 
-		Ok(())
+		try_join(appservice_send, federation_send)
+			.await
+			.map(|_| ())
 	}
 
 	pub async fn wait_for_update(&self, room_id: &RoomId) {
@@ -133,67 +147,76 @@ impl Service {
 		let current_timestamp = utils::millis_since_unix_epoch();
 		let mut removable = Vec::new();
 
-		{
-			let typing = self.typing.read().await;
-			let Some(room) = typing.get(room_id) else {
-				return Ok(());
-			};
-
-			for (user, timeout) in room {
-				if *timeout < current_timestamp {
-					removable.push(user.clone());
-				}
-			}
+		let typing = self.typing.read().await;
+		let Some(room) = typing.get(room_id) else {
+			return Ok(());
 		};
 
-		if !removable.is_empty() {
-			let typing = &mut self.typing.write().await;
-			let room = typing.entry(room_id.to_owned()).or_default();
-
-			for user in &removable {
-				debug_info!("typing timeout {user:?} in {room_id:?}");
-				room.remove(user);
-			}
-
-			// update clients
-			let count = self.services.globals.next_count();
-			self.last_typing_update
-				.write()
-				.await
-				.insert(room_id.to_owned(), *count);
-
-			if self
-				.typing_update_sender
-				.send(room_id.to_owned())
-				.is_err()
-			{
-				trace!("receiver found what it was looking for and is no longer interested");
-			}
-
-			// update appservices
-			self.appservice_send(room_id).await?;
-
-			// update federation
-			for user in &removable {
-				if self.services.globals.user_is_local(user) {
-					self.federation_send(room_id, user, false).await?;
-				}
+		for (user, timeout) in room {
+			if *timeout < current_timestamp {
+				removable.push(user.clone());
 			}
 		}
 
-		Ok(())
+		drop(typing);
+
+		if removable.is_empty() {
+			return Ok(());
+		}
+
+		let mut typing = self.typing.write().await;
+		let room = typing.entry(room_id.to_owned()).or_default();
+		for user in &removable {
+			debug_info!("typing timeout {user:?} in {room_id:?}");
+			room.remove(user);
+		}
+
+		drop(typing);
+
+		// update clients
+		let count = self.services.globals.next_count();
+		self.last_typing_update
+			.write()
+			.await
+			.insert(room_id.to_owned(), *count);
+
+		drop(count);
+
+		if self
+			.typing_update_sender
+			.send(room_id.to_owned())
+			.is_err()
+		{
+			trace!("receiver found what it was looking for and is no longer interested");
+		}
+
+		// update appservices
+		let appservice_send = self.appservice_send(room_id);
+
+		// update federation
+		let federation_sends = removable
+			.iter()
+			.filter(|user_id| self.services.globals.user_is_local(user_id))
+			.try_stream()
+			.try_for_each(|user_id| self.federation_send(room_id, user_id, false));
+
+		try_join(appservice_send, federation_sends)
+			.boxed()
+			.await
+			.map(|_| ())
 	}
 
 	/// Returns the count of the last typing update in this room.
 	pub async fn last_typing_update(&self, room_id: &RoomId) -> Result<u64> {
 		self.typings_maintain(room_id).await?;
-		Ok(self
-			.last_typing_update
+
+		self.last_typing_update
 			.read()
 			.await
 			.get(room_id)
 			.copied()
-			.unwrap_or(0))
+			.map(Ok)
+			.unwrap_or(Ok(0))
 	}
 
 	/// Returns the typing content with all typing users in the room.
@@ -212,18 +235,18 @@ impl Service {
 	/// Sends a typing EDU to all appservices interested in the room.
 	async fn appservice_send(&self, room_id: &RoomId) -> Result {
 		let content = self.typings_content(room_id).await;
-		let edu =
-			EphemeralData::Typing(EphemeralRoomEvent { content, room_id: room_id.to_owned() });
-
-		let mut buf = EduBuf::new();
-		serde_json::to_writer(&mut buf, &edu).expect("Serialized EphemeralData::Typing");
 
 		self.services
 			.sending
-			.send_edu_appservice_room(room_id, buf)
-			.await?;
+			.send_edu_room_appservices(room_id, |buf| {
+				let edu = EphemeralData::Typing(EphemeralRoomEvent {
+					room_id: room_id.to_owned(),
+					content: content.clone(),
+				});
 
-		Ok(())
+				Ok(serde_json::to_writer(buf, &edu)?)
+			})
+			.await
 	}
 
 	/// Returns a new typing EDU.

--- a/src/service/sending/mod.rs
+++ b/src/service/sending/mod.rs
@@ -5,7 +5,9 @@ mod sender;
 use std::{
 	fmt::Debug,
 	hash::{DefaultHasher, Hash, Hasher},
+	io::Write,
 	iter::once,
+	pin::pin,
 	sync::Arc,
 };
 
@@ -16,7 +18,10 @@ use tokio::{task, task::JoinSet};
 use tuwunel_core::{
 	Result, Server, debug, debug_warn, err, error,
 	smallvec::SmallVec,
-	utils::{ReadyExt, TryReadyExt, available_parallelism, math::usize_from_u64_truncated},
+	utils::{
+		IterStream, ReadyExt, TryReadyExt, available_parallelism, future::BoolExt,
+		math::usize_from_u64_truncated, result::LogErr,
+	},
 	warn,
 };
 
@@ -122,6 +127,7 @@ impl Service {
 		let event = SendingEvent::Pdu(*pdu_id);
 		let _cork = self.db.db.cork();
 		let keys = self.db.queue_requests(once((&event, &dest)));
+
 		self.dispatch(Msg {
 			dest,
 			event,
@@ -138,6 +144,7 @@ impl Service {
 		let event = SendingEvent::Pdu(pdu_id);
 		let _cork = self.db.db.cork();
 		let keys = self.db.queue_requests(once((&event, &dest)));
+
 		self.dispatch(Msg {
 			dest,
 			event,
@@ -189,6 +196,7 @@ impl Service {
 		let event = SendingEvent::Edu(serialized);
 		let _cork = self.db.db.cork();
 		let keys = self.db.queue_requests(once((&event, &dest)));
+
 		self.dispatch(Msg {
 			dest,
 			event,
@@ -217,6 +225,7 @@ impl Service {
 		let event = SendingEvent::Edu(serialized);
 		let _cork = self.db.db.cork();
 		let keys = self.db.queue_requests(once((&event, &dest)));
+
 		self.dispatch(Msg {
 			dest,
 			event,
@@ -230,33 +239,58 @@ impl Service {
 	/// Sends an EDU to all appservices interested in a room.
 	/// The `serialized` data must be in `EphemeralData` format, not federation
 	/// `Edu`.
-	#[tracing::instrument(skip(self, room_id, serialized), level = "debug")]
-	pub async fn send_edu_appservice_room(&self, room_id: &RoomId, serialized: EduBuf) -> Result {
-		for appservice in self.services.appservice.read().await.values() {
-			if !appservice.registration.receive_ephemeral {
-				continue;
-			}
+	#[tracing::instrument(skip(self, serializer), level = "debug")]
+	pub async fn send_edu_room_appservices<'a, F>(
+		&self,
+		room_id: &RoomId,
+		serializer: F,
+	) -> Result
+	where
+		F: Fn(&mut dyn Write) -> Result + Send + 'a,
+		&'a F: Send + Sync,
+	{
+		self.services
+			.appservice
+			.read()
+			.await
+			.values()
+			.stream()
+			.filter(|&appservice| async {
+				if !appservice.registration.receive_ephemeral {
+					return false;
+				}
 
-			let matching_aliases = self
-				.services
-				.alias
-				.local_aliases_for_room(room_id)
-				.ready_any(|room_alias| appservice.aliases.is_match(room_alias.as_str()))
-				.await;
+				if appservice.rooms.is_match(room_id.as_str()) {
+					return true;
+				}
 
-			if appservice.rooms.is_match(room_id.as_str())
-				|| matching_aliases
-				|| self
+				let appservice_in_room = self
 					.services
 					.state_cache
-					.appservice_in_room(room_id, appservice)
-					.await
-			{
-				self.send_edu_appservice(appservice.registration.id.clone(), serialized.clone())?;
-			}
-		}
+					.appservice_in_room(room_id, appservice);
 
-		Ok(())
+				let matching_aliases = self
+					.services
+					.alias
+					.local_aliases_for_room(room_id)
+					.ready_any(|room_alias| appservice.aliases.is_match(room_alias.as_str()));
+
+				pin!(appservice_in_room)
+					.or(pin!(matching_aliases))
+					.await
+			})
+			.map(Ok)
+			.ready_try_for_each(|appservice| {
+				let mut buf = EduBuf::new();
+
+				serializer(&mut buf)?;
+				self.send_edu_appservice(appservice.registration.id.clone(), buf)
+					.log_err()
+					.ok();
+
+				Ok(())
+			})
+			.await
 	}
 
 	#[tracing::instrument(skip(self, servers, serialized), level = "debug")]

--- a/src/service/sending/mod.rs
+++ b/src/service/sending/mod.rs
@@ -210,6 +210,55 @@ impl Service {
 		self.send_edu_servers(servers, serialized).await
 	}
 
+	/// Queue an EDU for delivery to a specific appservice.
+	#[tracing::instrument(skip(self, serialized), level = "debug")]
+	pub fn send_edu_appservice(&self, appservice_id: String, serialized: EduBuf) -> Result {
+		let dest = Destination::Appservice(appservice_id);
+		let event = SendingEvent::Edu(serialized);
+		let _cork = self.db.db.cork();
+		let keys = self.db.queue_requests(once((&event, &dest)));
+		self.dispatch(Msg {
+			dest,
+			event,
+			queue_id: keys
+				.into_iter()
+				.next()
+				.expect("request queue key"),
+		})
+	}
+
+	/// Sends an EDU to all appservices interested in a room.
+	/// The `serialized` data must be in `EphemeralData` format, not federation
+	/// `Edu`.
+	#[tracing::instrument(skip(self, room_id, serialized), level = "debug")]
+	pub async fn send_edu_appservice_room(&self, room_id: &RoomId, serialized: EduBuf) -> Result {
+		for appservice in self.services.appservice.read().await.values() {
+			if !appservice.registration.receive_ephemeral {
+				continue;
+			}
+
+			let matching_aliases = self
+				.services
+				.alias
+				.local_aliases_for_room(room_id)
+				.ready_any(|room_alias| appservice.aliases.is_match(room_alias.as_str()))
+				.await;
+
+			if appservice.rooms.is_match(room_id.as_str())
+				|| matching_aliases
+				|| self
+					.services
+					.state_cache
+					.appservice_in_room(room_id, appservice)
+					.await
+			{
+				self.send_edu_appservice(appservice.registration.id.clone(), serialized.clone())?;
+			}
+		}
+
+		Ok(())
+	}
+
 	#[tracing::instrument(skip(self, servers, serialized), level = "debug")]
 	pub async fn send_edu_servers<'a, S>(&self, servers: S, serialized: EduBuf) -> Result
 	where


### PR DESCRIPTION
Appservices with `receive_ephemeral: true` now receive `m.typing` and `m.receipt` events for rooms matching their registered namespaces.

Fixes #382.