### PR TITLE
fix a potential issue with firefox-based browsers when NAT loopback is not supported on the router

### DIFF
--- a/docs/calls/matrix_rtc.md
+++ b/docs/calls/matrix_rtc.md
@@ -97,7 +97,7 @@ rtc:
   port_range_start: 50100
   port_range_end: 50200
   use_external_ip: true
-  enable_loopback_candidate: false
+  enable_loopback_candidate: true
 keys:
   MRTCKEY: MRTCSECRET
 ```

--- a/docs/calls/matrix_rtc.md
+++ b/docs/calls/matrix_rtc.md
@@ -97,10 +97,17 @@ rtc:
   port_range_start: 50100
   port_range_end: 50200
   use_external_ip: true
-  enable_loopback_candidate: true
+  enable_loopback_candidate: false
 keys:
   MRTCKEY: MRTCSECRET
 ```
+
+> [!NOTE]
+> The `enable_loopback_candidate` option above causes Livekit to include
+> `127.0.0.1` and `::1` as ICE host candidates. It is intended for deployments
+> where the public IP is mapped to the loopback interface on the host. Set it
+> to `true` if you have that specific topology. If calls fail only for clients
+> on the same LAN as the server, see the Troubleshooting section.
 
 ## 3. Configure .well-known
 


### PR DESCRIPTION
Hello, 

For the past few weeks firefox users where not able to make call using the browsers versions of element call on my homeserver (for unknown reasons electron apps and chromium based browser where unaffected by any of the changes described bellow ¯\\\_(ツ)\_/¯). 

After some troubleshooting I realized it was one of the MANY consequences of my route not supporting NAT loopback (ability to resolve it's own public IP address). While overriding `/etc/hosts` and setting `network_mode: "host"` on relevant dockers to redirect all my subdomains to my local IP did work for external client, however it didn't work for local clients. 

This setting fixed the issue for both local and external clients on all browsers. with the added benefit of not needing to use `network_mode: "host"` nor changing `/etc/hosts` (at least for this particular issue).

Seeing as this should not hinder normal deployment but help in some niche scenario such as mine, it might be useful to set this setting as the default.

This alone doesn't make the whole tuwunel setup work nicely with routers without NAT loopback but it was is probably the related issue that took me the longest time to solve and should help anyone that are in similar situations.