### PR TITLE
docs: Add Authentik section

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,10 +4,4 @@ The release pipeline `Main` (main.yml) and its subroutines defined in the other 
 description for the underlying self-hosted build system in  `/docker`. In other words, this is a sort of
 terminal, a "thin-client" with a display and a keyboard for our docker mainframe. We minimize
 vendor-lockin and duplication with other services by limiting everything here to only what is
-essential for driving the docker builder.
-
-Though we slightly relax the above by specifying details of the actual CI pipeline, the 
-control-flow logic to go from some input event to some output or release here. This gives us
-better integration  with github, like granular progress indications by breaking up operations
-as individual jobs and workflows within the pipeline. This means we'll have duplicate logic
-with other services, but only as it relates to high-level control flow.
+essential for driving the docker builder. See: [documentation](../../docs/development/testing/workflows.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Enterprise JWT](authentication/jwt.md)
   - [Identity Providers](authentication/providers.md)
     - [Authelia](authentication/providers/authelia.md)
+    - [Authentik](authentication/providers/authentik.md)
     - [Keycloak](authentication/providers/keycloak.md)
 - [Multimedia and Storage](media.md)
   - [Storage Providers](media/storage.md)

--- a/docs/authentication/providers.md
+++ b/docs/authentication/providers.md
@@ -8,6 +8,7 @@ maps their identity to a Matrix account.
 ### Provider guides
 
 - [Authelia](providers/authelia.md)
+- [Authentik](providers/authentik.md)
 - [Keycloak](providers/keycloak.md)
 - _Please contribute documentation for yours here!_
 

