### PR TITLE
Fix startup crash on OpenBSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5583,6 +5583,7 @@ dependencies = [
  "maplit",
  "nix 0.31.2",
  "num-traits",
+ "num_cpus",
  "object_store",
  "rand 0.8.5",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,9 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bzip2-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,8 @@ version = "1.11"
 
 [workspace.dependencies.bytesize]
 version = "2.3"
+default-features = false
+features = ["serde", "std"]
 
 [workspace.dependencies.cargo_toml]
 version = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,9 @@ features = [
 	"user",
 ]
 
+[workspace.dependencies.num_cpus]
+version = "1"
+
 [workspace.dependencies.num-traits]
 version = "0.2"
 

--- a/docs/deploying/docker-compose.yml
+++ b/docs/deploying/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         image: jevolk/tuwunel:latest
         restart: unless-stopped
         ports:
-            - 8448:6167
+            - 8008:6167
         volumes:
             - db:/var/lib/tuwunel
             #- ./tuwunel.toml:/etc/tuwunel.toml

--- a/src/admin/debug/commands.rs
+++ b/src/admin/debug/commands.rs
@@ -17,7 +17,7 @@ use ruma::{
 use serde::Serialize;
 use tracing_subscriber::EnvFilter;
 use tuwunel_core::{
-	Err, Result, debug_error, err, info, jwt,
+	Err, Error, Result, debug_error, err, info, jwt,
 	matrix::{
 		Event,
 		pdu::{PduEvent, PduId, RawPduId},
@@ -26,7 +26,7 @@ use tuwunel_core::{
 	trace, utils,
 	utils::{
 		math::Expected,
-		stream::{IterStream, ReadyExt},
+		stream::{IterStream, ReadyExt, TryReadyExt},
 		string::EMPTY,
 		time::now_secs,
 	},
@@ -277,28 +277,56 @@ pub(super) async fn get_remote_pdu(
 }
 
 #[admin_command]
-pub(super) async fn get_room_state(&self, room: OwnedRoomOrAliasId) -> Result {
+pub(super) async fn get_room_state(
+	&self,
+	room: OwnedRoomOrAliasId,
+	kind: Option<String>,
+	state_key: Option<String>,
+) -> Result {
 	let room_id = self.services.alias.maybe_resolve(&room).await?;
-	let room_state: Vec<Raw<AnyStateEvent>> = self
-		.services
+
+	if state_key.is_none()
+		&& let Some(kind) = kind.clone().map(Into::into)
+	{
+		return self
+			.services
+			.state_accessor
+			.room_state_type_pdus(&room_id, &kind)
+			.map_ok(Event::into_format)
+			.ready_and_then(|event: Raw<AnyStateEvent>| {
+				serde_json::to_value(&event).map_err(Error::from)
+			})
+			.ready_and_then(|event| serde_json::to_string_pretty(&event).map_err(Error::from))
+			.try_for_each(|json| self.write_string(format!("```json\n{json}\n```\n")))
+			.await;
+	}
+
+	if let Some(state_key) = state_key
+		&& let Some(kind) = kind.map(Into::into)
+	{
+		let event: Raw<AnyStateEvent> = self
+			.services
+			.state_accessor
+			.room_state_get(&room_id, &kind, &state_key)
+			.await?
+			.into_format();
+
+		let value = serde_json::to_value(&event)?;
+		let json = serde_json::to_string_pretty(&value)?;
+		return self
+			.write_string(format!("```json\n{json}\n```\n"))
+			.await;
+	}
+
+	self.services
 		.state_accessor
 		.room_state_full_pdus(&room_id)
 		.map_ok(Event::into_format)
-		.try_collect()
-		.await?;
-
-	if room_state.is_empty() {
-		return Err!("Unable to find room state in our database (vector is empty)",);
-	}
-
-	let json = serde_json::to_string_pretty(&room_state).map_err(|e| {
-		err!(Database(
-			"Failed to convert room state events to pretty JSON, possible invalid room state \
-			 events in our database {e}",
-		))
-	})?;
-
-	self.write_str(&format!("```json\n{json}\n```"))
+		.ready_and_then(|event: Raw<AnyStateEvent>| {
+			serde_json::to_value(&event).map_err(Error::from)
+		})
+		.ready_and_then(|event| serde_json::to_string_pretty(&event).map_err(Error::from))
+		.try_for_each(|json| self.write_string(format!("```json\n{json}\n```\n")))
 		.await
 }
 

--- a/src/admin/debug/mod.rs
+++ b/src/admin/debug/mod.rs
@@ -75,6 +75,12 @@ pub(super) enum DebugCommand {
 	GetRoomState {
 		/// Room ID
 		room_id: OwnedRoomOrAliasId,
+
+		/// Event Type
+		kind: Option<String>,
+
+		/// State Key
+		state_key: Option<String>,
 	},
 
 	/// - Get and display signing keys from local cache or remote server.

--- a/src/admin/query/storage.rs
+++ b/src/admin/query/storage.rs
@@ -314,7 +314,7 @@ async fn query_storage_sync(&self, src: String, dst: String) -> Result {
 		.try_stream()
 		.broadn_and_then(2, async |item| {
 			let data = src_p.get(item.as_ref()).await?;
-			let put = dst_p.put(item.as_ref(), data).await?;
+			let put = dst_p.put_one(item.as_ref(), data).await?;
 
 			Ok((item, put))
 		})

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -3,9 +3,9 @@ mod filter;
 mod rooms;
 mod selector;
 
-use std::{collections::BTreeMap, fmt::Debug, time::Duration};
+use std::{collections::BTreeMap, fmt::Debug, sync::Arc, time::Duration};
 
-use axum::extract::State;
+use axum::extract::{Extension, State};
 use futures::{
 	FutureExt, TryFutureExt,
 	future::{join, try_join},
@@ -15,7 +15,10 @@ use ruma::{
 	api::client::sync::sync_events::v5::{ListId, Request, Response, response},
 	events::room::member::MembershipState,
 };
-use tokio::time::{Instant, timeout_at};
+use tokio::{
+	sync::Notify,
+	time::{Instant, timeout_at},
+};
 use tuwunel_core::{
 	Err, Result, debug,
 	debug::INFO_SPAN_LEVEL,
@@ -75,6 +78,7 @@ type ListIds = SmallVec<[ListId; 1]>;
 	)
 )]
 pub(crate) async fn sync_events_v5_route(
+	Extension(interrupted): Extension<Arc<Notify>>,
 	State(ref services): State<crate::State>,
 	body: Ruma<Request>,
 ) -> Result<Response> {
@@ -97,7 +101,7 @@ pub(crate) async fn sync_events_v5_route(
 		.unwrap_or(0);
 
 	let conn_key = into_connection_key(sender_user, sender_device, request.conn_id.as_deref());
-	let (conn_val, superseded) = services
+	let conn_val = services
 		.sync
 		.load_or_init_connection(&conn_key)
 		.await;
@@ -193,8 +197,8 @@ pub(crate) async fn sync_events_v5_route(
 		if timeout == 0
 			|| services.server.is_stopping()
 			|| tokio::select! {
-				() = superseded.notified() => true,
-				result = timeout_at(stop_at, watchers).boxed() => result.is_err(),
+				() = interrupted.notified() => return Ok(response),
+				watch = timeout_at(stop_at, watchers).boxed() => watch.is_err(),
 			} {
 			response.pos = conn.next_batch.to_string().into();
 			trace!(conn.globalsince, conn.next_batch, "timeout; empty response {response:?}");

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -101,7 +101,7 @@ pub(crate) async fn sync_events_v5_route(
 		.unwrap_or(0);
 
 	let conn_key = into_connection_key(sender_user, sender_device, request.conn_id.as_deref());
-	let conn_val = services
+	let (conn_val, superseded) = services
 		.sync
 		.load_or_init_connection(&conn_key)
 		.await;
@@ -196,11 +196,10 @@ pub(crate) async fn sync_events_v5_route(
 
 		if timeout == 0
 			|| services.server.is_stopping()
-			|| timeout_at(stop_at, watchers)
-				.boxed()
-				.await
-				.is_err()
-		{
+			|| tokio::select! {
+				() = superseded.notified() => true,
+				result = timeout_at(stop_at, watchers).boxed() => result.is_err(),
+			} {
 			response.pos = conn.next_batch.to_string().into();
 			trace!(conn.globalsince, conn.next_batch, "timeout; empty response {response:?}");
 			conn.store(&services.sync, &conn_key);

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -110,6 +110,9 @@ url.workspace = true
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
 
+[target.'cfg(target_os = "openbsd")'.dependencies]
+num_cpus.workspace = true
+
 [dev-dependencies]
 criterion.workspace = true
 insta.workspace = true

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -11,6 +11,7 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+use bytesize::ByteSize;
 use either::{Either, Either::Left};
 use figment::providers::{Data, Env, Format, Toml};
 pub use figment::{Figment, value::Value as FigmentValue};
@@ -3085,6 +3086,16 @@ pub struct StorageProviderS3 {
 	/// (expert use) When configured for the bucket it should be reflected here.
 	pub use_bucket_key: Option<bool>,
 
+	/// (expert use) Threshold size for switching to Multi-part uploads. This is
+	/// a quirk of the S3 protocol which requires us to use a different approach
+	/// for "large" uploads. This value determines what a "large" upload is. The
+	/// default value should be sufficient for most providers. The value is a
+	/// parsed string allowing SI or IEC units for convenience.
+	///
+	/// default: 100 MiB
+	#[serde(default = "default_multipart_threshold")]
+	pub multipart_threshold: ByteSize,
+
 	/// (developer use) Allows relaxing default requirement forcing HTTPS.
 	///
 	/// default: true
@@ -3670,3 +3681,5 @@ fn default_sso_grant_session_duration() -> Option<u64> { Some(300) }
 fn default_redaction_retention_seconds() -> u64 { 5_184_000 }
 
 fn default_media_storage_providers() -> BTreeSet<String> { ["media".to_owned()].into() }
+
+fn default_multipart_threshold() -> ByteSize { ByteSize::mib(100) }

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -2404,6 +2404,24 @@ pub struct Config {
 	#[serde(default = "true_fn")]
 	pub database_migrations: bool,
 
+	/// Force the database to set its version to the current version known to
+	/// the executable.
+	///
+	/// - When the discovered version is less than the current version any
+	///   migrations are applied normally.
+	/// - When the discovered version is equal to the current version,
+	///   unversioned migrations are applied normally.
+	/// - When the discovered database version is greater than the current
+	///   version, one-time migrations are applied normally and the discoverable
+	///   version is regressed back to the current version.
+	///
+	/// This option extremely dangerous and intended for developer debugging and
+	/// testing only. Never set this option unless you have been instructed to
+	/// do so. Setting this option may cause permanent damage and permanent loss
+	/// of data.
+	#[serde(default)]
+	pub force_migration: bool,
+
 	// external structure; separate section
 	#[serde(default)]
 	pub blurhashing: BlurhashConfig,

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -2388,6 +2388,22 @@ pub struct Config {
 	#[serde(default)]
 	pub appservice_dir: Option<PathBuf>,
 
+	/// Skip database migration on startup. This option is intended for
+	/// developer debugging and testing only. Never set this option to false
+	/// unless you have been instructed to do so. Setting this option to false
+	/// may cause permanent damage and permanent loss of data.
+	///
+	/// Any new database migrations will not be applied on startup, and the
+	/// database schema version will not be adjusted. These migrations and
+	/// schema changes may be expected by the current codebase but may not be
+	/// available when this option is set to false.
+	///
+	/// Setting this option to false will have no effect if no new migrations
+	/// are to be applied. New migrations are applied once during any execution
+	/// where this option is set to true (which is the default).
+	#[serde(default = "true_fn")]
+	pub database_migrations: bool,
+
 	// external structure; separate section
 	#[serde(default)]
 	pub blurhashing: BlurhashConfig,

--- a/src/core/utils/sys/compute.rs
+++ b/src/core/utils/sys/compute.rs
@@ -120,9 +120,15 @@ pub fn node_affinity(id: Id) -> impl Iterator<Item = Id> {
 
 /// Get the number of threads which could execute in parallel based on hardware
 /// constraints of this system.
+#[cfg(not(target_os = "openbsd"))]
 #[inline]
 #[must_use]
 pub fn available_parallelism() -> usize { cores_available().count() }
+
+#[cfg(target_os = "openbsd")]
+#[inline]
+#[must_use]
+pub fn available_parallelism() -> usize { num_cpus::get() }
 
 /// Gets the ID of the nth core available. This bijects our sequence of cores to
 /// actual ID's which may have gaps for cores which are not available.
@@ -168,12 +174,16 @@ pub fn getcpu() -> Result<usize> {
 #[inline]
 pub fn getcpu() -> Result<usize> { Err(crate::Error::Io(std::io::ErrorKind::Unsupported.into())) }
 
+#[cfg(not(target_os = "openbsd"))]
 fn query_cores_available() -> impl Iterator<Item = Id> {
 	core_affinity::get_core_ids()
 		.unwrap_or_default()
 		.into_iter()
 		.map(|core_id| core_id.id)
 }
+
+#[cfg(target_os = "openbsd")]
+fn query_cores_available() -> impl Iterator<Item = Id> { 0..num_cpus::get() }
 
 fn init_smt_topology() -> [Mask; MASK_BITS] { [Mask::default(); MASK_BITS] }
 

--- a/src/router/request.rs
+++ b/src/router/request.rs
@@ -47,26 +47,25 @@ pub(crate) async fn handle(
 
 	let uri = req.uri().clone();
 	let method = req.method().clone();
-	let requestor = async |services: Arc<Services>, parent: Span| {
-		tokio::select! {
-			response = execute(&services, req, next, &parent) => response,
-			response = services.server.until_shutdown()
-				.then(|()| {
-					let timeout = services.server.config.client_shutdown_timeout;
-					let timeout = Duration::from_secs(timeout);
-					sleep(timeout)
-				})
-				.map(|()| StatusCode::SERVICE_UNAVAILABLE)
-				.map(IntoResponse::into_response) => response,
-		}
-	};
-
+	let parent = Span::current();
 	let response = match method {
 		| Method::PUT | Method::POST | Method::DELETE | Method::PATCH => {
 			let task = services
+				.clone()
 				.server
 				.runtime()
-				.spawn(requestor(services.clone(), Span::current()));
+				.spawn(async move {
+					tokio::select! {
+						response = execute(&services, req, next, &parent) => response,
+						response = services.server.until_shutdown()
+							.then(|()| {
+								let timeout = services.config.client_shutdown_timeout;
+								sleep(Duration::from_secs(timeout))
+							})
+							.map(|()| StatusCode::SERVICE_UNAVAILABLE)
+							.map(IntoResponse::into_response) => response,
+					}
+				});
 
 			let abort = task.abort_handle();
 			defer! {{
@@ -77,7 +76,7 @@ pub(crate) async fn handle(
 
 			task.await.map_err(unhandled)?
 		},
-		| _ => requestor(services.clone(), Span::current()).await,
+		| _ => execute(&services, req, next, &parent).await,
 	};
 
 	handle_result(&method, &uri, response)

--- a/src/router/request.rs
+++ b/src/router/request.rs
@@ -11,7 +11,7 @@ use axum::{
 use futures::FutureExt;
 use http::{Method, StatusCode, Uri};
 use ruma::api::client::error::ErrorKind;
-use tokio::{task, time::sleep};
+use tokio::{sync::Notify, task, time::sleep};
 use tracing::Span;
 use tuwunel_core::{Error, Result, debug, debug_error, debug_warn, defer, error, trace};
 use tuwunel_service::Services;
@@ -32,7 +32,7 @@ use tuwunel_service::Services;
 )]
 pub(crate) async fn handle(
 	State(services): State<Arc<Services>>,
-	req: http::Request<axum::body::Body>,
+	mut req: http::Request<axum::body::Body>,
 	next: axum::middleware::Next,
 ) -> Result<Response, StatusCode> {
 	if !services.server.is_running() {
@@ -50,6 +50,8 @@ pub(crate) async fn handle(
 	let parent = Span::current();
 	let response = match method {
 		| Method::PUT | Method::POST | Method::DELETE | Method::PATCH => {
+			let detached = Arc::new(Notify::new());
+			req.extensions_mut().insert(detached.clone());
 			let task = services
 				.clone()
 				.server
@@ -70,7 +72,12 @@ pub(crate) async fn handle(
 			let abort = task.abort_handle();
 			defer! {{
 				if !abort.is_finished() {
-					debug_warn!(task = ?abort.id(), "Client disconnected; detached request.");
+					debug_warn!(
+						task = ?abort.id(),
+						"Client disconnected; detached request."
+					);
+
+					detached.notify_one();
 				}
 			}};
 

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, pin_mut};
 use http::StatusCode;
-use object_store::PutPayload;
 use ruma::{
 	Mxc, OwnedMxcUri, OwnedUserId, UserId,
 	api::client::error::{ErrorKind, RetryAfter},
@@ -598,12 +597,14 @@ impl Service {
 			.and_then(async |provider| {
 				let path = self.get_media_name_sha256(key);
 				debug!(
-					?key, ?path, provider = ?provider.name,
+					?key, ?path,
+					len = ?file.len(),
+					provider = ?provider.name,
 					"Creating media file on storage provider."
 				);
 
 				provider
-					.put(path.as_str(), PutPayload::from(file.to_vec()))
+					.put_one(path.as_str(), file.to_vec())
 					.await
 					.log_err()?;
 

--- a/src/service/migrations.rs
+++ b/src/service/migrations.rs
@@ -91,20 +91,23 @@ async fn migrate(services: &Services) -> Result {
 	let db = &services.db;
 	let config = &services.server.config;
 
-	if services.globals.db.database_version().await < 11 {
+	let target_version = DATABASE_VERSION;
+	let discovered_version = async || services.globals.db.database_version().await;
+
+	if discovered_version().await < 11 {
 		return Err!(Database(
 			"Database schema version {} is no longer supported",
-			services.globals.db.database_version().await
+			discovered_version().await,
 		));
 	}
 
-	if services.globals.db.database_version().await < 12 {
+	if discovered_version().await < 12 {
 		db_lt_12(services).await?;
 	}
 
 	// This migration can be reused as-is anytime the server-default rules are
 	// updated.
-	if services.globals.db.database_version().await < 13 {
+	if discovered_version().await < 13 {
 		db_lt_13(services).await?;
 	}
 
@@ -138,7 +141,6 @@ async fn migrate(services: &Services) -> Result {
 		.get(b"fix_referencedevents_missing_sep")
 		.await
 		.is_not_found()
-		|| services.globals.db.database_version().await < 17
 	{
 		fix_referencedevents_missing_sep(services).await?;
 	}
@@ -147,7 +149,6 @@ async fn migrate(services: &Services) -> Result {
 		.get(b"fix_readreceiptid_readreceipt_duplicates")
 		.await
 		.is_not_found()
-		|| services.globals.db.database_version().await < 17
 	{
 		fix_readreceiptid_readreceipt_duplicates(services).await?;
 	}
@@ -160,18 +161,34 @@ async fn migrate(services: &Services) -> Result {
 		fix_hashed_sentinel_passwords(services).await?;
 	}
 
-	if services.globals.db.database_version().await < 17 {
-		services.globals.db.bump_database_version(17);
-		info!("Migration: Bumped database version to 17");
+	if discovered_version().await < target_version {
+		services
+			.globals
+			.db
+			.bump_database_version(target_version);
+
+		info!(
+			"Database: Migrated schema version from {} to {target_version}",
+			discovered_version().await
+		);
+	} else if discovered_version().await != target_version && config.force_migration {
+		services
+			.globals
+			.db
+			.bump_database_version(target_version);
+
+		warn!(
+			"Database: Forced migration from schema version {} to {target_version}",
+			discovered_version().await,
+		);
 	}
 
 	assert_eq!(
-		services.globals.db.database_version().await,
-		DATABASE_VERSION,
+		target_version,
+		discovered_version().await,
 		"Failed asserting local database version {} is equal to known latest tuwunel database \
-		 version {}",
-		services.globals.db.database_version().await,
-		DATABASE_VERSION,
+		 version {target_version}",
+		discovered_version().await,
 	);
 
 	if !services.config.forbidden_usernames.is_empty() {

--- a/src/service/migrations.rs
+++ b/src/service/migrations.rs
@@ -32,6 +32,11 @@ use crate::{Services, media};
 pub(crate) const DATABASE_VERSION: u64 = 17;
 
 pub(crate) async fn migrations(services: &Services) -> Result {
+	if !services.config.database_migrations {
+		warn!("Skipping database migrations due to configuration...");
+		return Ok(());
+	}
+
 	let users_count = services.users.count().await;
 
 	// Matrix resource ownership is based on the server name; changing it

--- a/src/service/migrations.rs
+++ b/src/service/migrations.rs
@@ -1,13 +1,7 @@
 use std::cmp;
 
 use futures::{FutureExt, StreamExt};
-use ruma::{
-	OwnedUserId, RoomId, UserId,
-	events::{
-		GlobalAccountDataEventType, push_rules::PushRulesEvent, room::member::MembershipState,
-	},
-	push::Ruleset,
-};
+use ruma::{OwnedUserId, RoomId, UserId, events::room::member::MembershipState};
 use tuwunel_core::{
 	Err, Result, debug, debug_info, debug_warn, err, error, info,
 	itertools::Itertools,
@@ -94,21 +88,11 @@ async fn migrate(services: &Services) -> Result {
 	let target_version = DATABASE_VERSION;
 	let discovered_version = async || services.globals.db.database_version().await;
 
-	if discovered_version().await < 11 {
+	if discovered_version().await < 13 {
 		return Err!(Database(
 			"Database schema version {} is no longer supported",
 			discovered_version().await,
 		));
-	}
-
-	if discovered_version().await < 12 {
-		db_lt_12(services).await?;
-	}
-
-	// This migration can be reused as-is anytime the server-default rules are
-	// updated.
-	if discovered_version().await < 13 {
-		db_lt_13(services).await?;
 	}
 
 	if db["global"]
@@ -249,143 +233,6 @@ async fn migrate(services: &Services) -> Result {
 
 	info!("Loaded RocksDB database with schema version {DATABASE_VERSION}");
 
-	Ok(())
-}
-
-async fn db_lt_12(services: &Services) -> Result {
-	for username in &services
-		.users
-		.list_local_users()
-		.map(UserId::to_owned)
-		.collect::<Vec<_>>()
-		.await
-	{
-		let user = match UserId::parse_with_server_name(username.as_str(), &services.server.name)
-		{
-			| Ok(u) => u,
-			| Err(e) => {
-				warn!("Invalid username {username}: {e}");
-				continue;
-			},
-		};
-
-		let mut account_data: PushRulesEvent = services
-			.account_data
-			.get_global(&user, GlobalAccountDataEventType::PushRules)
-			.await
-			.expect("Username is invalid");
-
-		let rules_list = &mut account_data.content.global;
-
-		//content rule
-		{
-			let content_rule_transformation =
-				[".m.rules.contains_user_name", ".m.rule.contains_user_name"];
-
-			let rule = rules_list
-				.content
-				.get(content_rule_transformation[0]);
-
-			if let Some(rule) = rule {
-				let mut rule = rule.clone();
-				let mut rule_id = String::new();
-				content_rule_transformation[1].clone_into(&mut rule_id);
-				rule.rule_id = rule_id.into();
-				rules_list
-					.content
-					.shift_remove(content_rule_transformation[0]);
-
-				rules_list.content.insert(rule);
-			}
-		}
-
-		//underride rules
-		{
-			let underride_rule_transformation = [
-				[".m.rules.call", ".m.rule.call"],
-				[".m.rules.room_one_to_one", ".m.rule.room_one_to_one"],
-				[".m.rules.encrypted_room_one_to_one", ".m.rule.encrypted_room_one_to_one"],
-				[".m.rules.message", ".m.rule.message"],
-				[".m.rules.encrypted", ".m.rule.encrypted"],
-			];
-
-			for transformation in underride_rule_transformation {
-				let rule = rules_list.underride.get(transformation[0]);
-				if let Some(rule) = rule {
-					let mut rule = rule.clone();
-					let mut rule_id = String::new();
-					transformation[1].clone_into(&mut rule_id);
-					rule.rule_id = rule_id.into();
-					rules_list
-						.underride
-						.shift_remove(transformation[0]);
-					rules_list.underride.insert(rule);
-				}
-			}
-		}
-
-		services
-			.account_data
-			.update(
-				None,
-				&user,
-				GlobalAccountDataEventType::PushRules
-					.to_string()
-					.into(),
-				&serde_json::to_value(account_data).expect("to json value always works"),
-			)
-			.await?;
-	}
-
-	services.globals.db.bump_database_version(12);
-	info!("Migration: 11 -> 12 finished");
-	Ok(())
-}
-
-async fn db_lt_13(services: &Services) -> Result {
-	for username in &services
-		.users
-		.list_local_users()
-		.map(UserId::to_owned)
-		.collect::<Vec<_>>()
-		.await
-	{
-		let user = match UserId::parse_with_server_name(username.as_str(), &services.server.name)
-		{
-			| Ok(u) => u,
-			| Err(e) => {
-				warn!("Invalid username {username}: {e}");
-				continue;
-			},
-		};
-
-		let mut account_data: PushRulesEvent = services
-			.account_data
-			.get_global(&user, GlobalAccountDataEventType::PushRules)
-			.await
-			.expect("Username is invalid");
-
-		let user_default_rules = Ruleset::server_default(&user);
-		account_data
-			.content
-			.global
-			.update_with_server_default(user_default_rules);
-
-		services
-			.account_data
-			.update(
-				None,
-				&user,
-				GlobalAccountDataEventType::PushRules
-					.to_string()
-					.into(),
-				&serde_json::to_value(account_data).expect("to json value always works"),
-			)
-			.await?;
-	}
-
-	services.globals.db.bump_database_version(13);
-	info!("Migration: 12 -> 13 finished");
 	Ok(())
 }
 

--- a/src/service/oauth/server.rs
+++ b/src/service/oauth/server.rs
@@ -37,14 +37,13 @@ struct Data {
 
 impl Server {
 	pub(super) fn build(args: &crate::Args<'_>) -> Result<Option<Self>> {
-		if args.server.config.identity_provider.is_empty()
-			|| args.server.config.well_known.client.is_none()
+		if !args.server.config.identity_provider.is_empty()
+			&& args.server.config.well_known.client.is_none()
 		{
 			warn!(
-				"OIDC server (next-gen auth) requires `well_known.client` and one or more \
-				 `identity_provider` to be configured"
+				"OIDC server (Next-gen auth) requires `well_known.client` to be configured to \
+				 serve your `identity_provider`."
 			);
-
 			return Ok(None);
 		}
 

--- a/src/service/storage/provider.rs
+++ b/src/service/storage/provider.rs
@@ -14,8 +14,11 @@ use tuwunel_core::{
 	config::StorageProvider,
 	debug,
 	derivative::Derivative,
-	err, error, implement, info, trace,
-	utils::stream::{IterStream, TryReadyExt},
+	err, error, extract_variant, implement, info, trace,
+	utils::{
+		result::FlatOk,
+		stream::{IterStream, TryReadyExt},
+	},
 };
 
 #[derive(Derivative)]
@@ -66,6 +69,13 @@ async fn startup_check(self: &Arc<Self>) -> Result {
 		.await
 }
 
+/// Put object into store from streaming input.
+///
+/// Highly recommended to know the total size of the object. If size is `None`,
+/// the stream may be collected in memory to find the size. If you are certain
+/// the size exceeds the multipart-threshold but truly cannot know the size
+/// (e.g. huge dataset, chunked encoding, etc) then pass `Some(usize::max)` to
+/// prevent collecting in memory; incorrect assumption will result in error.
 #[implement(Provider)]
 #[tracing::instrument(
 	level = "debug",
@@ -76,10 +86,80 @@ async fn startup_check(self: &Arc<Self>) -> Result {
 		?path,
 	)
 )]
-pub async fn store<S, T>(&self, path: &str, input: S) -> Result<PutResult>
+pub async fn put<S, T>(&self, path: &str, size: Option<usize>, input: S) -> Result<PutResult>
 where
 	S: Stream<Item = Result<T>> + Send,
-	PutPayload: From<T>,
+	PutPayload: From<T> + From<PutPayload>,
+{
+	if size >= Some(self.multipart_threshold()) {
+		return self.put_multi(path, input).await;
+	}
+
+	let payloads: Vec<PutPayload> = input
+		.map_ok(PutPayload::from)
+		.try_collect::<Vec<_>>()
+		.await?;
+
+	let len = payloads
+		.iter()
+		.map(PutPayload::content_length)
+		.fold(0_usize, usize::saturating_add);
+
+	if len >= self.multipart_threshold() {
+		return self
+			.put_multi(path, payloads.into_iter().try_stream())
+			.await;
+	}
+
+	let payload: PutPayload = payloads.into_iter().map(Bytes::from).collect();
+
+	self.put_single(path, payload).await
+}
+
+/// Put object into the store from contiguous input.
+///
+/// The size of input will be determined and multipart upload will be chosen as
+/// necessary internally.
+#[implement(Provider)]
+#[tracing::instrument(
+	level = "debug",
+	err(level = "debug"),
+	skip_all,
+	fields(
+		provider = %self.name,
+		?path,
+	)
+)]
+pub async fn put_one<T>(&self, path: &str, input: T) -> Result<PutResult>
+where
+	PutPayload: From<T> + From<PutPayload>,
+{
+	let payload: PutPayload = input.into();
+
+	if payload.content_length() >= self.multipart_threshold() {
+		return self
+			.put_multi(path, once(payload).try_stream())
+			.await;
+	}
+
+	self.put_single(path, payload).await
+}
+
+/// Put object into the store from streaming input using multipart upload.
+#[implement(Provider)]
+#[tracing::instrument(
+	level = "debug",
+	err(level = "debug"),
+	skip_all,
+	fields(
+		provider = %self.name,
+		?path,
+	)
+)]
+async fn put_multi<S, T>(&self, path: &str, input: S) -> Result<PutResult>
+where
+	S: Stream<Item = Result<T>> + Send,
+	PutPayload: From<T> + From<PutPayload>,
 {
 	let path = self.to_abs_path(path)?;
 	let mut handle = self
@@ -114,6 +194,7 @@ where
 	}
 }
 
+/// Put object into the store from contiguous input non-multipart upload.
 #[implement(Provider)]
 #[tracing::instrument(
 	level = "debug",
@@ -124,14 +205,11 @@ where
 		?path,
 	)
 )]
-pub async fn put<T>(&self, path: &str, input: T) -> Result<PutResult>
-where
-	PutPayload: From<T>,
-{
+async fn put_single(&self, path: &str, input: PutPayload) -> Result<PutResult> {
 	let path = self.to_abs_path(path)?;
 
 	self.provider
-		.put(&path, input.into())
+		.put(&path, input)
 		.map_err(Error::from)
 		.await
 }
@@ -378,4 +456,13 @@ fn to_abs_path(&self, location: &str) -> Result<Path> {
 	);
 
 	Ok(path)
+}
+
+#[implement(Provider)]
+fn multipart_threshold(&self) -> usize {
+	extract_variant!(&self.config, StorageProvider::S3)
+		.map(|config| config.multipart_threshold.as_u64())
+		.map(TryInto::try_into)
+		.flat_ok()
+		.unwrap_or(usize::MAX)
 }

--- a/src/service/sync/mod.rs
+++ b/src/service/sync/mod.rs
@@ -14,7 +14,7 @@ use ruma::{
 	},
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex as TokioMutex, Notify};
+use tokio::sync::Mutex as TokioMutex;
 use tuwunel_core::{Result, at, debug, err, implement, is_equal_to, utils::stream::TryIgnore};
 use tuwunel_database::{Cbor, Deserialized, Map};
 
@@ -57,10 +57,9 @@ pub struct Room {
 	pub roomsince: u64,
 }
 
+type Connections = TokioMutex<BTreeMap<ConnectionKey, ConnectionVal>>;
 pub type ConnectionVal = Arc<TokioMutex<Connection>>;
-pub type ConnectionEntry = (ConnectionVal, Arc<Notify>);
 pub type ConnectionKey = (OwnedUserId, Option<OwnedDeviceId>, Option<ConnectionId>);
-type Connections = TokioMutex<BTreeMap<ConnectionKey, ConnectionEntry>>;
 
 pub type Subscriptions = BTreeMap<OwnedRoomId, request::ListConfig>;
 pub type Lists = BTreeMap<ListId, request::List>;
@@ -103,22 +102,22 @@ pub async fn clear_connections(
 	device_id: Option<&DeviceId>,
 	conn_id: Option<&ConnectionId>,
 ) {
-	self.connections.lock().await.retain(
-		|(conn_user_id, conn_device_id, conn_conn_id), (_, notify)| {
+	self.connections
+		.lock()
+		.await
+		.retain(|(conn_user_id, conn_device_id, conn_conn_id), _| {
 			let retain = user_id.is_none_or(is_equal_to!(conn_user_id))
 				&& (device_id.is_none() || device_id == conn_device_id.as_deref())
 				&& (conn_id.is_none() || conn_id == conn_conn_id.as_ref());
 
 			if !retain {
-				notify.notify_waiters();
 				self.db
 					.userdeviceconnid_conn
 					.del((conn_user_id, conn_device_id, conn_conn_id));
 			}
 
 			retain
-		},
-	);
+		});
 }
 
 #[implement(Service)]
@@ -127,24 +126,16 @@ pub async fn drop_connection(&self, key: &ConnectionKey) {
 	let mut cache = self.connections.lock().await;
 
 	self.db.userdeviceconnid_conn.del(key);
-	if let Some((_, notify)) = cache.remove(key) {
-		notify.notify_waiters();
-	}
+	cache.remove(key);
 }
 
 #[implement(Service)]
 #[tracing::instrument(level = "debug", skip(self))]
-pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionEntry {
+pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionVal {
 	let mut cache = self.connections.lock().await;
 
 	match cache.entry(key.clone()) {
-		| Entry::Occupied(mut entry) => {
-			entry.get().1.notify_waiters();
-			let conn = entry.get().0.clone();
-			let notify = Arc::new(Notify::new());
-			entry.insert((conn.clone(), notify.clone()));
-			(conn, notify)
-		},
+		| Entry::Occupied(val) => val.get().clone(),
 		| Entry::Vacant(val) => {
 			let conn = self
 				.db
@@ -158,9 +149,7 @@ pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionEn
 				.map(Arc::new)
 				.unwrap_or_default();
 
-			let notify = Arc::new(Notify::new());
-			let (conn, _) = val.insert((conn, notify.clone()));
-			(conn.clone(), notify)
+			val.insert(conn).clone()
 		},
 	}
 }
@@ -171,7 +160,7 @@ pub async fn load_connection(&self, key: &ConnectionKey) -> Result<ConnectionVal
 	let mut cache = self.connections.lock().await;
 
 	match cache.entry(key.clone()) {
-		| Entry::Occupied(val) => Ok(val.get().0.clone()),
+		| Entry::Occupied(val) => Ok(val.get().clone()),
 		| Entry::Vacant(val) => self
 			.db
 			.userdeviceconnid_conn
@@ -181,10 +170,7 @@ pub async fn load_connection(&self, key: &ConnectionKey) -> Result<ConnectionVal
 			.map(at!(0))
 			.map(TokioMutex::new)
 			.map(Arc::new)
-			.map(|conn| {
-				let notify = Arc::new(Notify::new());
-				val.insert((conn, notify)).0.clone()
-			}),
+			.map(|conn| val.insert(conn).clone()),
 	}
 }
 
@@ -195,7 +181,7 @@ pub async fn get_loaded_connection(&self, key: &ConnectionKey) -> Result<Connect
 		.lock()
 		.await
 		.get(key)
-		.map(|(conn, _)| conn.clone())
+		.cloned()
 		.ok_or_else(|| err!(Request(NotFound("Connection not found."))))
 }
 

--- a/src/service/sync/mod.rs
+++ b/src/service/sync/mod.rs
@@ -14,7 +14,7 @@ use ruma::{
 	},
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::{Mutex as TokioMutex, Notify};
 use tuwunel_core::{Result, at, debug, err, implement, is_equal_to, utils::stream::TryIgnore};
 use tuwunel_database::{Cbor, Deserialized, Map};
 
@@ -57,9 +57,10 @@ pub struct Room {
 	pub roomsince: u64,
 }
 
-type Connections = TokioMutex<BTreeMap<ConnectionKey, ConnectionVal>>;
 pub type ConnectionVal = Arc<TokioMutex<Connection>>;
+pub type ConnectionEntry = (ConnectionVal, Arc<Notify>);
 pub type ConnectionKey = (OwnedUserId, Option<OwnedDeviceId>, Option<ConnectionId>);
+type Connections = TokioMutex<BTreeMap<ConnectionKey, ConnectionEntry>>;
 
 pub type Subscriptions = BTreeMap<OwnedRoomId, request::ListConfig>;
 pub type Lists = BTreeMap<ListId, request::List>;
@@ -102,22 +103,22 @@ pub async fn clear_connections(
 	device_id: Option<&DeviceId>,
 	conn_id: Option<&ConnectionId>,
 ) {
-	self.connections
-		.lock()
-		.await
-		.retain(|(conn_user_id, conn_device_id, conn_conn_id), _| {
+	self.connections.lock().await.retain(
+		|(conn_user_id, conn_device_id, conn_conn_id), (_, notify)| {
 			let retain = user_id.is_none_or(is_equal_to!(conn_user_id))
 				&& (device_id.is_none() || device_id == conn_device_id.as_deref())
 				&& (conn_id.is_none() || conn_id == conn_conn_id.as_ref());
 
 			if !retain {
+				notify.notify_waiters();
 				self.db
 					.userdeviceconnid_conn
 					.del((conn_user_id, conn_device_id, conn_conn_id));
 			}
 
 			retain
-		});
+		},
+	);
 }
 
 #[implement(Service)]
@@ -126,16 +127,24 @@ pub async fn drop_connection(&self, key: &ConnectionKey) {
 	let mut cache = self.connections.lock().await;
 
 	self.db.userdeviceconnid_conn.del(key);
-	cache.remove(key);
+	if let Some((_, notify)) = cache.remove(key) {
+		notify.notify_waiters();
+	}
 }
 
 #[implement(Service)]
 #[tracing::instrument(level = "debug", skip(self))]
-pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionVal {
+pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionEntry {
 	let mut cache = self.connections.lock().await;
 
 	match cache.entry(key.clone()) {
-		| Entry::Occupied(val) => val.get().clone(),
+		| Entry::Occupied(mut entry) => {
+			entry.get().1.notify_waiters();
+			let conn = entry.get().0.clone();
+			let notify = Arc::new(Notify::new());
+			entry.insert((conn.clone(), notify.clone()));
+			(conn, notify)
+		},
 		| Entry::Vacant(val) => {
 			let conn = self
 				.db
@@ -149,7 +158,9 @@ pub async fn load_or_init_connection(&self, key: &ConnectionKey) -> ConnectionVa
 				.map(Arc::new)
 				.unwrap_or_default();
 
-			val.insert(conn).clone()
+			let notify = Arc::new(Notify::new());
+			let (conn, _) = val.insert((conn, notify.clone()));
+			(conn.clone(), notify)
 		},
 	}
 }
@@ -160,7 +171,7 @@ pub async fn load_connection(&self, key: &ConnectionKey) -> Result<ConnectionVal
 	let mut cache = self.connections.lock().await;
 
 	match cache.entry(key.clone()) {
-		| Entry::Occupied(val) => Ok(val.get().clone()),
+		| Entry::Occupied(val) => Ok(val.get().0.clone()),
 		| Entry::Vacant(val) => self
 			.db
 			.userdeviceconnid_conn
@@ -170,7 +181,10 @@ pub async fn load_connection(&self, key: &ConnectionKey) -> Result<ConnectionVal
 			.map(at!(0))
 			.map(TokioMutex::new)
 			.map(Arc::new)
-			.map(|conn| val.insert(conn).clone()),
+			.map(|conn| {
+				let notify = Arc::new(Notify::new());
+				val.insert((conn, notify)).0.clone()
+			}),
 	}
 }
 
@@ -181,7 +195,7 @@ pub async fn get_loaded_connection(&self, key: &ConnectionKey) -> Result<Connect
 		.lock()
 		.await
 		.get(key)
-		.cloned()
+		.map(|(conn, _)| conn.clone())
 		.ok_or_else(|| err!(Request(NotFound("Connection not found."))))
 }
 

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2619,6 +2619,14 @@
 #
 #use_bucket_key =
 
+# (expert use) Threshold size for switching to Multi-part uploads. This is
+# a quirk of the S3 protocol which requires us to use a different approach
+# for "large" uploads. This value determines what a "large" upload is. The
+# default value should be sufficient for most providers. The value is a
+# parsed string allowing SI or IEC units for convenience.
+#
+#multipart_threshold = 100 MiB
+
 # (developer use) Allows relaxing default requirement forcing HTTPS.
 #
 #use_https = true

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2042,6 +2042,22 @@
 #
 #appservice_dir = ""
 
+# Skip database migration on startup. This option is intended for
+# developer debugging and testing only. Never set this option to false
+# unless you have been instructed to do so. Setting this option to false
+# may cause permanent damage and permanent loss of data.
+#
+# Any new database migrations will not be applied on startup, and the
+# database schema version will not be adjusted. These migrations and
+# schema changes may be expected by the current codebase but may not be
+# available when this option is set to false.
+#
+# Setting this option to false will have no effect if no new migrations
+# are to be applied. New migrations are applied once during any execution
+# where this option is set to true (which is the default).
+#
+#database_migrations = true
+
 
 
 #[global.tls]

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2058,6 +2058,24 @@
 #
 #database_migrations = true
 
+# Force the database to set its version to the current version known to
+# the executable.
+#
+# - When the discovered version is less than the current version any
+#   migrations are applied normally.
+# - When the discovered version is equal to the current version,
+#   unversioned migrations are applied normally.
+# - When the discovered database version is greater than the current
+#   version, one-time migrations are applied normally and the discoverable
+#   version is regressed back to the current version.
+#
+# This option extremely dangerous and intended for developer debugging and
+# testing only. Never set this option unless you have been instructed to
+# do so. Setting this option may cause permanent damage and permanent loss
+# of data.
+#
+#force_migration = false
+
 
 
 #[global.tls]


### PR DESCRIPTION
OpenBSD is not supported by the `core_affinity_rs` crate. It leads to wrong results when trying to get the number of available cores that trigger a startup crash.

The fix proposes to use the `num_cpus` crate to get the number of cores on OpenBSD. I know that, [in the past](https://github.com/matrix-construct/tuwunel/commit/a537462d51d236ad24a033a9e378552583f24b8f), `num_cpus::get()` was used to get `available_parallelism()`.

It have been running a server with this patch for few weeks now without issue.

Note that, in order for it to compile, one should set the `LIBCLANG_PATH` to `/usr/local/llvm${V}/lib/` where `V` is the llvm version, and disable jemalloc associated features, e.g.:
```
$ cargo build --release --no-default-features --features "blurhashing,brotli_compression,bzip2_compression,console,direct_tls,element_hacks,gzip_compression,io_uring,ldap,lz4_compression,media_thumbnail,perf_measurements,sentry_telemetry,systemd,tokio_console,tuwunel_mods,url_preview,zstd_compression"
```
Tested on OpenBSD-current only since the rust version on -stable is too old to compile tuwunel.

Thanks.
