### PR TITLE
fix: replace ready_try_take_while with ready_try_filter in pdu_ids_near_ts

### DIFF
--- a/src/service/rooms/timeline/pdus.rs
+++ b/src/service/rooms/timeline/pdus.rs
@@ -90,7 +90,8 @@ pub fn pdu_ids_near_ts(
 				| Forward => Left(self.db.roomid_ts_pducount.stream_from(&key)),
 				| Backward => Right(self.db.roomid_ts_pducount.rev_stream_from(&key)),
 			}
-			.ready_try_filter(move |((room_id_, _), _): &KeyVal<'_>| room_id == *room_id_)
+			.ready_try_skip_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id != *room_id_))
+				.ready_try_take_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id == *room_id_))
 			.map_ok(move |((_, ts), count)| {
 				(MilliSecondsSinceUnixEpoch(ts), PduId { shortroomid, count: count.into() })
 			})

--- a/src/service/rooms/timeline/pdus.rs
+++ b/src/service/rooms/timeline/pdus.rs
@@ -90,7 +90,7 @@ pub fn pdu_ids_near_ts(
 				| Forward => Left(self.db.roomid_ts_pducount.stream_from(&key)),
 				| Backward => Right(self.db.roomid_ts_pducount.rev_stream_from(&key)),
 			}
-			.ready_try_take_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id == *room_id_))
+			.ready_try_filter(move |((room_id_, _), _): &KeyVal<'_>| room_id == *room_id_)
 			.map_ok(move |((_, ts), count)| {
 				(MilliSecondsSinceUnixEpoch(ts), PduId { shortroomid, count: count.into() })
 			})


### PR DESCRIPTION
### Problem

`/timestamp_to_event` (MSC3030) returns `M_NOT_FOUND` for many valid timestamps, especially older ones.

### Root Cause

`pdu_ids_near_ts` uses `ready_try_take_while` to filter by room_id. The database index is keyed by `(RoomId, timestamp)`, so keys from different rooms are interleaved. When the scan hits a key from a different room, `take_while` **terminates** the stream immediately, returning no results.

For `prefix`-based scans (e.g., `starts_with`), `take_while` is correct because non-matching keys are contiguous. For interleaved keys like `(RoomId, timestamp)`, `filter` must be used instead.

### Fix

Replace `ready_try_take_while` with `ready_try_filter` so non-matching room keys are skipped instead of terminating the stream.

### Testing

- `ts=Date.now()` (recent events) — works before and after
- `ts=May 30` (older events) — fails with `M_NOT_FOUND` before, works after