--- a/docs/authentication/providers/authentik.md
+++ b/docs/authentication/providers/authentik.md
@@ -1,0 +1,165 @@
+# Authentik
+
+> [!IMPORTANT]
+> This guide is based on Authentik version 2026.2.2
+
+## Authentik configuration
+
+Create a provider and application for tuwunel. From the Admin interface, select
+**Applications** > **Applications** > **Create with Provider**.
+
+Go through each step of the "New application dialog":
+
+### Application
+
+- Application name: select the user-facing name of your server on the Authentik
+  side
+- Slug: this will be part of the `base_url` in your tuwunel configuration
+
+### Choose a provider
+
+Select **OAuth2/OpenID Provider**.
+
+### Configure provider
+
+1. Provider Name: this can be left to the default value
+1. Authorization flow: if you have not created custom flows, either of the two
+   built-in flows can be used depending on desired behaviour
+1. **Client ID** and **Client secret**: these will be generated for you. Save
+   these values as you will need them in your tuwunel configuration
+1. **Redirect URIs/Origins**: set this to
+   `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`
+   replacing `<your.matrix.example.com>` with tuwunel's public (sub)domain and
+   `<client_id>` with the value from the previous step
+1. Other values can be left as default
+
+### Configure bindings
+
+Optional: set policies if you want to restrict access to tuwunel to only certain
+of your Authentik users.
+
+### Review and Submit Application
+
+Verify all information is correct and press "Submit".
+
+## Tuwunel configuration
+
+Add the following to your `tuwunel.toml`:
+
+```toml
+[[global.identity_provider]]
+brand = "Authentik"
+client_id = "<client_id>" # Replace with the Client ID from Authentik
+client_secret = "<client_secret>" # Replace with the Client secret from Authentik
+callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>" # Replace with the same Callback URL you configure in Authentik
+issuer_url = "https://<your.authentik.example.com>/application/o/<slug>" # Replace with your Authentik (sub)domain and the slug you selected above
+base_path = "/application/o/<slug>" # Replace with the slug you selected above
+
+# Optional items
+#name = "Authentik"
+#unique_id_fallbacks = false # prevent randomly generated matrix usernames if none are available
+```
+
+See the
+[Authentik OAuth 2.0/OIDC documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/)
+for full details on the provider side.
+
+## Setting up different Authentik and tuwunel usernames
+
+By default, tuwunel will assign the localpart of a username [based on
+Authentik's userinfo][user-ids-from-claims]. By default, the user's Authentik
+username will be served as the `preferred_username` to tuwunel. For example,
+user `foo` would be assigned the account `@foo:example.com` if it is available.
+
+[user-ids-from-claims]:
+    ../providers.md#how-tuwunel-derives-matrix-user-ids-from-claims
+
+This behaviour can be modified using a custom Authentik mapping.
+
+> [!NOTE]
+> For example, this configuration would allow Authentik user `foo` to receive
+> the matrix username `@bar:example.com`.
+
+### Create a custom mapping for tuwunel
+
+From the Authentik Admin interface, select **Customization** > **Property
+Mappings** > **Create**.
+
+When prompted to select a type, choose **Scope Mapping**.
+
+In the "Create Scope Mapping" dialog, set the Scope name to `profile`.
+
+In "Expression", provide a Python expression that will return a dictionary of
+userinfo entries. For example, to return a custom user attribute
+`matrix_localpart` as the preferred username if it is set, enter:
+
+```python
+if "matrix_localpart" in request.user.attributes:
+  return {
+    "name": request.user.name,
+    "given_name": request.user.name,
+    "preferred_username": request.user.attributes["matrix_localpart"],
+    "nickname": request.user.attributes["matrix_localpart"],
+    "groups": [group.name for group in request.user.ak_groups.all()],
+}
+else:
+  return {
+    "name": request.user.name,
+    "given_name": request.user.name,
+    "preferred_username": request.user.username,
+    "nickname": request.user.username,
+    "groups": [group.name for group in request.user.ak_groups.all()],
+}
+```
+
+Take note of the **Name** you selected and click **Finish**.
+
+### Replace the default profile mapping in your tuwunel provider
+
+From the Admin interface, select **Applications** > **Providers** and click on
+the "Edit" icon for your tuwunel provider.
+
+Expand the **Advanced protocol settings** section and scroll to **Scope**.
+
+In **Available Scopes**, search for the **Name** of your custom mapping, select
+it, and add it to the **Selected Scopes** with the right arrow (`>`).
+
+In **Selected Scopes**, remove the
+`authentik default OAuth Mapping: OpenID 'profile'` by selecting it and moving
+it out with the left arrow (`<`).
+
+Complete the dialog by clicking **Update**.
+
+### Assign a custom attribute to a user
+
+From the Admin interface, select **Directory** > **Users** and click on the
+desired user. Under **Actions**, click **Edit**.
+
+Under **Attributes**, add a custom attribute:
+
+```yaml
+matrix_localpart: bar
+```
+
+Complete the dialog by clicking **Update**.
+
+> [!TIP]
+> Users can be allowed to set a custom attribute themselves using a custom
+> Prompt within a Stage Configuration flow, but this is beyond the scope of this
+> guide.
+
+### Test the custom mapping
+
+From the Admin interface, select **Applications** > **Providers**, click on the
+link of your tuwunel provider, then click **Preview**.
+
+Under **Preview for user**, select user `foo`.
+
+The JWT payload should contain the custom matrix localpart:
+
+```json
+{
+    "preferred_username": "bar",
+    "nickname": "bar"
+}
+``

--- a/docs/authentication/providers/authentik.md
+++ b/docs/authentication/providers/authentik.md
@@ -1,109 +1,110 @@
 # Authentik
 
-> [!IMPORTANT]
-> This guide is based on Authentik version 2026.2.2
+[Authentik](https://goauthentik.io/) is a self-hostable identity provider that
+speaks OpenID Connect.
+
+> [!NOTE]
+> This guide was written against `Authentik 2025.10`; the flow is the same on
+> all later versions through at least `2026.2`.
 
 ## Authentik configuration
 
-Create a provider and application for tuwunel. From the Admin interface, select
-**Applications** > **Applications** > **Create with Provider**.
+From the admin interface, navigate to **Applications** > **Applications** and
+select **Create with Provider**. Review the items below and click **Submit**.
 
-Go through each step of the "New application dialog":
+##### Application
 
-### Application
+- **Application name**: the user-facing name shown to your users on the
+  Authentik side.
+- **Slug**: appears in the issuer URL on the tuwunel side. Pick something
+  short and stable, such as `tuwunel`.
 
-- Application name: select the user-facing name of your server on the Authentik
-  side
-- Slug: this will be part of the `base_url` in your tuwunel configuration
-
-### Choose a provider
+##### Provider
 
 Select **OAuth2/OpenID Provider**.
 
-### Configure provider
+- **Authorization flow**: any built-in flow is fine if you have not created
+  custom ones.
+- **Client ID** and **Client Secret**: Authentik generates these. Save both
+  values — tuwunel needs them.
+- **Redirect URIs/Origins**: set this to
+  `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`,
+  substituting your Matrix server's public hostname and the **Client ID** from
+  the previous step.
+- All other fields can stay at their defaults.
 
-1. Provider Name: this can be left to the default value
-1. Authorization flow: if you have not created custom flows, either of the two
-   built-in flows can be used depending on desired behaviour
-1. **Client ID** and **Client secret**: these will be generated for you. Save
-   these values as you will need them in your tuwunel configuration
-1. **Redirect URIs/Origins**: set this to
-   `https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>`
-   replacing `<your.matrix.example.com>` with tuwunel's public (sub)domain and
-   `<client_id>` with the value from the previous step
-1. Other values can be left as default
+##### Bindings
 
-### Configure bindings
+Optional. Add policies here to restrict tuwunel access to a subset of your
+Authentik users.
 
-Optional: set policies if you want to restrict access to tuwunel to only certain
-of your Authentik users.
-
-### Review and Submit Application
-
-Verify all information is correct and press "Submit".
 
 ## Tuwunel configuration
 
-Add the following to your `tuwunel.toml`:
+Add an `[[global.identity_provider]]` entry to your `tuwunel.toml`:
 
 ```toml
 [[global.identity_provider]]
 brand = "Authentik"
-client_id = "<client_id>" # Replace with the Client ID from Authentik
-client_secret = "<client_secret>" # Replace with the Client secret from Authentik
-callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>" # Replace with the same Callback URL you configure in Authentik
-issuer_url = "https://<your.authentik.example.com>/application/o/<slug>" # Replace with your Authentik (sub)domain and the slug you selected above
-base_path = "/application/o/<slug>" # Replace with the slug you selected above
-
-# Optional items
-#name = "Authentik"
-#unique_id_fallbacks = false # prevent randomly generated matrix usernames if none are available
+client_id = "<client_id>"
+client_secret = "<client_secret>"
+issuer_url = "https://<your.authentik.example.com>/application/o/<slug>/"
+callback_url = "https://<your.matrix.example.com>/_matrix/client/unstable/login/sso/callback/<client_id>"
 ```
 
-See the
-[Authentik OAuth 2.0/OIDC documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/)
-for full details on the provider side.
+`issuer_url` is the application's slug-based path with a trailing slash. This
+is the value Authentik returns as the `iss` claim in issued tokens, and tuwunel
+discovers all other endpoints from
+`<issuer_url>.well-known/openid-configuration` automatically.
 
-## Setting up different Authentik and tuwunel usernames
+If your Authentik instance reports a different `iss` — for example when running
+behind a path prefix, or with a non-default **Issuer Mode** on the provider —
+override discovery directly:
 
-By default, tuwunel will assign the localpart of a username [based on
-Authentik's userinfo][user-ids-from-claims]. By default, the user's Authentik
-username will be served as the `preferred_username` to tuwunel. For example,
-user `foo` would be assigned the account `@foo:example.com` if it is available.
+```toml
+discovery_url = "https://<your.authentik.example.com>/application/o/<slug>/.well-known/openid-configuration"
+```
+
+> [!TIP]
+> For the full set of identity provider options see the
+> [providers reference](../providers.md). For the Authentik side, see the
+> [OAuth2/OpenID Connect provider documentation](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/).
+
+## Customising the Matrix localpart
+
+By default tuwunel derives a new user's Matrix localpart from the
+`preferred_username` claim Authentik returns — see
+[How tuwunel derives Matrix user IDs from claims][user-ids-from-claims]. The
+default Authentik mapping populates `preferred_username` with the user's
+Authentik username, so user `foo` becomes `@foo:example.com`.
 
 [user-ids-from-claims]:
     ../providers.md#how-tuwunel-derives-matrix-user-ids-from-claims
 
-This behaviour can be modified using a custom Authentik mapping.
+To decouple the two — for example to give Authentik user `foo` the localpart
+`@bar:example.com` — replace Authentik's default `profile` scope with a custom
+property mapping that returns the localpart you want.
 
-> [!NOTE]
-> For example, this configuration would allow Authentik user `foo` to receive
-> the matrix username `@bar:example.com`.
+### Create a custom property mapping
 
-### Create a custom mapping for tuwunel
+In the admin interface, navigate to **Customization** > **Property Mappings**
+and select **Create**. Choose **Scope Mapping**, then set the **Scope name** to
+`profile`.
 
-From the Authentik Admin interface, select **Customization** > **Property
-Mappings** > **Create**.
-
-When prompted to select a type, choose **Scope Mapping**.
-
-In the "Create Scope Mapping" dialog, set the Scope name to `profile`.
-
-In "Expression", provide a Python expression that will return a dictionary of
-userinfo entries. For example, to return a custom user attribute
-`matrix_localpart` as the preferred username if it is set, enter:
+In **Expression**, return a dictionary that exposes the desired localpart as
+`preferred_username`. The example below uses a per-user `matrix_localpart`
+attribute when set, falling back to the Authentik username:
 
 ```python
 if "matrix_localpart" in request.user.attributes:
-  return {
-    "name": request.user.name,
-    "given_name": request.user.name,
-    "preferred_username": request.user.attributes["matrix_localpart"],
-    "nickname": request.user.attributes["matrix_localpart"],
-    "groups": [group.name for group in request.user.ak_groups.all()],
-}
-else:
-  return {
+    return {
+        "name": request.user.name,
+        "given_name": request.user.name,
+        "preferred_username": request.user.attributes["matrix_localpart"],
+        "nickname": request.user.attributes["matrix_localpart"],
+        "groups": [group.name for group in request.user.ak_groups.all()],
+    }
+return {
     "name": request.user.name,
     "given_name": request.user.name,
     "preferred_username": request.user.username,
@@ -112,54 +113,40 @@ else:
 }
 ```
 
-Take note of the **Name** you selected and click **Finish**.
+Note the **Name** you give the mapping, then click **Finish**.
 
-### Replace the default profile mapping in your tuwunel provider
+### Replace the default profile mapping
 
-From the Admin interface, select **Applications** > **Providers** and click on
-the "Edit" icon for your tuwunel provider.
+In **Applications** > **Providers**, edit your tuwunel provider, expand
+**Advanced protocol settings**, and find the **Scopes** field.
 
-Expand the **Advanced protocol settings** section and scroll to **Scope**.
+Move your new mapping from **Available Scopes** into **Selected Scopes** with
+the right arrow (`>`), then move `authentik default OAuth Mapping: OpenID
+'profile'` out with the left arrow (`<`). Click **Update**.
 
-In **Available Scopes**, search for the **Name** of your custom mapping, select
-it, and add it to the **Selected Scopes** with the right arrow (`>`).
+### Set the attribute on a user
 
-In **Selected Scopes**, remove the
-`authentik default OAuth Mapping: OpenID 'profile'` by selecting it and moving
-it out with the left arrow (`<`).
-
-Complete the dialog by clicking **Update**.
-
-### Assign a custom attribute to a user
-
-From the Admin interface, select **Directory** > **Users** and click on the
-desired user. Under **Actions**, click **Edit**.
-
-Under **Attributes**, add a custom attribute:
+In **Directory** > **Users**, edit the user and add to **Attributes**:
 
 ```yaml
 matrix_localpart: bar
 ```
 
-Complete the dialog by clicking **Update**.
+Click **Update**.
 
 > [!TIP]
-> Users can be allowed to set a custom attribute themselves using a custom
-> Prompt within a Stage Configuration flow, but this is beyond the scope of this
-> guide.
+> Users can be allowed to set the attribute themselves through a custom prompt
+> in a Stage Configuration flow. See Authentik's documentation for details.
 
-### Test the custom mapping
+### Verify
 
-From the Admin interface, select **Applications** > **Providers**, click on the
-link of your tuwunel provider, then click **Preview**.
-
-Under **Preview for user**, select user `foo`.
-
-The JWT payload should contain the custom matrix localpart:
+In **Applications** > **Providers**, open your provider and click **Preview**.
+Select the user under **Preview for user**; the JWT payload should contain the
+customised localpart:
 
 ```json
 {
     "preferred_username": "bar",
     "nickname": "bar"
 }
-``
+```

--- a/docs/development/testing/complement.md
+++ b/docs/development/testing/complement.md
@@ -74,12 +74,6 @@ docker/bake.sh complement-tester complement-testee && \
 The argument to `complement.sh` becomes the `complement_run` regex, passed to
 Go's test runner via `-run`.
 
-##### Keep a failed run's containers for inspection
-
-```bash
-complement_dirty=1 docker/complement.sh
-```
-
 ##### View logs from the last run
 
 ```bash

--- a/docs/development/testing/workflows.md
+++ b/docs/development/testing/workflows.md
@@ -36,10 +36,10 @@ The `init` job runs before everything else. It has two responsibilities:
    | Runner | Reserved space | Max space |
    |---|---|---|
    | `het` | 192 GB | 384 GB |
-   | `aws` | 48 GB | 64 GB |
+   | `aws` | 48 GB  | 64 GB  |
    | `gcp` | 160 GB | 192 GB |
 
-2. **Emit 40+ output variables** that all downstream jobs consume as inputs.
+2. **Emit output variables** that all downstream jobs consume as inputs.
    These control which matrix dimensions to test, which phases to enable, and
    metadata like the pages URL and release upload URL.
 


### PR DESCRIPTION
I am not entirely sure what the minimum functioning tuwunel configuration for Authentik is. I would particularly appreciate any corrections/modifications to:

https://github.com/alametti/tuwunel/blob/653eb4ce1f2e6374bc39a50de174664b34af1ff4/docs/authentication/providers/authentik.md?plain=1#L49-L61