### PR TITLE
fix(sync): refresh cached sliding-sync list ranges

### DIFF
--- a/src/service/sync/mod.rs
+++ b/src/service/sync/mod.rs
@@ -1,5 +1,8 @@
 mod watch;
 
+#[cfg(test)]
+mod tests;
+
 use std::{
 	collections::{BTreeMap, btree_map::Entry},
 	sync::Arc,
@@ -291,6 +294,7 @@ fn update_cache_lists(request: &Request, cached: &mut Self) {
 
 #[implement(Connection)]
 fn update_cache_list(request: &request::List, cached: &mut request::List) {
+	cached.ranges.clone_from(&request.ranges);
 	list_or_sticky(&request.room_details.required_state, &mut cached.room_details.required_state);
 
 	match (&request.filters, &mut cached.filters) {

--- a/src/service/sync/tests.rs
+++ b/src/service/sync/tests.rs
@@ -1,0 +1,102 @@
+use ruma::{
+	UInt,
+	api::client::sync::sync_events::v5::{ListId, Ranges, Request, request},
+	events::StateEventType,
+};
+
+use super::Connection;
+
+const LIST_ID: &str = "main";
+
+#[test]
+fn update_cache_replaces_existing_list_ranges() {
+	let mut conn = Connection::default();
+
+	conn.update_cache(&request_with_list(list_with_ranges(&[(0, 19)])));
+	conn.update_cache(&request_with_list(list_with_ranges(&[(20, 39)])));
+
+	assert_cached_ranges(&conn, &[(20, 39)]);
+}
+
+#[test]
+fn update_cache_allows_empty_ranges_to_replace_existing_ranges() {
+	let mut conn = Connection::default();
+
+	conn.update_cache(&request_with_list(list_with_ranges(&[(0, 19)])));
+	conn.update_cache(&request_with_list(list_with_ranges(&[])));
+
+	assert_cached_ranges(&conn, &[]);
+}
+
+#[test]
+fn update_cache_keeps_ranges_when_list_is_omitted() {
+	let mut conn = Connection::default();
+
+	conn.update_cache(&request_with_list(list_with_ranges(&[(0, 19)])));
+	conn.update_cache(&Request::new());
+
+	assert_cached_ranges(&conn, &[(0, 19)]);
+}
+
+#[test]
+fn update_cache_preserves_sticky_list_metadata() {
+	let mut conn = Connection::default();
+	let required_state = vec![(StateEventType::RoomMember, "$LAZY".into())];
+
+	conn.update_cache(&request_with_list(list_with_required_state(
+		&[(0, 19)],
+		required_state.clone(),
+	)));
+	conn.update_cache(&request_with_list(list_with_ranges(&[(20, 39)])));
+
+	let cached = conn
+		.lists
+		.get(&list_id())
+		.expect("list must remain cached");
+
+	assert_eq!(cached.room_details.required_state, required_state);
+	assert_cached_ranges(&conn, &[(20, 39)]);
+}
+
+fn request_with_list(list: request::List) -> Request {
+	let mut request = Request::new();
+
+	request.lists.insert(list_id(), list);
+
+	request
+}
+
+fn list_with_ranges(ranges: &[(u64, u64)]) -> request::List {
+	list_with_required_state(ranges, Vec::new())
+}
+
+fn list_with_required_state(
+	ranges: &[(u64, u64)],
+	required_state: Vec<(StateEventType, ruma::events::StateKey)>,
+) -> request::List {
+	request::List {
+		ranges: ranges_from_u64(ranges),
+		room_details: request::ListConfig { required_state, ..Default::default() },
+		..Default::default()
+	}
+}
+
+fn assert_cached_ranges(conn: &Connection, expected: &[(u64, u64)]) {
+	let cached = conn
+		.lists
+		.get(&list_id())
+		.expect("list must be cached");
+
+	assert_eq!(cached.ranges, ranges_from_u64(expected));
+}
+
+fn ranges_from_u64(ranges: &[(u64, u64)]) -> Ranges {
+	ranges
+		.iter()
+		.map(|&(start, end)| (uint(start), uint(end)))
+		.collect()
+}
+
+fn uint(value: u64) -> UInt { UInt::new(value).expect("range value must fit UInt") }
+
+fn list_id() -> ListId { LIST_ID.into() }


### PR DESCRIPTION
## Summary

Fixes sliding-sync list range caching so a client can change which part of a list it is asking for.

Tuwunel keeps sliding-sync request data cached per connection. That is useful for sticky request fields, but list ranges are different: when a request explicitly includes a list, its `ranges` describe the client’s current visible window. If the client scrolls from `[0, 19]` to `[20, 39]`, the cached list range needs to change too.

Before this change, an existing cached list kept its original range. In practice, the first requested range could stick around indefinitely, so later scroll/range updates were ignored.

## What changed

- Update cached list ranges whenever a list is explicitly present in the request.
- Keep omitted lists sticky, so a request that does not mention a list does not clear it.
- Preserve existing sticky behavior for list metadata such as `required_state`, filters, and extensions.
- Treat an explicit empty range list as authoritative, matching the selector’s current behavior where `[]` means full-list selection.

## Why

This makes the server-side cache match what sliding-sync clients are actually asking for.

A list range is a moving window over a room list, not a room subscription. When the client changes that window, Tuwunel should use the new window. Keeping the old range can hide problems in small accounts and break larger accounts where users scroll or where the visible range changes over time.

## Compatibility

For explicit list updates, this matches Synapse’s sliding-sync list handling: the ranges in the current request define the active room window for that list. If a client changes a list from `[0, 19]` to `[20, 39]`, the old range should no longer remain active.

Tuwunel differs internally because it keeps a per-connection request cache. This PR does not change that existing sticky-cache model for omitted lists; it only fixes the merge behavior so that lists explicitly present in a request replace their cached ranges.

## Tests

Added focused cache-level tests for:

- replacing an existing list range, e.g. `[0, 19]` to `[20, 39]`
- replacing a non-empty range with `[]`
- keeping cached ranges when a request omits `lists`
- preserving sticky metadata such as `required_state`

Verified with:

`cargo test -p tuwunel_service sync::tests::`