### PR TITLE
Add ClientIp extractor and migrate handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,9 +4392,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/api/client/account.rs
+++ b/src/api/client/account.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, StreamExt};
 use ruma::api::client::account::{
 	ThirdPartyIdRemovalStatus, change_password, deactivate, get_3pids,
@@ -7,7 +6,7 @@ use ruma::api::client::account::{
 };
 use tuwunel_core::{Err, Result, err, info, utils::ReadyExt};
 
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 /// # `POST /_matrix/client/r0/account/password`
 ///
@@ -29,7 +28,7 @@ use crate::{Ruma, router::auth_uiaa};
 #[tracing::instrument(skip_all, fields(%client), name = "change_password")]
 pub(crate) async fn change_password_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<change_password::v3::Request>,
 ) -> Result<change_password::v3::Response> {
 	let ref sender_user = auth_uiaa(&services, &body).await?;
@@ -96,7 +95,7 @@ pub(crate) async fn whoami_route(
 #[tracing::instrument(skip_all, fields(%client), name = "deactivate")]
 pub(crate) async fn deactivate_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<deactivate::v3::Request>,
 ) -> Result<deactivate::v3::Response> {
 	let ref sender_user = auth_uiaa(&services, &body).await?;

--- a/src/api/client/dehydrated_device.rs
+++ b/src/api/client/dehydrated_device.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::api::client::dehydrated_device::{
 	delete_dehydrated_device::unstable as delete_dehydrated_device,
@@ -8,7 +7,7 @@ use ruma::api::client::dehydrated_device::{
 };
 use tuwunel_core::{Err, Result, at, utils::result::IsErrOr};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const MAX_BATCH_EVENTS: usize = 50;
 
@@ -18,7 +17,7 @@ const MAX_BATCH_EVENTS: usize = 50;
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn put_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<put_dehydrated_device::Request>,
 ) -> Result<put_dehydrated_device::Response> {
 	let sender_user = body
@@ -42,7 +41,7 @@ pub(crate) async fn put_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn delete_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<delete_dehydrated_device::Request>,
 ) -> Result<delete_dehydrated_device::Response> {
 	let sender_user = body.sender_user();
@@ -66,7 +65,7 @@ pub(crate) async fn delete_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn get_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_dehydrated_device::Request>,
 ) -> Result<get_dehydrated_device::Response> {
 	let sender_user = body.sender_user();
@@ -88,7 +87,7 @@ pub(crate) async fn get_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn get_dehydrated_events_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_events::Request>,
 ) -> Result<get_events::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/device.rs
+++ b/src/api/client/device.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::{
 	MilliSecondsSinceUnixEpoch,
@@ -9,7 +8,7 @@ use ruma::{
 };
 use tuwunel_core::{Err, Result, debug, err, utils::string::to_small_string};
 
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 /// # `GET /_matrix/client/r0/devices`
 ///
@@ -49,7 +48,7 @@ pub(crate) async fn get_device_route(
 #[tracing::instrument(skip_all, fields(%client), name = "update_device")]
 pub(crate) async fn update_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<update_device::v3::Request>,
 ) -> Result<update_device::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/directory.rs
+++ b/src/api/client/directory.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{
 	FutureExt, StreamExt, TryFutureExt,
 	future::{join, join4, join5},
@@ -33,7 +32,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::Services;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/publicRooms`
 ///
@@ -43,7 +42,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "publicrooms")]
 pub(crate) async fn get_public_rooms_filtered_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms_filtered::v3::Request>,
 ) -> Result<get_public_rooms_filtered::v3::Response> {
 	check_server_banned(&services, body.server.as_deref())?;
@@ -72,7 +71,7 @@ pub(crate) async fn get_public_rooms_filtered_route(
 #[tracing::instrument(skip_all, fields(%client), name = "publicrooms")]
 pub(crate) async fn get_public_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms::v3::Request>,
 ) -> Result<get_public_rooms::v3::Response> {
 	check_server_banned(&services, body.server.as_deref())?;
@@ -104,7 +103,7 @@ pub(crate) async fn get_public_rooms_route(
 #[tracing::instrument(skip_all, fields(%client), name = "room_directory")]
 pub(crate) async fn set_room_visibility_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<set_room_visibility::v3::Request>,
 ) -> Result<set_room_visibility::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/media.rs
+++ b/src/api/client/media.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use reqwest::Url;
 use ruma::{
 	MilliSecondsSinceUnixEpoch, Mxc, UserId,
@@ -25,7 +24,7 @@ use tuwunel_service::{
 	media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, MXC_LENGTH, Media},
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/v1/media/config`
 pub(crate) async fn get_media_config_route(
@@ -51,7 +50,7 @@ pub(crate) async fn get_media_config_route(
 )]
 pub(crate) async fn create_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_content::v3::Request>,
 ) -> Result<create_content::v3::Response> {
 	let user = body.sender_user();
@@ -94,7 +93,7 @@ pub(crate) async fn create_content_route(
 )]
 pub(crate) async fn create_mxc_uri_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_mxc_uri::v1::Request>,
 ) -> Result<create_mxc_uri::v1::Response> {
 	let user = body.sender_user();
@@ -134,7 +133,7 @@ pub(crate) async fn create_mxc_uri_route(
 )]
 pub(crate) async fn create_content_async_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_content_async::v3::Request>,
 ) -> Result<create_content_async::v3::Response> {
 	let user = body.sender_user();
@@ -166,7 +165,7 @@ pub(crate) async fn create_content_async_route(
 )]
 pub(crate) async fn get_content_thumbnail_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v1::Request>,
 ) -> Result<get_content_thumbnail::v1::Response> {
 	let user = body.sender_user();
@@ -203,7 +202,7 @@ pub(crate) async fn get_content_thumbnail_route(
 )]
 pub(crate) async fn get_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v1::Request>,
 ) -> Result<get_content::v1::Response> {
 	let user = body.sender_user();
@@ -239,7 +238,7 @@ pub(crate) async fn get_content_route(
 )]
 pub(crate) async fn get_content_as_filename_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_as_filename::v1::Request>,
 ) -> Result<get_content_as_filename::v1::Response> {
 	let user = body.sender_user();
@@ -275,7 +274,7 @@ pub(crate) async fn get_content_as_filename_route(
 )]
 pub(crate) async fn get_media_preview_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_media_preview::v1::Request>,
 ) -> Result<get_media_preview::v1::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/media_legacy.rs
