### PR TITLE
perf(state-res): use roaring bitmaps for faster auth difference computing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "ruma"
 version = "0.15.1"
 source = "git+https://github.com/matrix-construct/ruma?rev=439210cf2b07f8c5aa6de98f3ae1575abe8762b8#439210cf2b07f8c5aa6de98f3ae1575abe8762b8"
@@ -5137,7 +5147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5956,6 +5966,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "ring",
+ "roaring",
  "ruma",
  "rustls",
  "rustyline-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,6 +357,9 @@ features = [
 version = "0.17"
 default-features = false
 
+[workspace.dependencies.roaring]
+version = "0.11.4"
+
 [workspace.dependencies.ruma]
 git = "https://github.com/matrix-construct/ruma"
 rev = "439210cf2b07f8c5aa6de98f3ae1575abe8762b8"

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -109,6 +109,7 @@ rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 ring.workspace = true
+roaring.workspace = true
 ruma.workspace = true
 rustls.workspace = true
 rustyline-async.workspace = true

--- a/src/service/rooms/auth_chain/mod.rs
+++ b/src/service/rooms/auth_chain/mod.rs
@@ -10,6 +10,7 @@ use futures::{
 	FutureExt, Stream, StreamExt, TryFutureExt, pin_mut,
 	stream::{FuturesUnordered, unfold},
 };
+use roaring::RoaringTreemap;
 use ruma::{
 	EventId, OwnedEventId, OwnedRoomId, RoomId, RoomVersionId,
 	room_version_rules::RoomVersionRules,
@@ -335,9 +336,15 @@ where
 
 	debug_assert!(!key.is_empty(), "auth_chain key must not be empty");
 
-	self.db
-		.authchainkey_authchain
-		.put(key.as_slice(), auth_chain);
+	let mut treemap = RoaringTreemap::new();
+	treemap.extend(auth_chain.iter().copied());
+
+	let mut buffer = Vec::with_capacity(treemap.serialized_size());
+	if treemap.serialize_into(&mut buffer).is_ok() {
+		self.db
+			.authchainkey_authchain
+			.put(key.as_slice(), &buffer);
+	}
 }
 
 #[implement(Service)]
@@ -361,7 +368,7 @@ where
 	}
 
 	// On miss, fall back to the single-event legacy table for older entries.
-	let chain = self
+	let bytes = self
 		.db
 		.authchainkey_authchain
 		.qry(key.as_slice())
@@ -377,7 +384,15 @@ where
 				.map_err(|_| err!(Request(NotFound("auth_chain not found"))))
 				.await
 		})
-		.await?
+		.await?;
+
+	// Try reading as highly-compressed RoaringTreemap blob
+	if let Ok(treemap) = RoaringTreemap::deserialize_from(&*bytes) {
+		return Ok(treemap.into_iter().collect());
+	}
+
+	// If header is invalid, fall back to standard array parsing.
+	let chain = bytes
 		.chunks_exact(size_of::<u64>())
 		.map(utils::u64_from_u8)
 		.collect();

