### PR TITLE
Add configurable ip_source for client IP resolution.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,9 +4392,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -166,6 +166,26 @@ Regardless of which reverse proxy you choose, you will need to:
    - Port 443 (HTTPS) for client-server API
    - Port 8448 for federation (if federating with other homeservers)
 
+### Client IP source
+
+Set `ip_source` when you want Tuwunel to use a spoofing-resistant client IP
+source for rate limiting, logging, and security tooling. Leave it unset to keep
+the legacy fallback behavior.
+
+Use `ip_source = "connect_info"` only when Tuwunel accepts direct TCP
+connections and should use the TCP peer address. Do not use `connect_info` for
+Unix-socket deployments; leave `ip_source` unset there.
+
+If Tuwunel is behind a trusted reverse proxy, set `ip_source` to match the
+header that proxy controls. Caddy, Nginx, and Traefik usually use
+`ip_source = "rightmost_x_forwarded_for"`. Cloudflare and cloudflared
+deployments can use `ip_source = "cf_connecting_ip"` when Cloudflare supplies
+that header.
+
+Only use header-based values when clients cannot connect to Tuwunel directly.
+If clients can reach Tuwunel without going through the trusted proxy, they can
+send forged forwarding headers and choose the IP address Tuwunel sees.
+
 See the following spec pages for more details on well-known files:
 - [`/.well-known/matrix/server`](https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixserver)
 - [`/.well-known/matrix/client`](https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixclient)

--- a/docs/deploying/reverse-proxy-caddy.md
+++ b/docs/deploying/reverse-proxy-caddy.md
@@ -28,6 +28,12 @@ your.server.name, your.server.name:8448 {
 - Sets all necessary reverse proxy headers correctly
 - Routes all traffic to Tuwunel listening on `localhost:8008`
 
+### Client IP source
+
+If Caddy is the only way clients can reach Tuwunel, set
+`ip_source = "rightmost_x_forwarded_for"` in `tuwunel.toml`. If you use the
+Unix-socket `reverse_proxy` target, leave `ip_source` unset instead.
+
 That's it! Just start and enable the service and you're set.
 
 ```bash

--- a/docs/deploying/reverse-proxy-nginx.md
+++ b/docs/deploying/reverse-proxy-nginx.md
@@ -84,6 +84,9 @@ server {
 
 - **Replace `matrix.example.com`** with your actual server name
 - **`client_max_body_size`**: Must match or exceed `max_request_size` in your `tuwunel.toml`
+- **`ip_source`**: If Nginx is the only way clients can reach Tuwunel, set
+  `ip_source = "rightmost_x_forwarded_for"` so Tuwunel uses the trusted
+  `X-Forwarded-For` value
 - **Do NOT use `$request_uri`** in `proxy_pass` - while some guides suggest this, it's not necessary for Tuwunel and can cause issues
 - **IPv6**: The `listen [::]:443` and `listen [::]:8448` lines enable IPv6 support. Remove them if you don't need IPv6
 

--- a/docs/deploying/reverse-proxy-traefik.md
+++ b/docs/deploying/reverse-proxy-traefik.md
@@ -76,7 +76,15 @@ http:
                     - url: "http://tuwunel:6167"
                 passHostHeader: true
 ```
+
+### Client IP source
+
+If Traefik is the only way clients can reach Tuwunel, set
+`ip_source = "rightmost_x_forwarded_for"` in `tuwunel.toml` so Tuwunel uses the
+trusted `X-Forwarded-For` value.
+
 ### Federation
+
 If you will use a .well-known file you can use traefik to redirect .well-known/matrix to tuwunel built-in .well-known file.
 
 replace the rule in either of the methods from

--- a/src/api/client/account.rs
+++ b/src/api/client/account.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, StreamExt};
 use ruma::api::client::account::{
 	ThirdPartyIdRemovalStatus, change_password, deactivate, get_3pids,
@@ -7,7 +6,7 @@ use ruma::api::client::account::{
 };
 use tuwunel_core::{Err, Result, err, info, utils::ReadyExt};
 
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 /// # `POST /_matrix/client/r0/account/password`
 ///
@@ -29,7 +28,7 @@ use crate::{Ruma, router::auth_uiaa};
 #[tracing::instrument(skip_all, fields(%client), name = "change_password")]
 pub(crate) async fn change_password_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<change_password::v3::Request>,
 ) -> Result<change_password::v3::Response> {
 	let ref sender_user = auth_uiaa(&services, &body).await?;
@@ -96,7 +95,7 @@ pub(crate) async fn whoami_route(
 #[tracing::instrument(skip_all, fields(%client), name = "deactivate")]
 pub(crate) async fn deactivate_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<deactivate::v3::Request>,
 ) -> Result<deactivate::v3::Response> {
 	let ref sender_user = auth_uiaa(&services, &body).await?;

--- a/src/api/client/dehydrated_device.rs
+++ b/src/api/client/dehydrated_device.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::api::client::dehydrated_device::{
 	delete_dehydrated_device::unstable as delete_dehydrated_device,
@@ -8,7 +7,7 @@ use ruma::api::client::dehydrated_device::{
 };
 use tuwunel_core::{Err, Result, at, utils::result::IsErrOr};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const MAX_BATCH_EVENTS: usize = 50;
 
@@ -18,7 +17,7 @@ const MAX_BATCH_EVENTS: usize = 50;
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn put_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<put_dehydrated_device::Request>,
 ) -> Result<put_dehydrated_device::Response> {
 	let sender_user = body
@@ -42,7 +41,7 @@ pub(crate) async fn put_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn delete_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<delete_dehydrated_device::Request>,
 ) -> Result<delete_dehydrated_device::Response> {
 	let sender_user = body.sender_user();
@@ -66,7 +65,7 @@ pub(crate) async fn delete_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn get_dehydrated_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_dehydrated_device::Request>,
 ) -> Result<get_dehydrated_device::Response> {
 	let sender_user = body.sender_user();
@@ -88,7 +87,7 @@ pub(crate) async fn get_dehydrated_device_route(
 #[tracing::instrument(skip_all, fields(%client))]
 pub(crate) async fn get_dehydrated_events_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_events::Request>,
 ) -> Result<get_events::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/device.rs
+++ b/src/api/client/device.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::{
 	MilliSecondsSinceUnixEpoch,
@@ -9,7 +8,7 @@ use ruma::{
 };
 use tuwunel_core::{Err, Result, debug, err, utils::string::to_small_string};
 
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 /// # `GET /_matrix/client/r0/devices`
 ///
@@ -49,7 +48,7 @@ pub(crate) async fn get_device_route(
 #[tracing::instrument(skip_all, fields(%client), name = "update_device")]
 pub(crate) async fn update_device_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<update_device::v3::Request>,
 ) -> Result<update_device::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/directory.rs
+++ b/src/api/client/directory.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{
 	FutureExt, StreamExt, TryFutureExt,
 	future::{join, join4, join5},
@@ -33,7 +32,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::Services;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/publicRooms`
 ///
@@ -43,7 +42,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "publicrooms")]
 pub(crate) async fn get_public_rooms_filtered_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms_filtered::v3::Request>,
 ) -> Result<get_public_rooms_filtered::v3::Response> {
 	check_server_banned(&services, body.server.as_deref())?;
@@ -72,7 +71,7 @@ pub(crate) async fn get_public_rooms_filtered_route(
 #[tracing::instrument(skip_all, fields(%client), name = "publicrooms")]
 pub(crate) async fn get_public_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms::v3::Request>,
 ) -> Result<get_public_rooms::v3::Response> {
 	check_server_banned(&services, body.server.as_deref())?;
@@ -104,7 +103,7 @@ pub(crate) async fn get_public_rooms_route(
 #[tracing::instrument(skip_all, fields(%client), name = "room_directory")]
 pub(crate) async fn set_room_visibility_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<set_room_visibility::v3::Request>,
 ) -> Result<set_room_visibility::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/media.rs
+++ b/src/api/client/media.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use reqwest::Url;
 use ruma::{
 	MilliSecondsSinceUnixEpoch, Mxc, UserId,
@@ -25,7 +24,7 @@ use tuwunel_service::{
 	media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, MXC_LENGTH, Media},
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/v1/media/config`
 pub(crate) async fn get_media_config_route(
@@ -51,7 +50,7 @@ pub(crate) async fn get_media_config_route(
 )]
 pub(crate) async fn create_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_content::v3::Request>,
 ) -> Result<create_content::v3::Response> {
 	let user = body.sender_user();
@@ -94,7 +93,7 @@ pub(crate) async fn create_content_route(
 )]
 pub(crate) async fn create_mxc_uri_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_mxc_uri::v1::Request>,
 ) -> Result<create_mxc_uri::v1::Response> {
 	let user = body.sender_user();
@@ -134,7 +133,7 @@ pub(crate) async fn create_mxc_uri_route(
 )]
 pub(crate) async fn create_content_async_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_content_async::v3::Request>,
 ) -> Result<create_content_async::v3::Response> {
 	let user = body.sender_user();
@@ -166,7 +165,7 @@ pub(crate) async fn create_content_async_route(
 )]
 pub(crate) async fn get_content_thumbnail_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v1::Request>,
 ) -> Result<get_content_thumbnail::v1::Response> {
 	let user = body.sender_user();
@@ -203,7 +202,7 @@ pub(crate) async fn get_content_thumbnail_route(
 )]
 pub(crate) async fn get_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v1::Request>,
 ) -> Result<get_content::v1::Response> {
 	let user = body.sender_user();
@@ -239,7 +238,7 @@ pub(crate) async fn get_content_route(
 )]
 pub(crate) async fn get_content_as_filename_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_as_filename::v1::Request>,
 ) -> Result<get_content_as_filename::v1::Response> {
 	let user = body.sender_user();
@@ -275,7 +274,7 @@ pub(crate) async fn get_content_as_filename_route(
 )]
 pub(crate) async fn get_media_preview_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_media_preview::v1::Request>,
 ) -> Result<get_media_preview::v1::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/media_legacy.rs