+++ b/src/api/client/media_legacy.rs
@@ -1,7 +1,6 @@
 #![expect(deprecated)]
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use reqwest::Url;
 use ruma::{
 	Mxc,
@@ -16,7 +15,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, Media};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/media/v3/config`
 ///
@@ -36,7 +35,7 @@ pub(crate) async fn get_media_config_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "url_preview_legacy", level = "debug")]
 pub(crate) async fn get_media_preview_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_media_preview::v3::Request>,
 ) -> Result<get_media_preview::v3::Response> {
 	let sender_user = body.sender_user();
@@ -84,7 +83,7 @@ pub(crate) async fn get_media_preview_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_get_legacy", level = "debug")]
 pub(crate) async fn get_content_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v3::Request>,
 ) -> Result<get_content::v3::Response> {
 	let mxc = Mxc {
@@ -156,7 +155,7 @@ pub(crate) async fn get_content_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_get_legacy", level = "debug")]
 pub(crate) async fn get_content_as_filename_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_as_filename::v3::Request>,
 ) -> Result<get_content_as_filename::v3::Response> {
 	let mxc = Mxc {
@@ -228,7 +227,7 @@ pub(crate) async fn get_content_as_filename_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_thumbnail_get_legacy", level = "debug")]
 pub(crate) async fn get_content_thumbnail_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v3::Request>,
 ) -> Result<get_content_thumbnail::v3::Response> {
 	let mxc = Mxc {

--- a/src/api/client/membership/invite.rs
+++ b/src/api/client/membership/invite.rs
@@ -1,11 +1,10 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, join};
 use ruma::{api::client::membership::invite_user, events::room::member::MembershipState};
 use tuwunel_core::{Err, Result};
 
 use super::banned_room_check;
-use crate::{Ruma, client::utils::invite_check};
+use crate::{Ruma, client::utils::invite_check, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/r0/rooms/{roomId}/invite`
 ///
