### PR TITLE
feat: add configurable ip_source for reverse proxy and cloudflared deployments

### DIFF
--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -3,7 +3,7 @@ use std::env::consts::OS;
 use either::Either;
 use itertools::Itertools;
 
-use super::{DEPRECATED_KEYS, IdentityProvider};
+use super::{DEPRECATED_KEYS, IdentityProvider, IpSource};
 use crate::{Config, Err, Result, debug, debug_info, error, warn};
 
 /// Performs check() with additional checks specific to reloading old config
@@ -16,6 +16,13 @@ pub fn reload(old: &Config, new: &Config) -> Result {
 			"server_name",
 			"You can't change the server's name from {:?}.",
 			old.server_name
+		));
+	}
+
+	if new.ip_source != old.ip_source {
+		return Err!(Config(
+			"ip_source",
+			"ip_source cannot be changed at runtime; restart the server to apply this change."
 		));
 	}
 
@@ -59,6 +66,15 @@ pub fn check(config: &Config) -> Result {
 	let key_set = config.tls.key.is_some();
 	if certs_set ^ key_set {
 		return Err!(Config("tls", "tls.certs and tls.key must either both be set or unset"));
+	}
+
+	if !matches!(config.ip_source, IpSource::ConnectInfo) {
+		warn!(
+			"ip_source is set to a header-based value ({:?}). Ensure a trusted reverse proxy \
+			 populates this header for every request; otherwise clients can spoof their IP \
+			 address.",
+			config.ip_source
+		);
 	}
 
 	if !config.listening {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -576,6 +576,28 @@ pub struct Config {
 	#[serde(default = "default_client_shutdown_timeout")]
 	pub client_shutdown_timeout: u64,
 
+	/// Source of the client IP address for logging and security purposes.
+	///
+	/// Use `connect_info` (the default) when tuwunel receives connections
+	/// directly from clients. When tuwunel sits behind a trusted reverse
+	/// proxy, set this to the header the proxy populates:
+	///
+	/// - `rightmost_x_forwarded_for` — last value in `X-Forwarded-For`
+	/// - `rightmost_forwarded` — last value in RFC 7239 `Forwarded`
+	/// - `x_real_ip` — Nginx-style `X-Real-IP`
+	/// - `cf_connecting_ip` — Cloudflare `CF-Connecting-IP`
+	/// - `true_client_ip` — Akamai / Cloudflare Enterprise `True-Client-IP`
+	/// - `fly_client_ip` — Fly.io `Fly-Client-IP`
+	/// - `cloudfront_viewer_address` — AWS CloudFront
+	///   `CloudFront-Viewer-Address`
+	///
+	/// WARNING: setting a header-based source without a trusted reverse proxy
+	/// in front of tuwunel allows clients to spoof their IP address.
+	///
+	/// default: "connect_info"
+	#[serde(default)]
+	pub ip_source: IpSource,
+
 	/// Grace period for clean shutdown of federation requests (seconds).
 	///
 	/// default: 5
@@ -3285,6 +3307,33 @@ impl From<AppServiceNamespace> for ruma::api::appservice::Namespace {
 			regex: conf.regex,
 		}
 	}
+}
+
+/// Selects the source used to determine the connecting client's IP address.
+///
+/// Matches the variants of `axum_client_ip::SecureClientIpSource`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpSource {
+	/// Use the peer address of the TCP connection. Safe default; no
+	/// proxy required.
+	#[default]
+	ConnectInfo,
+	/// Last address in the `X-Forwarded-For` header.
+	RightmostXForwardedFor,
+	/// Last address in the RFC 7239 `Forwarded` header.
+	RightmostForwarded,
+	/// Value of the `X-Real-IP` header (Nginx convention).
+	XRealIp,
+	/// Value of the `CF-Connecting-IP` header (Cloudflare).
+	CfConnectingIp,
+	/// Value of the `True-Client-IP` header (Akamai / Cloudflare
+	/// Enterprise).
+	TrueClientIp,
+	/// Value of the `Fly-Client-IP` header (Fly.io).
+	FlyClientIp,
+	/// Value of the `CloudFront-Viewer-Address` header (AWS CloudFront).
+	CloudFrontViewerAddress,
 }
 
 const DEPRECATED_KEYS: &[&str; 9] = &[

--- a/src/router/layers.rs
+++ b/src/router/layers.rs
@@ -21,7 +21,7 @@ use tower_http::{
 };
 use tracing::Level;
 use tuwunel_api::router::state::Guard;
-use tuwunel_core::{Result, Server, debug, error};
+use tuwunel_core::{Result, Server, config::IpSource, debug, error};
 use tuwunel_service::Services;
 
 use crate::{request, router};
@@ -71,7 +71,7 @@ pub(crate) fn build(services: &Arc<Services>) -> Result<(Router, Guard)> {
 				.on_response(DefaultOnResponse::new().level(Level::DEBUG)),
 		)
 		.layer(axum::middleware::from_fn_with_state(Arc::clone(services), request::handle))
-		.layer(SecureClientIpSource::ConnectInfo.into_extension())
+		.layer(ip_source_layer(&server.config.ip_source))
 		.layer(ResponseBodyTimeoutLayer::new(Duration::from_secs(
 			server.config.client_response_timeout,
 		)))
@@ -211,6 +211,21 @@ fn cors_layer(server: &Server) -> CorsLayer {
 
 fn body_limit_layer(server: &Server) -> DefaultBodyLimit {
 	DefaultBodyLimit::max(server.config.max_request_size)
+}
+
+fn ip_source_layer(source: &IpSource) -> axum::Extension<SecureClientIpSource> {
+	let secure_source = match source {
+		| IpSource::ConnectInfo => SecureClientIpSource::ConnectInfo,
+		| IpSource::RightmostXForwardedFor => SecureClientIpSource::RightmostXForwardedFor,
+		| IpSource::RightmostForwarded => SecureClientIpSource::RightmostForwarded,
+		| IpSource::XRealIp => SecureClientIpSource::XRealIp,
+		| IpSource::CfConnectingIp => SecureClientIpSource::CfConnectingIp,
+		| IpSource::TrueClientIp => SecureClientIpSource::TrueClientIp,
+		| IpSource::FlyClientIp => SecureClientIpSource::FlyClientIp,
+		| IpSource::CloudFrontViewerAddress => SecureClientIpSource::CloudFrontViewerAddress,
+	};
+
+	secure_source.into_extension()
 }
 
 #[tracing::instrument(name = "panic", level = "error", skip_all)]

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -437,6 +437,25 @@
 #
 #client_shutdown_timeout = 10
 
+# Source of the client IP address for logging and security purposes.
+#
+# Use "connect_info" (the default) when tuwunel receives connections directly
+# from clients. When tuwunel sits behind a trusted reverse proxy, set this to
+# the header the proxy populates:
+#
+#   "rightmost_x_forwarded_for" — last value in X-Forwarded-For
+#   "rightmost_forwarded"       — last value in RFC 7239 Forwarded
+#   "x_real_ip"                 — Nginx-style X-Real-IP
+#   "cf_connecting_ip"          — Cloudflare CF-Connecting-IP
+#   "true_client_ip"            — Akamai / Cloudflare Enterprise True-Client-IP
+#   "fly_client_ip"             — Fly.io Fly-Client-IP
+#   "cloudfront_viewer_address" — AWS CloudFront CloudFront-Viewer-Address
+#
+# WARNING: setting a header-based source without a trusted reverse proxy in
+# front of tuwunel allows clients to spoof their IP address.
+#
+#ip_source = "connect_info"
+
 # Grace period for clean shutdown of federation requests (seconds).
 #
 #sender_shutdown_timeout = 5


### PR DESCRIPTION
## Problem

When tuwunel runs behind a reverse proxy (nginx, Caddy) or Cloudflare Tunnel (`cloudflared`), the TCP peer address seen by tuwunel is the proxy's loopback address (`127.0.0.1`). The `axum_client_ip` layer is hardcoded to `SecureClientIpSource::ConnectInfo`, so all clients appear as `127.0.0.1` for any logging or security tooling that reads tuwunel logs (e.g. CrowdSec, fail2ban).

The nginx reverse proxy docs already include `proxy_set_header X-Forwarded-For $remote_addr`, but tuwunel has no way to tell its layer to read that header.

## What this PR does

Adds an `ip_source` config option (default: `"connect_info"`, preserving existing behaviour) that selects the `SecureClientIpSource` variant installed by the router layer at startup.

```toml
# Direct access (default — no change to existing deployments)
# ip_source = "connect_info"

# Behind nginx or Caddy
ip_source = "rightmost_x_forwarded_for"

# Behind Cloudflare Tunnel (cloudflared)
ip_source = "cf_connecting_ip"
```

A startup warning is logged when a header-based source is configured. Changes to `ip_source` during hot reload are rejected (restart required — the layer stack is not rebuilt on reload).

## Known limitation

Handlers that use `InsecureClientIp` (most API endpoints) scan headers in their own fixed order regardless of `SecureClientIpSource`. This PR wires the configured source into the layer correctly; migrating handlers from `InsecureClientIp` to `SecureClientIp` is a separate, broader change that touches ~22 files and warrants its own PR.

## Changes

- `src/core/config/mod.rs` — add `pub enum IpSource` (8 variants, `#[serde(rename_all = "snake_case")]`, `PartialEq`, `ConnectInfo` default) and `ip_source: IpSource` field
- `src/core/config/check.rs` — warn at startup when header-based source is configured; reject `ip_source` changes during hot reload
- `src/router/layers.rs` — replace hardcoded `SecureClientIpSource::ConnectInfo.into_extension()` with `ip_source_layer(&config.ip_source)` backed by exhaustive match
- `tuwunel-example.toml` — add commented `ip_source` entry with all supported values documented

## Supported values

| Value | Header / source | Use when |
| --- | --- | --- |
| `connect_info` | TCP peer address | Direct access (default) |
| `rightmost_x_forwarded_for` | `X-Forwarded-For` (rightmost) | nginx / Caddy |
| `rightmost_forwarded` | RFC 7239 `Forwarded` (rightmost) | RFC-compliant proxies |
| `x_real_ip` | `X-Real-IP` | nginx with `proxy_set_header X-Real-IP` |
| `cf_connecting_ip` | `CF-Connecting-IP` | Cloudflare or cloudflared |
| `true_client_ip` | `True-Client-IP` | Cloudflare Enterprise / Akamai |
| `fly_client_ip` | `Fly-Client-IP` | Fly.io |
| `cloudfront_viewer_address` | `CloudFront-Viewer-Address` | AWS CloudFront |

## No breaking changes

Default is `"connect_info"`. Existing deployments behave identically.