+++ b/src/api/client/media_legacy.rs
@@ -1,7 +1,6 @@
 #![expect(deprecated)]
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use reqwest::Url;
 use ruma::{
 	Mxc,
@@ -16,7 +15,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::media::{CACHE_CONTROL_IMMUTABLE, CORP_CROSS_ORIGIN, Dim, Media};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/media/v3/config`
 ///
@@ -36,7 +35,7 @@ pub(crate) async fn get_media_config_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "url_preview_legacy", level = "debug")]
 pub(crate) async fn get_media_preview_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_media_preview::v3::Request>,
 ) -> Result<get_media_preview::v3::Response> {
 	let sender_user = body.sender_user();
@@ -84,7 +83,7 @@ pub(crate) async fn get_media_preview_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_get_legacy", level = "debug")]
 pub(crate) async fn get_content_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v3::Request>,
 ) -> Result<get_content::v3::Response> {
 	let mxc = Mxc {
@@ -156,7 +155,7 @@ pub(crate) async fn get_content_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_get_legacy", level = "debug")]
 pub(crate) async fn get_content_as_filename_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_as_filename::v3::Request>,
 ) -> Result<get_content_as_filename::v3::Response> {
 	let mxc = Mxc {
@@ -228,7 +227,7 @@ pub(crate) async fn get_content_as_filename_legacy_route(
 #[tracing::instrument(skip_all, fields(%client), name = "media_thumbnail_get_legacy", level = "debug")]
 pub(crate) async fn get_content_thumbnail_legacy_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v3::Request>,
 ) -> Result<get_content_thumbnail::v3::Response> {
 	let mxc = Mxc {

--- a/src/api/client/membership/invite.rs
+++ b/src/api/client/membership/invite.rs
@@ -1,11 +1,10 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, join};
 use ruma::{api::client::membership::invite_user, events::room::member::MembershipState};
 use tuwunel_core::{Err, Result};
 
 use super::banned_room_check;
-use crate::{Ruma, client::utils::invite_check};
+use crate::{Ruma, client::utils::invite_check, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/r0/rooms/{roomId}/invite`
 ///
@@ -13,7 +12,7 @@ use crate::{Ruma, client::utils::invite_check};
 #[tracing::instrument(skip_all, fields(%client), name = "invite")]
 pub(crate) async fn invite_user_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<invite_user::v3::Request>,
 ) -> Result<invite_user::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/membership/join.rs
+++ b/src/api/client/membership/join.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::FutureExt;
 use ruma::{
 	RoomId,
@@ -8,7 +7,7 @@ use ruma::{
 use tuwunel_core::{Result, warn};
 
 use super::banned_room_check;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/r0/rooms/{roomId}/join`
 ///
@@ -21,7 +20,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "join")]
 pub(crate) async fn join_room_by_id_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<join_room_by_id::v3::Request>,
 ) -> Result<join_room_by_id::v3::Response> {
 	let sender_user = body.sender_user();
@@ -74,7 +73,7 @@ pub(crate) async fn join_room_by_id_route(
 #[tracing::instrument(skip_all, fields(%client), name = "join")]
 pub(crate) async fn join_room_by_id_or_alias_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<join_room_by_id_or_alias::v3::Request>,
 ) -> Result<join_room_by_id_or_alias::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/membership/knock.rs
+++ b/src/api/client/membership/knock.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::knock::knock_room;
 use tuwunel_core::Result;
 
 use super::banned_room_check;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/*/knock/{roomIdOrAlias}`
 ///
@@ -12,7 +11,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "knock")]
 pub(crate) async fn knock_room_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<knock_room::v3::Request>,
 ) -> Result<knock_room::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/register.rs