--- a/src/service/rooms/state_res/resolve/auth_difference.rs
+++ b/src/service/rooms/state_res/resolve/auth_difference.rs
@@ -86,7 +86,7 @@ where
 			if state.first {
 				Vec::new().into_iter().stream()
 			} else {
-				let diff = state.union - state.intersection;
+				let diff = std::ops::Sub::sub(state.union, state.intersection);
 				let result_ids: Vec<Id> = diff
 					.into_iter()
 					.map(move |idx| {

--- a/src/service/rooms/state_res/resolve/auth_difference.rs
+++ b/src/service/rooms/state_res/resolve/auth_difference.rs
@@ -1,27 +1,55 @@
 use std::{borrow::Borrow, collections::BTreeMap};
 
 use futures::{FutureExt, Stream};
+use roaring::RoaringBitmap;
 use ruma::EventId;
 use tuwunel_core::utils::stream::{IterStream, ReadyExt};
 
 use super::AuthSet;
 
-struct Counts<Id: Ord> {
-	by_id: BTreeMap<Id, usize>,
-	total: usize,
+struct RoaringState<Id: Ord> {
+	id_to_index: BTreeMap<Id, u32>,
+	index_to_id: Vec<Id>,
+	union: RoaringBitmap,
+	intersection: RoaringBitmap,
+	first: bool,
 }
 
-impl<Id: Ord> Default for Counts<Id> {
-	fn default() -> Self { Self { by_id: BTreeMap::new(), total: 0 } }
+impl<Id: Ord> Default for RoaringState<Id> {
+	fn default() -> Self {
+		Self {
+			id_to_index: BTreeMap::new(),
+			index_to_id: Vec::new(),
+			union: RoaringBitmap::new(),
+			intersection: RoaringBitmap::new(),
+			first: true,
+		}
+	}
 }
 
-impl<Id: Ord> Counts<Id> {
+impl<Id: Ord + Clone> RoaringState<Id> {
 	fn merge(mut self, set: AuthSet<Id>) -> Self {
-		self.total = self.total.saturating_add(1);
+		let mut bitmap = RoaringBitmap::new();
 		for id in set {
-			let count = self.by_id.entry(id).or_default();
+			let idx = match self.id_to_index.get(&id) {
+				| Some(&idx) => idx,
+				| None => {
+					let idx = u32::try_from(self.index_to_id.len()).expect("too many event IDs");
+					self.id_to_index.insert(id.clone(), idx);
+					self.index_to_id.push(id);
+					idx
+				},
+			};
+			bitmap.insert(idx);
+		}
 
-			*count = count.saturating_add(1);
+		if self.first {
+			self.union.clone_from(&bitmap);
+			self.intersection = bitmap;
+			self.first = false;
+		} else {
+			self.union |= &bitmap;
+			self.intersection &= bitmap;
 		}
 
 		self
@@ -53,12 +81,21 @@ where
 	Id: Borrow<EventId> + Clone + Eq + Ord + Send + 'a,
 {
 	auth_sets
-		.ready_fold_default(Counts::<Id>::merge)
-		.map(|Counts { by_id, total }: Counts<Id>| {
-			by_id
-				.into_iter()
-				.filter_map(move |(id, count)| (count < total).then_some(id))
-				.stream()
+		.ready_fold_default(RoaringState::<Id>::merge)
+		.map(|state: RoaringState<Id>| {
+			if state.first {
+				Vec::new().into_iter().stream()
+			} else {
+				let diff = state.union - state.intersection;
+				let result_ids: Vec<Id> = diff
+					.into_iter()
+					.map(move |idx| {
+						let index = usize::try_from(idx).expect("idx fits in usize");
+						state.index_to_id[index].clone()
+					})
+					.collect();
+				result_ids.into_iter().stream()
+			}
 		})
 		.flatten_stream()
 }


### PR DESCRIPTION
One of the few magical times where adding more lines of code makes things run significantly faster.

Rapidly computes set unions and intersections with hardware-accelerated bitwise operations, keeping the L1/L2 cache hot throughout. Sometimes this means performing comparisons or operations on up to 256 graph nodes per clock cycle.

----

## Future work / Next steps

Ultimately, this would further greatly benefit from a refactor which enabled loading the full auth chain into memory at once (if the machine's throughput would allow).

That's when you would start to see large evals happen in a tiny fraction of a second, because you could compute full topological sweeps and pre-compute transitive auth closures virtually at the silicon limit.

----

EDIT: About to push some commits that read directly from DB into roaring data types, should achieve similar speedup as this benchmark:

```log
Starting Comparative Performance Benchmark...

--- Benchmark with size: 100 elements across 20 sets ---
Origin/Main (BTreeMap Counts):      2.856805795s (avg: 142.84µs)
Cached/Pre-computed Roaring:      189.769309ms (avg: 9.488µs)
Speedup of Cached Roaring over origin/main: 15.05x

--- Benchmark with size: 2000 elements across 20 sets ---
Origin/Main (BTreeMap Counts):     89.105965617s (avg: 4.455298ms)
Cached/Pre-computed Roaring:        4.187627498s (avg: 209.381µs)
Speedup of Cached Roaring over origin/main: 21.28x
```