### PR TITLE
Extra authorization parameters for the upstream OIDC provider

### DIFF
--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -1,6 +1,6 @@
 mod uiaa;
 
-use std::{borrow::Cow, net::IpAddr, time::Duration};
+use std::{borrow::Cow, collections::BTreeMap, net::IpAddr, time::Duration};
 
 use axum::extract::State;
 use axum_extra::extract::cookie::{Cookie, SameSite};
@@ -179,6 +179,17 @@ async fn handle_sso_login(
 		.map(|mut location| {
 			let query = serde_html_form::to_string(&query).ok();
 			location.set_query(query.as_deref());
+			if !provider.extra_authorization_parameters.is_empty() {
+				// Overlay extra_authorization_parameters onto the base query, overriding
+				// duplicate keys.
+				let merged: BTreeMap<String, String> = location
+					.query_pairs()
+					.map(|(k, v)| (k.into_owned(), v.into_owned()))
+					.chain(provider.extra_authorization_parameters.clone())
+					.collect();
+				location.set_query(None);
+				location.query_pairs_mut().extend_pairs(&merged);
+			}
 			location
 		})
 		.ok_or_else(|| {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -3087,6 +3087,19 @@ pub struct IdentityProvider {
 	/// default: true
 	#[serde(default = "true_fn")]
 	pub check_cookie: bool,
+
+	/// Extra query parameters appended to every authorization request sent to
+	/// the identity provider.
+	///
+	/// E.g. to force re-authentication even if IdP cookies are present:
+	/// ```toml
+	/// [[global.identity_provider]]
+	/// extra_authorization_parameters = { prompt = "login" }
+	/// ```
+	///
+	/// default: {}
+	#[serde(default)]
+	pub extra_authorization_parameters: BTreeMap<String, String>,
 }
 
 impl IdentityProvider {

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2629,6 +2629,16 @@
 #
 #check_cookie = true
 
+# Extra query parameters appended to every authorization request sent to the identity provider.
+#
+# E.g. to force re-authentication even if IdP cookies are present:
+# ```toml
+# [[global.identity_provider]]
+# extra_authorization_parameters = { prompt = "login" }
+# ```
+#
+#extra_authorization_parameters = {}
+
 
 
 #[global.storage_provider.<ID>.local]


### PR DESCRIPTION
## Problem

It is impossible to switch accounts when using an OIDC provider.

My stack: tuwunel, logto, Element X.

When I log out and try to log in again, the app silently logs me into the old account without prompting for a password, because the Logto cookie is still valid in the WebView.

The standard fix is to pass a `prompt=login` query parameter to the IdP, which forces re-authentication.

---

Tuwunel receives `prompt` from the client app but currently ignores it:

**authorize.rs:**
```rust
#[derive(Debug, Deserialize)]
pub(crate) struct AuthorizeParams {
    ...
    #[serde(default, rename = "prompt")]
    _prompt: Option<String>,
}
```

We could forward this value to the IdP but it is not sufficient. Element X sends `prompt=consent`, which still logs the user in silently.

## Solution

I suggest adding `extra_authorization_parameters` to the config. They are added as query parameters during authentication. Example:

```toml
[[global.identity_provider]]
extra_authorization_parameters = { prompt = "login" }
```

There are many other OIDC parameters one can put here: `login_hint`, `domain_hint`, `max_age`, `hd`, `acr_values`, `ui_locales`, etc