+++ b/src/api/client/register.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	UserId,
 	api::client::{
@@ -16,7 +15,7 @@ use tuwunel_core::{Err, Error, Result, debug_info, debug_warn, info, utils};
 use tuwunel_service::users::{Register, device::generate_refresh_token};
 
 use super::SESSION_ID_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const RANDOM_USER_ID_LENGTH: usize = 10;
 
@@ -34,7 +33,7 @@ const RANDOM_USER_ID_LENGTH: usize = 10;
 #[tracing::instrument(skip_all, fields(%client), name = "register_available")]
 pub(crate) async fn get_register_available_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_username_availability::v3::Request>,
 ) -> Result<get_username_availability::v3::Response> {
 	// workaround for https://github.com/matrix-org/matrix-appservice-irc/issues/1780 due to inactivity of fixing the issue
@@ -131,7 +130,7 @@ pub(crate) async fn get_register_available_route(
 #[tracing::instrument(skip_all, fields(%client), name = "register")]
 pub(crate) async fn register_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<register::v3::Request>,
 ) -> Result<register::v3::Response> {
 	let is_guest = body.kind == RegistrationKind::Guest;

--- a/src/api/client/report.rs
+++ b/src/api/client/report.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	EventId, RoomId, UserId,
 	api::client::room::{report_content, report_room},
@@ -8,7 +7,7 @@ use ruma::{
 use tuwunel_core::{Err, Result, debug_info, info, matrix::pdu::PduEvent, utils::ReadyExt};
 use tuwunel_service::Services;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 const REASON_MAX_LEN: usize = 750;
 
@@ -18,7 +17,7 @@ const REASON_MAX_LEN: usize = 750;
 #[tracing::instrument(skip_all, fields(%client), name = "report_room")]
 pub(crate) async fn report_room_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<report_room::v3::Request>,
 ) -> Result<report_room::v3::Response> {
 	let sender_user = body.sender_user();
@@ -64,7 +63,7 @@ pub(crate) async fn report_room_route(
 #[tracing::instrument(skip_all, fields(%client), name = "report_event")]
 pub(crate) async fn report_event_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<report_content::v3::Request>,
 ) -> Result<report_content::v3::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client/room/summary.rs
+++ b/src/api/client/room/summary.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, StreamExt, TryFutureExt, future::join3, stream::FuturesUnordered};
 use ruma::{
 	OwnedServerName, RoomId, UserId,
@@ -16,7 +15,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::Services;
 
-use crate::{Ruma, RumaResponse};
+use crate::{Ruma, RumaResponse, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/unstable/im.nheko.summary/rooms/{roomIdOrAlias}/summary`
 ///
@@ -29,10 +28,10 @@ use crate::{Ruma, RumaResponse};
 /// An implementation of [MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266)
 pub(crate) async fn get_room_summary_legacy(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_summary::v1::Request>,
 ) -> Result<RumaResponse<get_summary::v1::Response>> {
-	get_room_summary(State(services), InsecureClientIp(client), body)
+	get_room_summary(State(services), ClientIp(client), body)
 		.boxed()
 		.await
 		.map(RumaResponse)
@@ -46,7 +45,7 @@ pub(crate) async fn get_room_summary_legacy(
 #[tracing::instrument(skip_all, fields(%client), name = "room_summary")]
 pub(crate) async fn get_room_summary(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_summary::v1::Request>,
 ) -> Result<get_summary::v1::Response> {
 	let (room_id, servers) = services

--- a/src/api/client/session/logout.rs
+++ b/src/api/client/session/logout.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::api::client::session::{logout, logout_all};
 use tuwunel_core::Result;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/logout`
 ///
@@ -18,7 +17,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "logout")]
 pub(crate) async fn logout_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<logout::v3::Request>,
 ) -> Result<logout::v3::Response> {
 	services
@@ -45,7 +44,7 @@ pub(crate) async fn logout_route(
 #[tracing::instrument(skip_all, fields(%client), name = "logout")]
 pub(crate) async fn logout_all_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<logout_all::v3::Request>,
 ) -> Result<logout_all::v3::Response> {
 	services

--- a/src/api/client/session/mod.rs
+++ b/src/api/client/session/mod.rs
@@ -8,7 +8,6 @@ mod sso;
 mod token;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::session::{
 	get_login_types::{
 		self,
@@ -35,7 +34,7 @@ pub(crate) use self::{
 	token::login_token_route,
 };
 use super::TOKEN_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/v3/login`
 ///
@@ -44,7 +43,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "login")]
 pub(crate) async fn get_login_types_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	_body: Ruma<get_login_types::v3::Request>,
 ) -> Result<get_login_types::v3::Response> {
 	let get_login_token = services.config.login_via_existing_session;
@@ -105,7 +104,7 @@ pub(crate) async fn get_login_types_route(
 #[tracing::instrument(name = "login", skip_all, fields(%client, ?body.login_info))]
 pub(crate) async fn login_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<login::v3::Request>,
 ) -> Result<login::v3::Response> {
 	// Validate login method

--- a/src/api/client/session/refresh.rs
+++ b/src/api/client/session/refresh.rs
@@ -1,10 +1,9 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::api::client::session::refresh_token::v3::{Request, Response};
 use tuwunel_core::{Err, Result, debug_info, err};
 use tuwunel_service::users::device::generate_refresh_token;
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/client/v3/refresh`
 ///
@@ -14,7 +13,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "refresh_token")]
 pub(crate) async fn refresh_token_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<Request>,
 ) -> Result<Response> {
 	let refresh_token_claim = body.body.refresh_token;

--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -3,7 +3,6 @@ mod uiaa;
 use std::{borrow::Cow, net::IpAddr, time::Duration};
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as b64};
 use futures::{FutureExt, StreamExt, TryFutureExt, future::try_join};
@@ -45,7 +44,7 @@ use url::Url;
 
 pub(crate) use self::uiaa::sso_fallback_route;
 use super::TOKEN_LENGTH;
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// Grant phase query string.
 #[derive(Debug, Serialize)]
@@ -83,7 +82,7 @@ static GRANT_SESSION_COOKIE: &str = "tuwunel_grant_session";
 )]
 pub(crate) async fn sso_login_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_login::v3::Request>,
 ) -> Result<sso_login::v3::Response> {
 	if services.config.sso_custom_providers_page {
@@ -125,7 +124,7 @@ pub(crate) async fn sso_login_route(
 )]
 pub(crate) async fn sso_login_with_provider_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_login_with_provider::v3::Request>,
 ) -> Result<sso_login_with_provider::v3::Response> {
 	let idp_id = body.body.idp_id;
@@ -254,7 +253,7 @@ async fn handle_sso_login(
 )]
 pub(crate) async fn sso_callback_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<sso_callback::unstable::Request>,
 ) -> Result<sso_callback::unstable::Response> {
 	let sess_id = body

--- a/src/api/client/session/token.rs
+++ b/src/api/client/session/token.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	OwnedUserId,
 	api::client::session::{
@@ -13,7 +12,7 @@ use tuwunel_core::{Err, Result, utils::random_string};
 use tuwunel_service::Services;
 
 use super::TOKEN_LENGTH;
-use crate::{Ruma, router::auth_uiaa};
+use crate::{Ruma, client_ip::ClientIp, router::auth_uiaa};
 
 pub(super) async fn handle_login(
 	services: &Services,
@@ -38,7 +37,7 @@ pub(super) async fn handle_login(
 #[tracing::instrument(skip_all, fields(%client), name = "login_token")]
 pub(crate) async fn login_token_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_login_token::v1::Request>,
 ) -> Result<get_login_token::v1::Response> {
 	if !services.config.login_via_existing_session || !services.config.login_via_token {

--- a/src/api/client/unstable.rs
+++ b/src/api/client/unstable.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::StreamExt;
 use ruma::{
 	OwnedRoomId,
@@ -17,7 +16,7 @@ use ruma::{
 };
 use tuwunel_core::{Err, Result, err};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms`
 ///
@@ -29,7 +28,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "mutual_rooms")]
 pub(crate) async fn get_mutual_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<mutual_rooms::unstable::Request>,
 ) -> Result<mutual_rooms::unstable::Response> {
 	let sender_user = body.sender_user();

--- a/src/api/client_ip.rs
+++ b/src/api/client_ip.rs
@@ -1,0 +1,193 @@
+//! Tuwunel's client-IP extractor.
+//!
+//! Wraps `axum_client_ip` with a two-mode fallback:
+//!
+//! * If the operator configured `ip_source`, a [`ConfiguredIpSource`] marker is
+//!   installed in request extensions and we delegate to
+//!   [`axum_client_ip::SecureClientIp`] with that source.
+//! * Otherwise we fall back to [`axum_client_ip::InsecureClientIp`], preserving
+//!   existing behavior exactly -- including the header scan chain and the
+//!   socket-address fallback that matters for Unix-socket deployments (see
+//!   matrix-construct/tuwunel#310).
+//!
+//! The plain `SecureClientIpSource::ConnectInfo` extension already
+//! installed by `src/router/layers.rs` is intentionally ignored here;
+//! only the [`ConfiguredIpSource`] marker participates in the secure
+//! path. This avoids flipping behavior for deployments that never opted
+//! in.
+
+use std::{fmt, marker::Sync, net::IpAddr};
+
+use axum::{
+	extract::FromRequestParts,
+	http::{StatusCode, request::Parts},
+};
+use axum_client_ip::{InsecureClientIp, SecureClientIp, SecureClientIpSource};
+
+/// Marker wrapper around [`SecureClientIpSource`] placed into request
+/// extensions only when an operator has explicitly configured
+/// `ip_source`.
+#[derive(Clone, Debug)]
+pub struct ConfiguredIpSource(pub SecureClientIpSource);
+
+/// Tuwunel client-IP extractor. See module docs.
+#[derive(Clone, Copy, Debug)]
+pub struct ClientIp(pub IpAddr);
+
+impl fmt::Display for ClientIp {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+impl<S> FromRequestParts<S> for ClientIp
+where
+	S: Sync,
+{
+	type Rejection = (StatusCode, &'static str);
+
+	async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+		if let Some(ConfiguredIpSource(source)) = parts.extensions.get::<ConfiguredIpSource>() {
+			SecureClientIp::from(source, &parts.headers, &parts.extensions)
+				.map(|SecureClientIp(ip)| Self(ip))
+				.map_err(|_| {
+					(
+						StatusCode::INTERNAL_SERVER_ERROR,
+						"Can't extract client IP from configured ip_source",
+					)
+				})
+		} else {
+			InsecureClientIp::from(&parts.headers, &parts.extensions)
+				.map(|InsecureClientIp(ip)| Self(ip))
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::SocketAddr;
+
+	use axum::{
+		extract::{ConnectInfo, FromRequestParts},
+		http::{Request, StatusCode, request::Parts},
+	};
+	use axum_client_ip::SecureClientIpSource;
+
+	use super::{ClientIp, ConfiguredIpSource};
+
+	fn parts(headers: impl IntoIterator<Item = (&'static str, &'static str)>) -> Parts {
+		let mut request = Request::builder().uri("/");
+		for (name, value) in headers {
+			request = request.header(name, value);
+		}
+		let (parts, ()) = request.body(()).unwrap().into_parts();
+		parts
+	}
+
+	async fn extract_client_ip(
+		parts: &mut Parts,
+	) -> Result<ClientIp, (StatusCode, &'static str)> {
+		ClientIp::from_request_parts(parts, &()).await
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_uses_leftmost_ip() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_takes_priority_over_x_real_ip() {
+		let mut parts =
+			parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2"), ("X-Real-Ip", "3.3.3.3")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn x_forwarded_for_accepts_ipv6() {
+		let mut parts = parts([("X-Forwarded-For", "2001:db8::1, 2001:db8::2")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "2001:db8::1");
+	}
+
+	#[tokio::test]
+	async fn x_real_ip_works() {
+		let mut parts = parts([("X-Real-Ip", "1.2.3.4")]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.2.3.4");
+	}
+
+	#[tokio::test]
+	async fn malformed_headers_fall_through_to_next_valid_source() {
+		let mut parts = parts([
+			("X-Forwarded-For", "foo"),
+			("X-Real-Ip", "foo"),
+			("Forwarded", "foo"),
+			("Forwarded", "for=1.1.1.1;proto=https;by=2.2.2.2"),
+		]);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn no_headers_or_connect_info_rejects() {
+		let mut parts = parts(std::iter::empty());
+		let err = extract_client_ip(&mut parts).await.unwrap_err();
+		assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+		assert!(err.1.contains("ConnectInfo"), "{err:?}");
+	}
+
+	#[tokio::test]
+	async fn configured_source_uses_secure_extraction() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts
+			.extensions
+			.insert(ConfiguredIpSource(SecureClientIpSource::RightmostXForwardedFor));
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "2.2.2.2");
+	}
+
+	#[tokio::test]
+	async fn configured_source_without_matching_header_rejects() {
+		let mut parts = parts(std::iter::empty());
+		parts
+			.extensions
+			.insert(ConfiguredIpSource(SecureClientIpSource::RightmostXForwardedFor));
+		let err = extract_client_ip(&mut parts).await.unwrap_err();
+		assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+		assert_eq!(err.1, "Can't extract client IP from configured ip_source");
+	}
+
+	#[tokio::test]
+	async fn secure_client_ip_source_extension_does_not_hijack() {
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts
+			.extensions
+			.insert(SecureClientIpSource::ConnectInfo);
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+
+	#[tokio::test]
+	async fn connect_info_fallback_uses_real_socket_addr_without_config() {
+		let socket_addr = SocketAddr::from(([203, 0, 113, 9], 4567));
+		let mut parts = parts(std::iter::empty());
+		parts.extensions.insert(ConnectInfo(socket_addr));
+
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip, socket_addr.ip());
+	}
+
+	#[tokio::test]
+	async fn bare_secure_client_ip_source_connect_info_does_not_hijack() {
+		let socket_addr = SocketAddr::from(([203, 0, 113, 10], 4567));
+		let mut parts = parts([("X-Forwarded-For", "1.1.1.1, 2.2.2.2")]);
+		parts.extensions.insert(ConnectInfo(socket_addr));
+		parts
+			.extensions
+			.insert(SecureClientIpSource::ConnectInfo);
+
+		let ClientIp(ip) = extract_client_ip(&mut parts).await.unwrap();
+		assert_eq!(ip.to_string(), "1.1.1.1");
+	}
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@
 #![allow(unused_features)] // 1.96.0-nightly 2026-03-07 bug
 
 pub mod client;
+pub mod client_ip;
 pub mod oidc;
 pub mod router;
 pub mod server;

--- a/src/api/server/invite.rs
+++ b/src/api/server/invite.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use base64::{Engine as _, engine::general_purpose};
 use futures::StreamExt;
 use ruma::{
@@ -23,7 +22,7 @@ use tuwunel_core::{
 	utils::hash::sha256,
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `PUT /_matrix/federation/v2/invite/{roomId}/{eventId}`
 ///
@@ -31,7 +30,7 @@ use crate::Ruma;
 #[tracing::instrument(skip_all, fields(%client), name = "invite")]
 pub(crate) async fn create_invite_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<create_invite::v2::Request>,
 ) -> Result<create_invite::v2::Response> {
 	// ACL check origin

--- a/src/api/server/media.rs
+++ b/src/api/server/media.rs
@@ -1,5 +1,4 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	Mxc,
 	api::federation::authenticated_media::{
@@ -9,7 +8,7 @@ use ruma::{
 use tuwunel_core::{Result, utils::content_disposition::make_content_disposition};
 use tuwunel_service::media::{Dim, Media};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `GET /_matrix/federation/v1/media/download/{mediaId}`
 ///
@@ -22,7 +21,7 @@ use crate::Ruma;
 )]
 pub(crate) async fn get_content_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content::v1::Request>,
 ) -> Result<get_content::v1::Response> {
 	let mxc = Mxc {
@@ -62,7 +61,7 @@ pub(crate) async fn get_content_route(
 )]
 pub(crate) async fn get_content_thumbnail_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_content_thumbnail::v1::Request>,
 ) -> Result<get_content_thumbnail::v1::Response> {
 	let dim = Dim::from_ruma(body.width, body.height, body.method.clone())?;

--- a/src/api/server/publicrooms.rs
+++ b/src/api/server/publicrooms.rs
@@ -1,12 +1,11 @@
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use ruma::{
 	api::federation::directory::{get_public_rooms, get_public_rooms_filtered},
 	directory::Filter,
 };
 use tuwunel_core::{Err, Result, err};
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 /// # `POST /_matrix/federation/v1/publicRooms`
 ///
@@ -14,7 +13,7 @@ use crate::Ruma;
 #[tracing::instrument(name = "publicrooms", level = "debug", skip_all, fields(%client))]
 pub(crate) async fn get_public_rooms_filtered_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms_filtered::v1::Request>,
 ) -> Result<get_public_rooms_filtered::v1::Response> {
 	if !services
@@ -50,7 +49,7 @@ pub(crate) async fn get_public_rooms_filtered_route(
 #[tracing::instrument(name = "publicrooms", level = "debug", skip_all, fields(%client))]
 pub(crate) async fn get_public_rooms_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<get_public_rooms::v1::Request>,
 ) -> Result<get_public_rooms::v1::Response> {
 	if !services

--- a/src/api/server/send.rs
+++ b/src/api/server/send.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use axum::extract::State;
-use axum_client_ip::InsecureClientIp;
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use ruma::{
 	CanonicalJsonObject, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, ServerName,
@@ -47,7 +46,7 @@ use tuwunel_service::{
 	sending::{EDU_LIMIT, PDU_LIMIT},
 };
 
-use crate::Ruma;
+use crate::{Ruma, client_ip::ClientIp};
 
 type ResolvedMap = BTreeMap<OwnedEventId, Result>;
 type RoomsPdus = SmallVec<[RoomPdus; 1]>;
@@ -70,7 +69,7 @@ type Pdu = (OwnedRoomId, OwnedEventId, CanonicalJsonObject);
 )]
 pub(crate) async fn send_transaction_message_route(
 	State(services): State<crate::State>,
-	InsecureClientIp(client): InsecureClientIp,
+	ClientIp(client): ClientIp,
 	body: Ruma<send_transaction_message::v1::Request>,
 ) -> Result<send_transaction_message::v1::Response> {
 	if body.origin() != body.body.origin {

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -3,7 +3,7 @@ use std::env::consts::OS;
 use either::Either;
 use itertools::Itertools;
 
-use super::{DEPRECATED_KEYS, IdentityProvider};
+use super::{DEPRECATED_KEYS, IdentityProvider, IpSource};
 use crate::{Config, Err, Result, debug, debug_info, error, warn};
 
 /// Performs check() with additional checks specific to reloading old config
@@ -16,6 +16,13 @@ pub fn reload(old: &Config, new: &Config) -> Result {
 			"server_name",
 			"You can't change the server's name from {:?}.",
 			old.server_name
+		));
+	}
+
+	if new.ip_source != old.ip_source {
+		return Err!(Config(
+			"ip_source",
+			"ip_source cannot be changed at runtime; restart the server to apply this change."
 		));
 	}
 
@@ -59,6 +66,16 @@ pub fn check(config: &Config) -> Result {
 	let key_set = config.tls.key.is_some();
 	if certs_set ^ key_set {
 		return Err!(Config("tls", "tls.certs and tls.key must either both be set or unset"));
+	}
+
+	if let Some(source) = config.ip_source
+		&& !matches!(source, IpSource::ConnectInfo)
+	{
+		warn!(
+			"ip_source is set to {source:?}, a header-based source. Ensure a trusted reverse \
+			 proxy populates this header for every request; otherwise clients can spoof their \
+			 IP address."
+		);
 	}
 
 	if !config.listening {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -576,6 +576,40 @@ pub struct Config {
 	#[serde(default = "default_client_shutdown_timeout")]
 	pub client_shutdown_timeout: u64,
 
+	/// Source of the client IP address for rate limiting, logging, and
+	/// security tooling.
+	///
+	/// When unset (the default), the `ClientIp` extractor falls back to
+	/// `axum-client-ip`'s `InsecureClientIp` for backward compatibility;
+	/// clients can spoof their address via request headers in that mode.
+	///
+	/// When set, tuwunel installs `SecureClientIpSource` with the selected
+	/// variant and `ClientIp` resolves exclusively from that source. The
+	/// rightmost value is used for multi-valued headers; only the proxy can
+	/// append to the right, so this is resistant to client spoofing.
+	///
+	/// Supported values:
+	/// - "connect_info" - TCP peer address only (direct connections)
+	/// - "rightmost_x_forwarded_for" - nginx, Caddy
+	/// - "rightmost_forwarded" - RFC 7239 proxies
+	/// - "x_real_ip" - nginx `X-Real-IP`
+	/// - "cf_connecting_ip" - Cloudflare / cloudflared
+	/// - "true_client_ip" - Akamai, Cloudflare Enterprise
+	/// - "fly_client_ip" - Fly.io
+	/// - "cloudfront_viewer_address" - AWS CloudFront
+	///
+	/// On Unix-socket deployments, leave this unset rather than setting
+	/// "connect_info"; that source requires a TCP peer address.
+	///
+	/// WARNING: a header-based value without a trusted reverse proxy in
+	/// front of tuwunel allows clients to forge their IP. Changing this
+	/// value requires a server restart.
+	///
+	/// default: unset
+	/// config-example: "connect_info"
+	#[serde(default)]
+	pub ip_source: Option<IpSource>,
+
 	/// Grace period for clean shutdown of federation requests (seconds).
 	///
 	/// default: 5
@@ -3287,6 +3321,31 @@ impl From<AppServiceNamespace> for ruma::api::appservice::Namespace {
 	}
 }
 
+/// Selects the source used to determine the connecting client's IP
+/// address. Variants correspond 1:1 to `axum_client_ip::SecureClientIpSource`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpSource {
+	/// TCP peer address. Safe default; no proxy required.
+	#[default]
+	ConnectInfo,
+	/// Rightmost value of `X-Forwarded-For`.
+	RightmostXForwardedFor,
+	/// Rightmost value of RFC 7239 `Forwarded`.
+	RightmostForwarded,
+	/// `X-Real-IP` header (nginx).
+	XRealIp,
+	/// `CF-Connecting-IP` (Cloudflare / cloudflared).
+	CfConnectingIp,
+	/// `True-Client-IP` (Akamai, Cloudflare Enterprise).
+	TrueClientIp,
+	/// `Fly-Client-IP` (Fly.io).
+	FlyClientIp,
+	/// `CloudFront-Viewer-Address` (AWS CloudFront).
+	#[serde(rename = "cloudfront_viewer_address")]
+	CloudFrontViewerAddress,
+}
+
 const DEPRECATED_KEYS: &[&str; 9] = &[
 	"cache_capacity",
 	"conduit_cache_capacity_modifier",
@@ -3719,3 +3778,234 @@ fn default_redaction_retention_seconds() -> u64 { 5_184_000 }
 fn default_media_storage_providers() -> BTreeSet<String> { ["media".to_owned()].into() }
 
 fn default_multipart_threshold() -> ByteSize { ByteSize::mib(100) }
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		io::{Result as IoResult, Write},
+		sync::{Arc, Mutex},
+	};
+
+	use tracing_subscriber::fmt::MakeWriter;
+
+	use super::*;
+
+	#[derive(Clone)]
+	struct SharedBufferWriter(Arc<Mutex<Vec<u8>>>);
+
+	impl Write for SharedBufferWriter {
+		fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+			self.0
+				.lock()
+				.expect("buffer lock poisoned")
+				.write(buf)
+		}
+
+		fn flush(&mut self) -> IoResult<()> { Ok(()) }
+	}
+
+	impl<'a> MakeWriter<'a> for SharedBufferWriter {
+		type Writer = Self;
+
+		fn make_writer(&'a self) -> Self::Writer { self.clone() }
+	}
+
+	fn config_from_toml(toml: &str) -> Result<Config> {
+		Config::new(&Figment::new().merge(Data::nested(Toml::string(toml))))
+	}
+
+	fn check_with_captured_logs(config: &Config) -> (Result, String) {
+		let captured = Arc::new(Mutex::new(Vec::new()));
+		let subscriber = tracing_subscriber::fmt()
+			.with_ansi(false)
+			.with_writer(SharedBufferWriter(Arc::clone(&captured)))
+			.finish();
+
+		let result = {
+			let _guard = tracing::subscriber::set_default(subscriber);
+			check(config)
+		};
+
+		let logs = String::from_utf8(
+			captured
+				.lock()
+				.expect("buffer lock poisoned")
+				.clone(),
+		)
+		.expect("captured tracing output should be valid UTF-8");
+
+		(result, logs)
+	}
+
+	#[test]
+	fn ip_source_absent_parses_as_none() {
+		let config = config_from_toml("[global]\n").unwrap();
+
+		assert_eq!(config.ip_source, None);
+	}
+
+	#[test]
+	fn ip_source_connect_info_parses() {
+		let config = config_from_toml(
+			r#"[global]
+ip_source = "connect_info"
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(config.ip_source, Some(IpSource::ConnectInfo));
+	}
+
+	#[test]
+	fn ip_source_rightmost_x_forwarded_for_parses() {
+		let config = config_from_toml(
+			r#"[global]
+ip_source = "rightmost_x_forwarded_for"
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(config.ip_source, Some(IpSource::RightmostXForwardedFor));
+	}
+
+	#[test]
+	fn ip_source_cf_connecting_ip_parses() {
+		let config = config_from_toml(
+			r#"[global]
+ip_source = "cf_connecting_ip"
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(config.ip_source, Some(IpSource::CfConnectingIp));
+	}
+
+	#[test]
+	fn ip_source_issue_427_values_parse() {
+		for (value, expected) in [
+			("connect_info", IpSource::ConnectInfo),
+			("rightmost_x_forwarded_for", IpSource::RightmostXForwardedFor),
+			("rightmost_forwarded", IpSource::RightmostForwarded),
+			("x_real_ip", IpSource::XRealIp),
+			("cf_connecting_ip", IpSource::CfConnectingIp),
+			("true_client_ip", IpSource::TrueClientIp),
+			("fly_client_ip", IpSource::FlyClientIp),
+			("cloudfront_viewer_address", IpSource::CloudFrontViewerAddress),
+		] {
+			let config = config_from_toml(&format!(
+				r#"[global]
+ip_source = "{value}"
+"#,
+			))
+			.unwrap();
+
+			assert_eq!(config.ip_source, Some(expected), "{value}");
+		}
+	}
+
+	#[test]
+	fn ip_source_camel_case_and_bogus_fail_to_parse() {
+		for value in ["CamelCase", "bogus"] {
+			let result = config_from_toml(&format!(
+				r#"[global]
+ip_source = "{value}"
+"#,
+			));
+
+			let Err(err) = result else {
+				panic!("ip_source value {value:?} should fail to parse");
+			};
+
+			let err = err.to_string();
+			assert!(err.contains("ip_source"), "{err}");
+			assert!(err.contains(value), "{err}");
+		}
+	}
+
+	#[test]
+	fn check_accepts_absent_connect_info_and_cf_connecting_ip() {
+		let absent = config_from_toml("[global]\n").unwrap();
+		let connect_info = config_from_toml(
+			r#"[global]
+ip_source = "connect_info"
+"#,
+		)
+		.unwrap();
+		let cf_connecting_ip = config_from_toml(
+			r#"[global]
+ip_source = "cf_connecting_ip"
+"#,
+		)
+		.unwrap();
+
+		let (result, logs) = check_with_captured_logs(&absent);
+		result.expect("absent ip_source should pass config check");
+		assert!(!logs.contains("ip_source is set to"));
+
+		let (result, logs) = check_with_captured_logs(&connect_info);
+		result.expect("connect_info should pass config check");
+		assert!(!logs.contains("ip_source is set to"));
+
+		let (result, logs) = check_with_captured_logs(&cf_connecting_ip);
+		result.expect("cf_connecting_ip should pass config check");
+		assert!(logs.contains("ip_source is set to CfConnectingIp"));
+	}
+
+	#[test]
+	fn reload_rejects_none_to_some_and_some_to_none() {
+		let none = config_from_toml("[global]\n").unwrap();
+		let some = config_from_toml(
+			r#"[global]
+ip_source = "connect_info"
+"#,
+		)
+		.unwrap();
+		let other_some = config_from_toml(
+			r#"[global]
+ip_source = "rightmost_x_forwarded_for"
+"#,
+		)
+		.unwrap();
+
+		let err = check::reload(&none, &some).unwrap_err();
+		assert!(
+			err.to_string().contains("'ip_source'")
+				&& err
+					.to_string()
+					.contains("cannot be changed at runtime"),
+			"{err}"
+		);
+
+		let err = check::reload(&some, &none).unwrap_err();
+		assert!(
+			err.to_string().contains("'ip_source'")
+				&& err
+					.to_string()
+					.contains("cannot be changed at runtime"),
+			"{err}"
+		);
+
+		let err = check::reload(&some, &other_some).unwrap_err();
+		assert!(
+			err.to_string().contains("'ip_source'")
+				&& err
+					.to_string()
+					.contains("cannot be changed at runtime"),
+			"{err}"
+		);
+	}
+
+	#[test]
+	fn reload_accepts_unchanged_none_and_unchanged_some() {
+		let none = config_from_toml("[global]\n").unwrap();
+		let some = config_from_toml(
+			r#"[global]
+ip_source = "rightmost_x_forwarded_for"
+"#,
+		)
+		.unwrap();
+
+		check::reload(&none, &none).expect("unchanged none config should reload");
+		check::reload(&some, &some).expect("unchanged some config should reload");
+	}
+}

--- a/src/macros/config.rs
+++ b/src/macros/config.rs
@@ -15,7 +15,7 @@ use crate::{
 
 const UNDOCUMENTED: &str = "# This item is undocumented. Please contribute documentation for it.";
 
-const HIDDEN: &[&str] = &["default", "display"];
+const HIDDEN: &[&str] = &["default", "display", "config-example"];
 
 #[expect(clippy::needless_pass_by_value)]
 pub(super) fn example_generator(input: ItemStruct, args: &[Meta]) -> Result<TokenStream> {
@@ -103,9 +103,9 @@ fn generate_example(input: &ItemStruct, args: &[Meta], write: bool) -> Result<To
 				format!("{doc}\n#\n")
 			};
 
-			let default = get_doc_comment_line(field, "default")
-				.or_else(|| get_default(field))
-				.unwrap_or_default();
+			// `config-example` overrides the emitted example value while `default`
+			// continues to document the runtime default separately.
+			let default = example_value(field);
 
 			let default = if !default.is_empty() {
 				format!(" {default}")
@@ -185,9 +185,8 @@ fn get_default(field: &Field) -> Option<String> {
 		let Some(arg) = Punctuated::<Meta, syn::Token![,]>::parse_terminated
 			.parse(tokens.clone().into())
 			.ok()?
-			.iter()
+			.into_iter()
 			.next()
-			.cloned()
 		else {
 			continue;
 		};
@@ -209,6 +208,13 @@ fn get_default(field: &Field) -> Option<String> {
 	}
 
 	None
+}
+
+fn example_value(field: &Field) -> String {
+	get_doc_comment_line(field, "config-example")
+		.or_else(|| get_doc_comment_line(field, "default"))
+		.or_else(|| get_default(field))
+		.unwrap_or_default()
 }
 
 fn get_doc_comment(field: &Field) -> Option<String> {
@@ -284,4 +290,35 @@ fn get_type_name(field: &Field) -> Option<String> {
 		.iter()
 		.next()
 		.map(|segment| segment.ident.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use syn::parse_quote;
+
+	use super::{example_value, get_doc_comment};
+
+	#[test]
+	fn config_example_overrides_default_for_generated_example_value() {
+		let field: syn::Field = parse_quote! {
+			#[doc = "config-example: from example"]
+			#[doc = "default: from default"]
+			name: String
+		};
+
+		assert_eq!(example_value(&field), "from example");
+	}
+
+	#[test]
+	fn config_example_is_hidden_from_emitted_comments() {
+		let field: syn::Field = parse_quote! {
+			#[doc = "visible setting docs"]
+			#[doc = "config-example: hidden value"]
+			name: String
+		};
+
+		let comment = get_doc_comment(&field).expect("visible comment to be emitted");
+		assert!(comment.contains("#visible setting docs"));
+		assert!(!comment.contains("config-example:"));
+	}
 }

--- a/src/macros/implement.rs
+++ b/src/macros/implement.rs
@@ -19,8 +19,8 @@ pub(super) fn implement(item: ItemFn, args: &[Meta]) -> Result<TokenStream> {
 	Ok(out.into())
 }
 
-fn get_receiver(args: &[Meta]) -> Result<Path> {
-	let receiver = &args.first().ok_or_else(|| {
+fn get_receiver(args: &[Meta]) -> Result<&Path> {
+	let receiver = args.first().ok_or_else(|| {
 		Error::new(Span::call_site().into(), "Missing required argument to receiver")
 	})?;
 
@@ -31,5 +31,5 @@ fn get_receiver(args: &[Meta]) -> Result<Path> {
 		));
 	};
 
-	Ok(receiver.clone())
+	Ok(receiver)
 }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -68,7 +68,7 @@ where
 	let item = parse_macro_input!(input as I);
 	syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated
 		.parse(args)
-		.map(|args| args.iter().cloned().collect::<Vec<_>>())
-		.and_then(|ref args| func(item, args))
+		.map(|args| args.into_iter().collect::<Vec<_>>())
+		.and_then(|args| func(item, &args))
 		.unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/src/router/layers.rs
+++ b/src/router/layers.rs
@@ -20,8 +20,8 @@ use tower_http::{
 	trace::{DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer},
 };
 use tracing::Level;
-use tuwunel_api::router::state::Guard;
-use tuwunel_core::{Result, Server, debug, error};
+use tuwunel_api::{client_ip::ConfiguredIpSource, router::state::Guard};
+use tuwunel_core::{Result, Server, config::IpSource, debug, error};
 use tuwunel_service::Services;
 
 use crate::{request, router};
@@ -71,7 +71,7 @@ pub(crate) fn build(services: &Arc<Services>) -> Result<(Router, Guard)> {
 				.on_response(DefaultOnResponse::new().level(Level::DEBUG)),
 		)
 		.layer(axum::middleware::from_fn_with_state(Arc::clone(services), request::handle))
-		.layer(SecureClientIpSource::ConnectInfo.into_extension())
+		.layer(ip_source_layer(server.config.ip_source))
 		.layer(ResponseBodyTimeoutLayer::new(Duration::from_secs(
 			server.config.client_response_timeout,
 		)))
@@ -213,6 +213,27 @@ fn body_limit_layer(server: &Server) -> DefaultBodyLimit {
 	DefaultBodyLimit::max(server.config.max_request_size)
 }
 
+fn configured_ip_source(source: IpSource) -> SecureClientIpSource {
+	match source {
+		| IpSource::ConnectInfo => SecureClientIpSource::ConnectInfo,
+		| IpSource::RightmostXForwardedFor => SecureClientIpSource::RightmostXForwardedFor,
+		| IpSource::RightmostForwarded => SecureClientIpSource::RightmostForwarded,
+		| IpSource::XRealIp => SecureClientIpSource::XRealIp,
+		| IpSource::CfConnectingIp => SecureClientIpSource::CfConnectingIp,
+		| IpSource::TrueClientIp => SecureClientIpSource::TrueClientIp,
+		| IpSource::FlyClientIp => SecureClientIpSource::FlyClientIp,
+		| IpSource::CloudFrontViewerAddress => SecureClientIpSource::CloudFrontViewerAddress,
+	}
+}
+
+fn ip_source_layer(
+	source: Option<IpSource>,
+) -> tower::util::Either<axum::Extension<ConfiguredIpSource>, tower::layer::util::Identity> {
+	tower::util::option_layer(
+		source.map(|source| axum::Extension(ConfiguredIpSource(configured_ip_source(source)))),
+	)
+}
+
 #[tracing::instrument(name = "panic", level = "error", skip_all)]
 #[expect(clippy::needless_pass_by_value)]
 fn catch_panic(
@@ -274,4 +295,48 @@ fn truncated_matched_path(path: &MatchedPath) -> &str {
 	path.as_str()
 		.rsplit_once('{')
 		.map_or(path.as_str(), |path| path.0.strip_suffix('/').unwrap_or(path.0))
+}
+
+#[cfg(test)]
+mod tests {
+	use tuwunel_api::client_ip::ConfiguredIpSource;
+	use tuwunel_core::config::IpSource;
+
+	use super::{configured_ip_source, ip_source_layer};
+
+	#[test]
+	fn configured_ip_source_maps_all_variants() {
+		let cases = [
+			(IpSource::ConnectInfo, "ConnectInfo"),
+			(IpSource::RightmostXForwardedFor, "RightmostXForwardedFor"),
+			(IpSource::RightmostForwarded, "RightmostForwarded"),
+			(IpSource::XRealIp, "XRealIp"),
+			(IpSource::CfConnectingIp, "CfConnectingIp"),
+			(IpSource::TrueClientIp, "TrueClientIp"),
+			(IpSource::FlyClientIp, "FlyClientIp"),
+			(IpSource::CloudFrontViewerAddress, "CloudFrontViewerAddress"),
+		];
+
+		for (source, expected) in cases {
+			let ConfiguredIpSource(actual) = ConfiguredIpSource(configured_ip_source(source));
+			assert_eq!(format!("{actual:?}"), expected);
+		}
+	}
+
+	#[test]
+	fn ip_source_layer_none_returns_identity_branch() {
+		let layer = ip_source_layer(None);
+
+		assert!(matches!(layer, tower::util::Either::Right(_)));
+	}
+
+	#[test]
+	fn ip_source_layer_connect_info_returns_extension_branch() {
+		let layer = ip_source_layer(Some(IpSource::ConnectInfo));
+
+		assert!(matches!(
+			layer,
+			tower::util::Either::Left(axum::Extension(ConfiguredIpSource(_)))
+		));
+	}
 }

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -437,6 +437,37 @@
 #
 #client_shutdown_timeout = 10
 
+# Source of the client IP address for rate limiting, logging, and
+# security tooling.
+#
+# When unset (the default), the `ClientIp` extractor falls back to
+# `axum-client-ip`'s `InsecureClientIp` for backward compatibility;
+# clients can spoof their address via request headers in that mode.
+#
+# When set, tuwunel installs `SecureClientIpSource` with the selected
+# variant and `ClientIp` resolves exclusively from that source. The
+# rightmost value is used for multi-valued headers; only the proxy can
+# append to the right, so this is resistant to client spoofing.
+#
+# Supported values:
+# - "connect_info" - TCP peer address only (direct connections)
+# - "rightmost_x_forwarded_for" - nginx, Caddy
+# - "rightmost_forwarded" - RFC 7239 proxies
+# - "x_real_ip" - nginx `X-Real-IP`
+# - "cf_connecting_ip" - Cloudflare / cloudflared
+# - "true_client_ip" - Akamai, Cloudflare Enterprise
+# - "fly_client_ip" - Fly.io
+# - "cloudfront_viewer_address" - AWS CloudFront
+#
+# On Unix-socket deployments, leave this unset rather than setting
+# "connect_info"; that source requires a TCP peer address.
+#
+# WARNING: a header-based value without a trusted reverse proxy in
+# front of tuwunel allows clients to forge their IP. Changing this
+# value requires a server restart.
+#
+#ip_source = "connect_info"
+
 # Grace period for clean shutdown of federation requests (seconds).
 #
 #sender_shutdown_timeout = 5


### PR DESCRIPTION
## Summary

Depends on #428 and should land after it.

Adds an optional `ip_source` config field for selecting how tuwunel resolves the client IP used by rate limiting, logging, and security tooling.

When `ip_source` is unset, no `ConfiguredIpSource` extension is installed, so the `ClientIp` extractor from #428 keeps the existing `InsecureClientIp` fallback behavior. When `ip_source` is set, the router installs a `ConfiguredIpSource` marker that maps to the selected `SecureClientIpSource` variant.

This also:

- rejects runtime reload changes to `ip_source`, because the router layer stack is built at startup;
- warns at startup when a header-based source is configured;
- documents `ip_source` in `tuwunel-example.toml` with a valid commented example;
- surfaces operator guidance in the generic deployment page and Caddy, Nginx, and Traefik reverse-proxy pages;
- calls out that Unix-socket deployments should leave `ip_source` unset rather than setting `connect_info`;
- teaches the config example generator a hidden `config-example:` directive, so fields can document an unset runtime default while emitting a valid example value;
- removes `syn` clone assumptions in the macro helper path so the touched macro crate remains directly testable.

## Macro note

`tuwunel-example.toml` is generated by `config_example_generator`, so a hand-edited example value would be overwritten on build. The new hidden `config-example:` directive lets `ip_source` keep its honest runtime default (`unset` / `None`) while generating the valid sample `#ip_source = "connect_info"`.

The small `src/macros/mod.rs` and `src/macros/implement.rs` changes remove existing `syn` clone assumptions that surfaced when adding direct tests for the generator behavior. They are included so `tuwunel_macros` can be checked, tested, and linted directly with this PR.

## Before / after

Before:

- client IP resolution followed the existing fallback behavior from `InsecureClientIp`;
- deployments behind trusted proxies had no typed config option for selecting a spoofing-resistant source;
- changing the intended source at runtime had no explicit guard because no source setting existed.

After:

- unset `ip_source` preserves the previous behavior;
- `ip_source = "connect_info"` uses the TCP peer address;
- header-based values such as `rightmost_x_forwarded_for` and `cf_connecting_ip` opt into the matching secure source and log a startup warning reminding operators to use a trusted reverse proxy;
- deployment docs explain which source to use for direct TCP, Unix sockets, and trusted reverse proxies;
- reload rejects `ip_source` changes until restart.

Closes #427.

## Test plan

- `git diff --check`
- `rustup run nightly rustfmt --check src/macros/config.rs src/macros/implement.rs src/macros/mod.rs src/core/config/mod.rs src/core/config/check.rs src/router/layers.rs`
- `cargo test -p tuwunel_macros`
- `cargo test -p tuwunel_core --no-default-features -- config::tests`
- `cargo test -p tuwunel_router --no-default-features -- layers::tests`
- `cargo check -p tuwunel_macros`
- `cargo clippy -p tuwunel_macros -- -D warnings`
- `cargo check -p tuwunel_core --no-default-features`
- `cargo check -p tuwunel_router --no-default-features`
- `cargo clippy -p tuwunel_core --no-default-features -- -D warnings`
- `cargo clippy -p tuwunel_core --no-default-features --tests -- -D warnings`
- `cargo clippy -p tuwunel_router --no-default-features -- -D warnings`
- `cargo clippy -p tuwunel_router --no-default-features --tests -- -D warnings`
- `lychee docs/deploying/generic.md docs/deploying/reverse-proxy-caddy.md docs/deploying/reverse-proxy-nginx.md docs/deploying/reverse-proxy-traefik.md` (31 links checked, 0 errors, 3 redirects)
- Confirmed the example remains `#ip_source = "connect_info"` and does not regenerate to `#ip_source = unset`.

On this local macOS checkout, router-targeted commands used `CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk/usr/include/c++/v1` because the local `clang++` installation did not find libc++ headers by default.