@@ -13,7 +12,7 @@ use crate::{Ruma, client::utils::invite_check};
 #[tracing::instrument(skip_all, fields(%client), name = "invite")]
 pub(crate) async fn invite_user_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<invite_user::v3::Request>,
 ) -> Result<invite_user::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/membership/join.rs
+++ b/src/api/client/membership/join.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::FutureExt;
 use ruma::{
 	RoomId,
@@ -8,7 +7,7 @@ use ruma::{
 use tuwunel_core::{Result, warn};
 
 use super::banned_room_check;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/r0/rooms/{roomId}/join`
 ///
@@ -21,7 +20,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "join")]
 pub(crate) async fn join_room_by_id_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<join_room_by_id::v3::Request>,
 ) -> Result<join_room_by_id::v3::Response> {
 	let sender_user = body.sender_user();
@@ -74,7 +73,7 @@ pub(crate) async fn join_room_by_id_route(
 #[tracing::instrument(skip_all, fields(%client), name = "join")]
 pub(crate) async fn join_room_by_id_or_alias_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<join_room_by_id_or_alias::v3::Request>,
 ) -> Result<join_room_by_id_or_alias::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/membership/knock.rs
+++ b/src/api/client/membership/knock.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::knock::knock_room;
 use tuwunel_core::Result;
 
 use super::banned_room_check;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/*/knock/{roomIdOrAlias}`
 ///
@@ -12,7 +11,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "knock")]
 pub(crate) async fn knock_room_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<knock_room::v3::Request>,
 ) -> Result<knock_room::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/register.rs
