### PR TITLE
docs: fix example nginx config for root domain delegation

### DIFF
--- a/docs/deploying/root-domain-delegation.md
+++ b/docs/deploying/root-domain-delegation.md
@@ -120,8 +120,10 @@ server {
   ~listen [::]:443 ssl http2;
   server_name example.com;
 
-  location /.well-known/matrix {
-    proxy_pass http://tuwunel/.well-known/matrix;
+  set $backend "tuwunel";
+
+  location /.well-known/matrix/ {
+    proxy_pass http://$backend:6167$request_uri;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_ssl_server_name on;
   }


### PR DESCRIPTION
The NGINX example should now work in a real NGINX configuration by appending `$request_uri` to the URI in `proxy_pass`.

Also added the default port that Tuwunel exposes on, which is 6167.

And as a plus:

Defining `set $backend "tuwunel"` and then referencing $backend in the `proxy_pass` directive allows NGINX to avoid crashing the whole reverse proxy (and possibly other services) if the tuwunel container name cannot be resolved within Docker DNS.