### PR TITLE
Update matrix_rtc.md to bring traefik in line with nginx and caddy.

### DIFF
--- a/docs/calls/matrix_rtc.md
+++ b/docs/calls/matrix_rtc.md
@@ -288,7 +288,7 @@ services:
     labels:
         - "traefik.enable=true"
         - "traefik.http.routers.matrixrtcjwt.entrypoints=websecure"
-        - "traefik.http.routers.matrixrtcjwt.rule=Host(`matrix-rtc.yourdomain.com`) && PathPrefix(`/sfu/get`) || PathPrefix(`/healthz`)"
+        - "traefik.http.routers.matrixrtcjwt.rule=Host(`matrix-rtc.yourdomain.com`) && (PathPrefix(`/sfu/get`) || PathPrefix(`/healthz`) || PathPrefix(`/get_token`))"
         - "traefik.http.routers.matrixrtcjwt.tls=true"
         - "traefik.http.routers.matrixrtcjwt.service=matrixrtcjwt"
         - "traefik.http.services.matrixrtcjwt.loadbalancer.server.port=8081"

--- a/docs/calls/matrix_rtc.md
+++ b/docs/calls/matrix_rtc.md
@@ -316,7 +316,7 @@ http:
         matrixrtcjwt:
             entryPoints:
                 - "websecure"
-            rule: "Host(`matrix-rtc.yourdomain.com`) && PathPrefix(`/sfu/get`) || PathPrefix(`/healthz`)"
+            rule: "Host(`matrix-rtc.yourdomain.com`) && (PathPrefix(`/sfu/get`) || PathPrefix(`/healthz`) || PathPrefix(`/get_token`))"
             tls:
                 certResolver: "yourcertresolver" # change to your cert resolver's name
             service: matrixrtcjwt


### PR DESCRIPTION
This PR adds the `/get_token` endpoint to the traefik config for MatrixRTC calling.

Thanks to Cardes for pointing out the omission in Matrix chat.