+++ b/src/api/client/register.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	UserId,
 	api::client::{
@@ -16,7 +15,7 @@ use tuwunel_core::{Err, Error, Result, debug_info, debug_warn, info, utils};
 use tuwunel_service::users::{Register, device::generate_refresh_token};
 
 use super::SESSION_ID_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const RANDOM_USER_ID_LENGTH: usize = 10;
 
@@ -34,7 +33,7 @@ const RANDOM_USER_ID_LENGTH: usize = 10;
 #[tracing::instrument(skip_all, fields(%client), name = "register_available")]
 pub(crate) async fn get_register_available_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_username_availability::v3::Request>,
 ) -> Result<get_username_availability::v3::Response> {
 	// workaround for https://github.com/matrix-org/matrix-appservice-irc/issues/1780 due to inactivity of fixing the issue
@@ -131,7 +130,7 @@ pub(crate) async fn get_register_available_route(
 #[tracing::instrument(skip_all, fields(%client), name = "register")]
 pub(crate) async fn register_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<register::v3::Request>,
 ) -> Result<register::v3::Response> {
 	let is_guest = body.kind == RegistrationKind::Guest;

--- a/src/api/client/report.rs
+++ b/src/api/client/report.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	EventId, RoomId, UserId,
 	api::client::room::{report_content, report_room},
@@ -8,7 +7,7 @@ use ruma::{
 use tuwunel_core::{Err, Result, debug_info, info, matrix::pdu::PduEvent, utils::ReadyExt};
 use tuwunel_service::Services;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const REASON_MAX_LEN: usize = 750;
 
@@ -18,7 +17,7 @@ const REASON_MAX_LEN: usize = 750;
 #[tracing::instrument(skip_all, fields(%client), name = "report_room")]
 pub(crate) async fn report_room_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<report_room::v3::Request>,
 ) -> Result<report_room::v3::Response> {
 	let sender_user = body.sender_user();
@@ -64,7 +63,7 @@ pub(crate) async fn report_room_route(
 #[tracing::instrument(skip_all, fields(%client), name = "report_event")]
 pub(crate) async fn report_event_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<report_content::v3::Request>,
 ) -> Result<report_content::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/room/summary.rs
+++ b/src/api/client/room/summary.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, StreamExt, TryFutureExt, future::join3, stream::FuturesUnordered};
 use ruma::{
 	OwnedServerName, RoomId, UserId,
@@ -16,7 +15,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::Services;
 
-use crate::{Ruma, RumaResponse};
+use crate::{Ruma, RumaResponse, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/unstable/im.nheko.summary/rooms/{roomIdOrAlias}/summary`
 ///
@@ -29,10 +28,10 @@ use crate::{Ruma, RumaResponse};
 /// An implementation of [MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266)
 pub(crate) async fn get_room_summary_legacy(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_summary::v1::Request>,
 ) -> Result<RumaResponse<get_summary::v1::Response>> {
-	get_room_summary(State(services), InsecureClientIp(client), body)
+	get_room_summary(State(services), ClientIp(client), body)
 		.boxed()
 		.await
 		.map(RumaResponse)
@@ -46,7 +45,7 @@ pub(crate) async fn get_room_summary_legacy(
 #[tracing::instrument(skip_all, fields(%client), name = "room_summary")]
 pub(crate) async fn get_room_summary(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_summary::v1::Request>,
 ) -> Result<get_summary::v1::Response> {
 	let (room_id, servers) = services

--- a/src/api/client/session/logout.rs
+++ b/src/api/client/session/logout.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::api::client::session::{logout, logout_all};
 use tuwunel_core::Result;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/logout`
 ///
@@ -18,7 +17,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "logout")]
 pub(crate) async fn logout_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<logout::v3::Request>,
 ) -> Result<logout::v3::Response> {
 	services
@@ -45,7 +44,7 @@ pub(crate) async fn logout_route(
 #[tracing::instrument(skip_all, fields(%client), name = "logout")]
 pub(crate) async fn logout_all_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<logout_all::v3::Request>,
 ) -> Result<logout_all::v3::Response> {
 	services

--- a/src/api/client/session/mod.rs
+++ b/src/api/client/session/mod.rs
@@ -8,7 +8,6 @@ mod sso;
 mod token;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::session::{
 	get_login_types::{
 		self,
@@ -35,7 +34,7 @@ pub(crate) use self::{
 	token::login_token_route,
 };
 use super::TOKEN_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/v3/login`
 ///
@@ -44,7 +43,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "login")]
 pub(crate) async fn get_login_types_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	_body: Ruma<get_login_types::v3::Request>,
 ) -> Result<get_login_types::v3::Response> {
 	let get_login_token = services.config.login_via_existing_session;
@@ -105,7 +104,7 @@ pub(crate) async fn get_login_types_route(
 #[tracing::instrument(name = "login", skip_all, fields(%client, ?body.login_info))]
 pub(crate) async fn login_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<login::v3::Request>,
 ) -> Result<login::v3::Response> {
 	// Validate login method

--- a/src/api/client/session/refresh.rs
+++ b/src/api/client/session/refresh.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::session::refresh_token::v3::{Request, Response};
 use tuwunel_core::{Err, Result, debug_info, err};
 use tuwunel_service::users::device::generate_refresh_token;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/refresh`
 ///
@@ -14,7 +13,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "refresh_token")]
 pub(crate) async fn refresh_token_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<Request>,
 ) -> Result<Response> {
 	let refresh_token_claim = body.body.refresh_token;

--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -3,7 +3,6 @@ mod uiaa;
 use std::{borrow::Cow, net::IpAddr, time::Duration};
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as b64};
 use futures::{FutureExt, StreamExt, TryFutureExt, future::try_join};
@@ -45,7 +44,7 @@ use url::Url;
 
 pub(crate) use self::uiaa::sso_fallback_route;
 use super::TOKEN_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// Grant phase query string.
 #[derive(Debug, Serialize)]
@@ -83,7 +82,7 @@ static GRANT_SESSION_COOKIE: &str = "tuwunel_grant_session";
 )]
 pub(crate) async fn sso_login_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_login::v3::Request>,
 ) -> Result<sso_login::v3::Response> {
 	if services.config.sso_custom_providers_page {
@@ -125,7 +124,7 @@ pub(crate) async fn sso_login_route(
 )]
 pub(crate) async fn sso_login_with_provider_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_login_with_provider::v3::Request>,
 ) -> Result<sso_login_with_provider::v3::Response> {
 	let idp_id = body.body.idp_id;
@@ -254,7 +253,7 @@ async fn handle_sso_login(
 )]
 pub(crate) async fn sso_callback_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_callback::unstable::Request>,
 ) -> Result<sso_callback::unstable::Response> {
 	let sess_id = body

--- a/src/api/client/session/token.rs
+++ b/src/api/client/session/token.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	OwnedUserId,
 	api::client::session::{
@@ -13,7 +12,7 @@ use tuwunel_core::{Err, Result, utils::random_string};
 use tuwunel_service::Services;
 
 use super::TOKEN_LENGTH;
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 pub(super) async fn handle_login(
 	services: &Services,
@@ -38,7 +37,7 @@ pub(super) async fn handle_login(
 #[tracing::instrument(skip_all, fields(%client), name = "login_token")]
 pub(crate) async fn login_token_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_login_token::v1::Request>,
 ) -> Result<get_login_token::v1::Response> {
 	if !services.config.login_via_existing_session || !services.config.login_via_token {

--- a/src/api/client/unstable.rs
+++ b/src/api/client/unstable.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::{
 	OwnedRoomId,
@@ -17,7 +16,7 @@ use ruma::{
 };
 use tuwunel_core::{Err, Result, err};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms`
 ///
@@ -29,7 +28,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "mutual_rooms")]
 pub(crate) async fn get_mutual_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<mutual_rooms::unstable::Request>,
 ) -> Result<mutual_rooms::unstable::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client_ip.rs
+++ b/src/api/client_ip.rs
@@ -1,0 +1,193 @@
+//! Tuwunel's client-IP extractor.
+//!
+//! Wraps `axum_client_ip` with a two-mode fallback:
+//!
+//! * If the operator configured `ip_source`, a [`ConfiguredIpSource`] marker is
+//!   installed in request extensions and we delegate to
+//!   [`axum_client_ip::SecureClientIp`] with that source.
+//! * Otherwise we fall back to [`axum_client_ip::InsecureClientIp`], preserving
+//!   existing behavior exactly -- including the header scan chain and the
+//!   socket-address fallback that matters for Unix-socket deployments (see
+//!   matrix-construct/tuwunel#310).
+//!
+//! The plain `SecureClientIpSource::ConnectInfo` extension already
+//! installed by `src/router/layers.rs` is intentionally ignored here;
+//! only the [`ConfiguredIpSource`] marker participates in the secure
+//! path. This avoids flipping behavior for deployments that never opted
+//! in.
+
+use std::{fmt, marker::Sync, net::IpAddr};
+
+use axum::{
+	extract::FromRequestParts,
+	http::{StatusCode, request::Parts},
+};
+use axum_client_ip::{InsecureClientIp, SecureClientIp, SecureClientIpSource};
+
+/// Marker wrapper around [`SecureClientIpSource`] placed into request
+/// extensions only when an operator has explicitly configured
+/// `ip_source`.
+#[derive(Clone, Debug)]
+pub struct ConfiguredIpSource(pub SecureClientIpSource);
+
+/// Tuwunel client-IP extractor. See module docs.
+#[derive(Clone, Copy, Debug)]
+pub struct ClientIp(pub IpAddr);
+
+impl fmt::Display for ClientIp {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+impl<S> FromRequestParts<S> for ClientIp
+where
+	S: Sync,
+{
+	type Rejection = (StatusCode, &'static str);
+
+	async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+		if let Some(ConfiguredIpSource(source)) = parts.extensions.get::<ConfiguredIpSource>() {
+			SecureClientIp::from(source, &parts.headers, &parts.extensions)
+				.map(|SecureClientIp(ip)| Self(ip))
+				.map_err(|_| {
+					(
+						StatusCode::INTERNAL_SERVER_ERROR,
+						"Can't extract client IP from configured ip_source",
+					)
+				})
+		} else {
+			InsecureClientIp::from(&parts.headers, &parts.extensions)
+				.map(|InsecureClientIp(ip)| Self(ip))
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::SocketAddr;
+
+	use axum::{
+		extract::{ConnectInfo, FromRequestParts},
+		http::{Request, StatusCode, request::Parts},
+	};
+	use axum_client_ip::SecureClientIpSource;
+
+	use super::{ClientIp, ConfiguredIpSource};
+
+	fn parts(headers: impl IntoIterator<Item = (&'static str, &'static str)>) -> Parts {
+		let mut request = Request::builder().uri("/");
+		for (name, value) in headers {
+			request = request.header(name, value);
+		}
+		let (parts, ()) = request.body(()).unwrap().into_parts();
+		parts
+	}
+
+	async fn extract_client_ip(
+		parts: &mut Parts,
+	) -> Result<ClientIp, (StatusCode, &'static str)> {
+		ClientIp::from_request_parts(parts, &()).await
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_uses_leftmost_ip() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_takes_priority_over_x_real_ip() {
+		let mut parts =
+			parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2"), ("X-Real-Ip", "3.3.3.3")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_accepts_ipv6() {
+		let mut parts = parts([("X-Forwarded-For", "2001:db8::1, 2001:db8::2")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "2001:db8::1");
+	}
+
+	#[tokio::test]
+	async fn x_real_ip_works() {
+		let mut parts = parts([("X-Real-Ip", "1.2.3.4")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.2.3.4");
+	}
+
+	#[tokio::test]
+	async fn malformed_headers_fall_through_to_next_valid_source() {
+		let mut parts = parts([
+			("X-Forwarded-For", "foo"),
+			("X-Real-Ip", "foo"),
+			("Forwarded", "foo"),
+			("Forwarded", "for=1.1.1.1;proto=https;by=2.2.2.2"),
+		]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn no_headers_or_connect_info_rejects() {
+		let mut parts = parts(std::iter::empty());
+		let err = extract_client_ip(&mut parts).await.unwrap_err();
+		assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+		assert!(err.1.contains("ConnectInfo"), "{err:?}");
+	}
+
+	#[tokio::test]
+	async fn configured_source_uses_secure_extraction() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts
+			.extensions
+			.insert(ConfiguredIpSource(SecureClientIpSource::RightmostXForwardedFor));
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "2.2.2.2");
+	}
+
+	#[tokio::test]
+	async fn configured_source_without_matching_header_rejects() {
+		let mut parts = parts(std::iter::empty());
+		parts
+			.extensions
+			.insert(ConfiguredIpSource(SecureClientIpSource::RightmostXForwardedFor));
+		let err = extract_client_ip(&mut parts).await.unwrap_err();
+		assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+		assert_eq!(err.1, "Can't extract client IP from configured ip_source");
+	}
+
+	#[tokio::test]
+	async fn secure_client_ip_source_extension_does_not_hijack() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts
+			.extensions
+			.insert(SecureClientIpSource::ConnectInfo);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn connect_info_fallback_uses_real_socket_addr_without_config() {
+		let socket_addr = SocketAddr::from(([203, 0, 113, 9], 4567));
+		let mut parts = parts(std::iter::empty());
+		parts.extensions.insert(ConnectInfo(socket_addr));
+
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip, socket_addr.ip());
+	}
+
+	#[tokio::test]
+	async fn bare_secure_client_ip_source_connect_info_does_not_hijack() {
+		let socket_addr = SocketAddr::from(([203, 0, 113, 10], 4567));
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts.extensions.insert(ConnectInfo(socket_addr));
+		parts
+			.extensions
+			.insert(SecureClientIpSource::ConnectInfo);
+
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@
 #![allow(unused_features)] // 1.96.0-nightly 2026-03-07 bug
 
 pub mod client;
+pub mod client_ip;
 pub mod oidc;
 pub mod router;
 pub mod server;

--- a/src/api/server/invite.rs
+++ b/src/api/server/invite.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use base64::{Engine as _, engine::general_purpose};
 use futures::StreamExt;
 use ruma::{
@@ -23,7 +22,7 @@ use tuwunel_core::{
 	utils::hash::sha256,
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `PUT /_matrix/federation/v2/invite/{roomId}/{eventId}`
 ///
@@ -31,7 +30,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "invite")]
 pub(crate) async fn create_invite_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_invite::v2::Request>,
 ) -> Result<create_invite::v2::Response> {
 	// ACL check origin

--- a/src/api/server/media.rs
+++ b/src/api/server/media.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	Mxc,
 	api::federation::authenticated_media::{
@@ -9,7 +8,7 @@ use ruma::{
 use tuwunel_core::{Result, utils::content_disposition::make_content_disposition};
 use tuwunel_service::media::{Dim, Media};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/federation/v1/media/download/{mediaId}`
 ///
@@ -22,7 +21,7 @@ use crate::Ruma;
 )]
 pub(crate) async fn get_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v1::Request>,
 ) -> Result<get_content::v1::Response> {
 	let mxc = Mxc {
@@ -62,7 +61,7 @@ pub(crate) async fn get_content_route(
 )]
 pub(crate) async fn get_content_thumbnail_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v1::Request>,
 ) -> Result<get_content_thumbnail::v1::Response> {
 	let dim = Dim::from_ruma(body.width, body.height, body.method.clone())?;

--- a/src/api/server/publicrooms.rs
+++ b/src/api/server/publicrooms.rs
@@ -1,12 +1,11 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	api::federation::directory::{get_public_rooms, get_public_rooms_filtered},
 	directory::Filter,
 };
 use tuwunel_core::{Err, Result, err};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/federation/v1/publicRooms`
 ///
@@ -14,7 +13,7 @@ use crate::Ruma;
 #[tracing::instrument(name = "publicrooms", level = "debug", skip_all, fields(%client))]
 pub(crate) async fn get_public_rooms_filtered_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms_filtered::v1::Request>,
 ) -> Result<get_public_rooms_filtered::v1::Response> {
 	if !services
@@ -50,7 +49,7 @@ pub(crate) async fn get_public_rooms_filtered_route(
 #[tracing::instrument(name = "publicrooms", level = "debug", skip_all, fields(%client))]
 pub(crate) async fn get_public_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms::v1::Request>,
 ) -> Result<get_public_rooms::v1::Response> {
 	if !services

--- a/src/api/server/send.rs
+++ b/src/api/server/send.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use ruma::{
 	CanonicalJsonObject, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, ServerName,
@@ -47,7 +46,7 @@ use tuwunel_service::{
 	sending::{EDU_LIMIT, PDU_LIMIT},
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 type ResolvedMap = BTreeMap<OwnedEventId, Result>;
 type RoomsPdus = SmallVec<[RoomPdus; 1]>;
@@ -70,7 +69,7 @@ type Pdu = (OwnedRoomId, OwnedEventId, CanonicalJsonObject);
 )]
 pub(crate) async fn send_transaction_message_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<send_transaction_message::v1::Request>,
 ) -> Result<send_transaction_message::v1::Response> {
 	if body.origin() != body.body.origin {


### PR DESCRIPTION
## Summary

Introduces a tuwunel-internal `ClientIp` extractor in `src/api/client_ip.rs` and migrates all 22 API handler call sites away from `axum_client_ip::InsecureClientIp`.

This change is plumbing only. It is designed to be a no-op for every existing deployment:

- The extractor default branch delegates to `InsecureClientIp`, preserving today's header scan chain and `ConnectInfo` fallback exactly.
- A new marker, `ConfiguredIpSource`, gates the `SecureClientIp` branch. Nothing in this change installs that marker; #429 installs it only when `ip_source` is configured.
- The existing `SecureClientIpSource::ConnectInfo` extension installed by `src/router/layers.rs` is intentionally untouched and ignored by this extractor, so Unix-socket deployments (#310) remain unaffected.

## Two-PR series

This is the first PR in a two-PR effort for configurable, spoofing-resistant client IP resolution:

- **#428 (this PR):** introduces the internal `ClientIp` extractor and migrates handlers to use it, while preserving current behavior by default.
- **#429:** builds on this extractor by adding the optional `ip_source` config field, startup warnings for trusted-proxy header sources, reload protection, router-layer installation of `ConfiguredIpSource`, and deployment documentation.

Keeping this split lets reviewers verify the mechanical extractor migration independently from the user-facing configuration and documentation work. #429 should land after this PR.

## Test plan

- [x] `cargo check -p tuwunel_api`
- [x] `cargo clippy -p tuwunel_api --no-deps -- -D warnings`
- [x] `rustup run nightly rustfmt --check` on touched files
- [x] `cargo test -p tuwunel_api client_ip`
- [x] Unit tests in `src/api/client_ip.rs` cover fallback and configured paths, malformed headers, IPv6, XFF priority, configured-header absence, and the auto-installed `SecureClientIpSource` regression.
- [ ] Manual smoke: start tuwunel, hit `/_matrix/client/versions`, confirm tracing emits the connecting IP as today.
