### PR TITLE
Add systemd watchdog keep-alive pings

### DIFF
--- a/arch/tuwunel.service
+++ b/arch/tuwunel.service
@@ -9,6 +9,7 @@ RequiresMountsFor=/var/lib/private/tuwunel
 DynamicUser=yes
 Type=notify-reload
 ReloadSignal=SIGUSR1
+WatchdogSec=30
 
 TTYPath=/dev/tty25
 DeviceAllow=char-tty

--- a/debian/tuwunel.service
+++ b/debian/tuwunel.service
@@ -8,6 +8,7 @@ Documentation=https://tuwunel.chat/
 User=tuwunel
 Group=tuwunel
 Type=notify
+WatchdogSec=30
 
 Environment="TUWUNEL_CONFIG=/etc/tuwunel/tuwunel.toml"
 

--- a/rpm/tuwunel.service
+++ b/rpm/tuwunel.service
@@ -8,6 +8,7 @@ Documentation=https://tuwunel.chat/
 User=tuwunel
 Group=tuwunel
 Type=notify
+WatchdogSec=30
 
 Environment="TUWUNEL_CONFIG=/etc/tuwunel/tuwunel.toml"
 

--- a/src/router/run.rs
+++ b/src/router/run.rs
@@ -28,6 +28,8 @@ pub(crate) async fn run(services: Arc<Services>) -> Result {
 	let sigs = server
 		.runtime()
 		.spawn(signal(server.clone(), handle.clone()));
+	#[cfg(all(feature = "systemd", target_os = "linux"))]
+	let watchdog = server.runtime().spawn(start_systemd_watchdog());
 
 	let non_listener = services
 		.config
@@ -55,7 +57,13 @@ pub(crate) async fn run(services: Arc<Services>) -> Result {
 		},
 	};
 
-	// Join the signal handler before we leave.
+	// Join watchdog and the signal handler before we leave.
+	#[cfg(all(feature = "systemd", target_os = "linux"))]
+	{
+		watchdog.abort();
+		_ = watchdog.await;
+	};
+
 	sigs.abort();
 	_ = sigs.await;
 
@@ -153,4 +161,27 @@ fn handle_services_finish(
 	}
 
 	result
+}
+
+#[cfg(all(feature = "systemd", target_os = "linux"))]
+async fn start_systemd_watchdog() {
+	use tokio::time::MissedTickBehavior;
+
+	let mut watchdog_usec = 0;
+	if !sd_notify::watchdog_enabled(false, &mut watchdog_usec) || watchdog_usec == 0 {
+		return;
+	}
+
+	let interval_usec = (watchdog_usec / 2).max(1);
+	let interval = Duration::from_micros(interval_usec);
+
+	let mut ticker = tokio::time::interval(interval);
+	ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+	loop {
+		ticker.tick().await;
+
+		if let Err(e) = sd_notify::notify(false, &[sd_notify::NotifyState::Watchdog]) {
+			error!("failed to notify systemd watchdog state: {e}");
+		}
+	}
 }


### PR DESCRIPTION
My tuwunel instance started hanging randomly where I have to restart it to get it working again. I don't know why it does that, since it shows no error by default, and I will try rebuilding it with more logs to see if I can fish out something. For now and future instances like this, this change will help to work around the issue by allowing systemd to detect the hanging and restart the service by itself.
