### PR TITLE
Support multiple domains on a single server.

### DIFF
--- a/src/api/client/session/password.rs
+++ b/src/api/client/session/password.rs
@@ -38,7 +38,7 @@ pub(super) async fn handle_login(
 
 	let lowercased_user_id = UserId::parse_with_server_name(
 		user_id.localpart().to_lowercase(),
-		&services.config.server_name,
+		user_id.server_name(),
 	)?;
 
 	let user_is_remote = !services.globals.user_is_local(&user_id)

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -88,6 +88,31 @@ pub struct Config {
 	#[cfg_attr(test, serde(default = "default_server_name"))]
 	pub server_name: OwnedServerName,
 
+	/// Alternate server names this homeserver is authoritative for. Users
+	/// with a Matrix ID on any of these domains can authenticate and use this
+	/// server, in addition to users on the primary `server_name`.
+	///
+	/// Each name must be a valid Matrix server name.
+	///
+	/// Alternate server names can be added after initialization, but should not
+	/// be removed while there exist accounts or appservice registrations using
+	/// that domain.
+	///
+	/// Each alternate domain must independently satisfy the Matrix
+	/// well-known/delegation requirements so that federation peers and clients
+	/// can resolve it to this server.
+	/// 
+	/// Note that servers providing the legacy registration endpoint can block
+	/// registration of users on alternate server names by including the full
+	/// User ID (e.g. "@user:example.com") or just the domain (e.g. ":example.com") in
+	/// `forbidden_usernames`.
+	///
+	/// example: ["legacy.example.com", "alias.example.org"]
+	/// 
+	/// default: []
+	#[serde(default)]
+	pub alternate_server_names: Vec<OwnedServerName>,
+
 	/// This is the only directory where tuwunel will save its data, including
 	/// media. Note: this was previously "/var/lib/matrix-conduit".
 	///

--- a/src/main/tests/alternate_domains.rs
+++ b/src/main/tests/alternate_domains.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use tuwunel::{Args, Runtime, Server};
+use tuwunel_core::{
+	Err, Result, ruma::
+		UserId
+	,
+};
+use tuwunel_service::Services;
+use tuwunel_service::users::Register;
+
+
+const PRIMARY: &str = "primary.example.test";
+const ALT: &str = "alt.example.test";
+
+fn alt_domain_user_id() -> &'static UserId {
+	"@bob:alt.example.test"
+		.try_into()
+		.expect("valid user id")
+}
+
+#[test]
+fn alternate_server_names_register_login_message_federate() -> Result {
+	let mut args = Args::default_test(&["fresh", "cleanup"]);
+
+	args.option
+		.push(format!("server_name=\"{PRIMARY}\""));
+	args.option
+		.push(format!("alternate_server_names=[\"{ALT}\"]"));
+
+	args.maintenance = true;
+
+	let runtime = Runtime::new(Some(&args))?;
+	let server = Server::new(Some(&args), Some(&runtime))?;
+
+	let result: Result = runtime.block_on(async {
+		let services = tuwunel::async_start(&server).await?;
+
+		let outcome = run_tests(&services).await;
+
+		server.server.shutdown()?;
+		drop(services);
+		tuwunel::async_run(&server).await?;
+		tuwunel::async_stop(&server).await?;
+
+		outcome
+	});
+
+	drop(runtime);
+	result
+}
+
+async fn run_tests(services: &Arc<Services>) -> Result {
+	test_register(services).await?;
+	Ok(())
+}
+
+/// Test that an alternate-domain user can be registered.
+async fn test_register(services: &Arc<Services>) -> Result {
+	let alternate_user_id = alt_domain_user_id();
+
+	services
+		.users
+		.full_register(Register {
+			user_id: Some(&alternate_user_id),
+			password: Some("alternateuserpassword"),
+			is_appservice: false,
+			is_guest: false,
+			grant_first_user_admin: false,
+			..Default::default()
+		})
+		.await?;
+
+	if !services.users.exists(alternate_user_id).await {
+		return Err!("({alternate_user_id}) was not found after registration");
+	}
+
+	Ok(())
+}

--- a/src/service/globals/mod.rs
+++ b/src/service/globals/mod.rs
@@ -100,6 +100,12 @@ impl Service {
 	#[must_use]
 	pub fn server_is_ours(&self, server_name: &ServerName) -> bool {
 		server_name == self.server_name()
+			|| self
+				.server
+				.config
+				.alternate_server_names
+				.iter()
+				.any(|s| s == server_name)
 	}
 
 	#[inline]

--- a/src/service/rooms/timeline/build.rs
+++ b/src/service/rooms/timeline/build.rs
@@ -160,9 +160,9 @@ pub async fn build_and_append_pdu(
 		servers.insert(state_key_uid.server_name().to_owned());
 	}
 
-	// Remove our server from the server list since it will be added to it by
-	// room_servers() and/or the if statement above
-	servers.remove(self.services.globals.server_name());
+	// Remove all servers we are authoritative for from the federation list,
+	// since they will be added to it by room_servers() and/or the if statement above.
+	servers.retain(|s| !self.services.globals.server_is_ours(s));
 
 	self.services
 		.sending

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -37,6 +37,29 @@
 #
 #server_name =
 
+# Alternate server names this homeserver is authoritative for. Users
+# with a Matrix ID on any of these domains can authenticate and use this
+# server, in addition to users on the primary `server_name`.
+#
+# Each name must be a valid Matrix server name.
+#
+# Alternate server names can be added after initialization, but should not
+# be removed while there exist accounts or appservice registrations using
+# that domain.
+#
+# Each alternate domain must independently satisfy the Matrix
+# well-known/delegation requirements so that federation peers and clients
+# can resolve it to this server.
+# 
+# Note that servers providing the legacy registration endpoint can block
+# registration of users on alternate server names by including the full
+# User ID (e.g. "@user:example.com") or just the domain (e.g. ":example.com") in
+# `forbidden_usernames`.
+#
+# example: ["legacy.example.com", "alias.example.org"]
+#
+#alternate_server_names = []
+
 # This is the only directory where tuwunel will save its data, including
 # media. Note: this was previously "/var/lib/matrix-conduit".
 #


### PR DESCRIPTION
This change allows the server to declare multiple domains that it is authoritative for, in addition to the base server name. Every listed domain must have its own `well-known` entry, pointing to the same REST API.

Clients will be able to use any of the supported domains as the homeserver name, and they all resolve to the same server. It's still a single server: for instance, it has a single room directory. But the server has the ability to authorize users from any of its supported domains.

Rationaille:

There are two use cases that immediately come to mind:
- An organization that wants a separate domain for staff vs users to reduce the risk of staff impersonation.
- Small homeservers that want to allow users to use a domain they control as a UserID.

The use of `well-known` already allows a Matrix server to be authoritative for a single domain that doesn't match the API domain: this change merely allows the server to be authoritative for multiple such domains.

Tests:

I added a basic test that the registration workflow works for alternate domains, but additional test coverage than this is probably required. Ideally we'd want to test that the server does not attempt to federate with itself or use the Server-Server API to resolve references to an alternate domain. But I couldn't find those kinds of integration tests in the codebase and wasn't sure how they should be added.

Risks:

I'm trying to think if alternate domains could violate any existing invariants. The big change is that it's now possible for IDs from two different domains to both be seen as "local", but I'm not sure if that can break anything.

It's possible that users on one domain might be able to create room aliases on the alternate domain. I'm not sure how room alias permissions work, and whether this is a problem.