### PR TITLE
fix: use skip_while + take_while for room-scoped timestamp scan

### DIFF
--- a/src/service/rooms/timeline/pdus.rs
+++ b/src/service/rooms/timeline/pdus.rs
@@ -90,7 +90,8 @@ pub fn pdu_ids_near_ts(
 				| Forward => Left(self.db.roomid_ts_pducount.stream_from(&key)),
 				| Backward => Right(self.db.roomid_ts_pducount.rev_stream_from(&key)),
 			}
-			.ready_try_filter(move |((room_id_, _), _): &KeyVal<'_>| room_id == *room_id_)
+			.ready_try_skip_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id != *room_id_))
+				.ready_try_take_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id == *room_id_))
 			.map_ok(move |((_, ts), count)| {
 				(MilliSecondsSinceUnixEpoch(ts), PduId { shortroomid, count: count.into() })
 			})

--- a/src/service/rooms/timeline/pdus.rs
+++ b/src/service/rooms/timeline/pdus.rs
@@ -90,7 +90,7 @@ pub fn pdu_ids_near_ts(
 				| Forward => Left(self.db.roomid_ts_pducount.stream_from(&key)),
 				| Backward => Right(self.db.roomid_ts_pducount.rev_stream_from(&key)),
 			}
-			.ready_try_take_while(move |((room_id_, _), _): &KeyVal<'_>| Ok(room_id == *room_id_))
+			.ready_try_filter(move |((room_id_, _), _): &KeyVal<'_>| room_id == *room_id_)
 			.map_ok(move |((_, ts), count)| {
 				(MilliSecondsSinceUnixEpoch(ts), PduId { shortroomid, count: count.into() })
 			})


### PR DESCRIPTION
### Problem

`/timestamp_to_event` (MSC3030) returns `M_NOT_FOUND` for valid searches. 

### Root Cause

`pdu_ids_near_ts` scans the `roomid_ts_pducount` index keyed by `(RoomId, timestamp)`. Keys from different rooms are interleaved. When the scan starts at a position belonging to another room, `ready_try_take_while` **terminates** the stream on the first non-matching key, returning no results.

For prefix-based scans (`starts_with`) `take_while` is correct because non-matching keys are contiguous. For interleaved composite keys, the scan must skip over non-matching entries first.

### Fix

Replace the single `ready_try_take_while` with `ready_try_skip_while` (skip to target room) + `ready_try_take_while` (stop when room changes). This correctly bounds the stream to only keys belonging to the target room.