### PR TITLE
fix(oidc): return M_UNRECOGNIZED when OIDC server is not configured

### DIFF
--- a/src/api/oidc/auth_issuer.rs
+++ b/src/api/oidc/auth_issuer.rs
@@ -1,6 +1,8 @@
 use axum::{Json, extract::State, response::IntoResponse};
+use http::StatusCode;
+use ruma::api::client::error::ErrorKind;
 use serde::Serialize;
-use tuwunel_core::Result;
+use tuwunel_core::{Error, Result};
 
 #[derive(Serialize)]
 struct AuthIssuerResponse {
@@ -10,7 +12,15 @@ struct AuthIssuerResponse {
 pub(crate) async fn auth_issuer_route(
 	State(services): State<crate::State>,
 ) -> Result<impl IntoResponse> {
-	let issuer = services.oauth.get_server()?.issuer_url()?;
+	// 404 + M_UNRECOGNIZED when OAuth is disabled (see auth_metadata.rs).
+	let Ok(server) = services.oauth.get_server() else {
+		return Err(Error::Request(
+			ErrorKind::Unrecognized,
+			"OIDC server not configured".into(),
+			StatusCode::NOT_FOUND,
+		));
+	};
+	let issuer = server.issuer_url()?;
 
 	Ok(Json(AuthIssuerResponse { issuer }))
 }

--- a/src/api/oidc/auth_metadata.rs
+++ b/src/api/oidc/auth_metadata.rs
@@ -1,6 +1,8 @@
 use axum::{Json, extract::State, response::IntoResponse};
+use http::StatusCode;
+use ruma::api::client::error::ErrorKind;
 use serde::{Deserialize, Serialize};
-use tuwunel_core::Result;
+use tuwunel_core::{Error, Result};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ProviderMetadata {
@@ -29,7 +31,18 @@ struct ProviderMetadata {
 pub(crate) async fn openid_configuration_route(
 	State(services): State<crate::State>,
 ) -> Result<impl IntoResponse> {
-	let issuer = services.oauth.get_server()?.issuer_url()?;
+	// When no OAuth server is configured, return 404 + M_UNRECOGNIZED so that
+	// clients (Element-web in particular) recognize this homeserver as not
+	// supporting MSC2965 instead of treating the response as a fatal config
+	// error. See <https://spec.matrix.org/latest/client-server-api/#common-error-codes>.
+	let Ok(server) = services.oauth.get_server() else {
+		return Err(Error::Request(
+			ErrorKind::Unrecognized,
+			"OIDC server not configured".into(),
+			StatusCode::NOT_FOUND,
+		));
+	};
+	let issuer = server.issuer_url()?;
 	let base = issuer.trim_end_matches('/').to_owned();
 
 	Ok(Json(ProviderMetadata {


### PR DESCRIPTION
## Summary

When OAuth/OIDC is not configured, `/_matrix/client/v1/auth_metadata` and `/_matrix/client/v1/auth_issuer` currently propagate the `services.oauth.get_server()` error as-is, which surfaces to clients as a generic `M_NOT_FOUND`.

Element Web (>= 1.12, via matrix-js-sdk's `buildValidatedConfigFromDiscovery`) only treats MSC2965 discovery as "not supported" when it receives **`404 + M_UNRECOGNIZED`**. Any other error — including `404 + M_NOT_FOUND` — is treated as a fatal misconfiguration and the login screen shows *"<server> is misconfigured"*.

This PR makes both endpoints return `404 + M_UNRECOGNIZED ("OIDC server not configured")` when no OAuth server is configured, matching the behavior of the router's default `not_found` handler. Password-only homeservers then work out of the box with recent Element Web builds.

## Reproduction

1. Deploy Tuwunel with `login_with_password = true` and **no** `[[global.identity_provider]]` block.
2. Open the latest Element Web, point it at that homeserver.
3. Before the patch: login screen stuck on *"<server> is misconfigured"*.
4. After the patch: login screen shows the password form as expected.

## Changes

- `src/api/oidc/auth_metadata.rs` — intercept `get_server()` error, return `Error::Request(ErrorKind::Unrecognized, ..., StatusCode::NOT_FOUND)`.
- `src/api/oidc/auth_issuer.rs` — same fix.

## Tested on

Built from this branch, deployed on `matrix.altanet.fr` (Tuwunel 1.6.0 + this patch). Element Web login flow, password auth, federation all nominal. Running for several days without regression.

## Notes

- No change to the happy path when OIDC *is* configured.
- No new dependencies.
- Reference for the expected behavior: the default `not_found` handler in `src/router/router.rs` already returns `M_UNRECOGNIZED` for unknown routes.
