### PR TITLE
oauth: fall back to Apple id_token claims when userinfo fails

### DIFF
--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -15,6 +15,7 @@ use ruma::{
 	},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use tuwunel_core::{
 	Err, Result, at,
 	config::IdentityProvider,
@@ -73,6 +74,64 @@ struct GrantCookie<'a> {
 }
 
 static GRANT_SESSION_COOKIE: &str = "tuwunel_grant_session";
+
+fn decode_apple_userinfo_from_id_token(session: &Session) -> Result<UserInfo> {
+	let id_token = session.id_token.as_deref().ok_or_else(|| {
+		err!(Request(Unauthorized("Missing Apple id_token in token response.")))
+	})?;
+
+	let payload_b64 = id_token
+		.split('.')
+		.nth(1)
+		.ok_or_else(|| err!(Request(Unauthorized("Apple id_token is malformed."))))?;
+
+	let payload = b64
+		.decode(payload_b64)
+		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is invalid base64."))))?;
+
+	let payload: JsonValue = serde_json::from_slice(&payload)
+		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is not valid JSON."))))?;
+
+	let sub = payload
+		.get("sub")
+		.and_then(JsonValue::as_str)
+		.ok_or_else(|| {
+			err!(Request(Unauthorized("Apple id_token missing required sub claim.")))
+		})?;
+
+	let email = payload
+		.get("email")
+		.and_then(JsonValue::as_str)
+		.map(ToOwned::to_owned);
+
+	let preferred_username = email
+		.as_deref()
+		.and_then(|value| value.split_once('@'))
+		.map(at!(0))
+		.map(ToOwned::to_owned);
+
+	Ok(UserInfo {
+		sub: sub.to_owned(),
+		preferred_username: preferred_username.clone(),
+		username: preferred_username,
+		nickname: None,
+		name: payload
+			.get("name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+		given_name: payload
+			.get("given_name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+		family_name: payload
+			.get("family_name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+		email,
+		avatar_url: None,
+		picture: None,
+	})
+}
 
 /// # `GET /_matrix/client/v3/login/sso/redirect`
 ///
@@ -344,7 +403,27 @@ pub(crate) async fn sso_callback_route(
 	let userinfo = services
 		.oauth
 		.request_userinfo((&provider, &session))
-		.await?;
+		.await
+		.or_else(|error| {
+			if provider.brand != "appleoidc" {
+				return Err(error);
+			}
+
+			debug_warn!(
+				?error,
+				idp_id = provider.id(),
+				"Failed to fetch Apple userinfo endpoint; falling back to id_token claims.",
+			);
+
+			decode_apple_userinfo_from_id_token(&session).map_err(|decode_error| {
+				debug_warn!(
+					?decode_error,
+					idp_id = provider.id(),
+					"Failed to decode Apple id_token fallback.",
+				);
+				error
+			})
+		})?;
 
 	let unique_id = unique_id_sub((&provider, &userinfo.sub))?;
 
@@ -453,6 +532,7 @@ fn apply_token_response(session: Session, token: TokenResponse) -> Result<Sessio
 		scope: token.scope,
 		token_type: token.token_type,
 		access_token: token.access_token,
+		id_token: token.id_token,
 		expires_at,
 		refresh_token: token.refresh_token,
 		refresh_token_expires_at,
@@ -855,5 +935,81 @@ fn parse_user_id(server_name: &ServerName, username: &str) -> Result<OwnedUserId
 				"Username {username} contains disallowed characters or spaces: {e}"
 			)))),
 		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+
+	use super::*;
+
+	fn apple_session_with_claims(claims: serde_json::Value) -> Session {
+		let payload = b64.encode(serde_json::to_vec(&claims).expect("serialize claims"));
+
+		Session {
+			id_token: Some(format!("header.{payload}.signature")),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn decode_apple_userinfo_from_id_token_extracts_expected_claims() {
+		let session = apple_session_with_claims(json!({
+			"sub": "apple-user-123",
+			"email": "alice@example.com",
+			"name": "Alice Example",
+			"given_name": "Alice",
+			"family_name": "Example"
+		}));
+
+		let userinfo =
+			decode_apple_userinfo_from_id_token(&session).expect("decode Apple id_token claims");
+
+		assert_eq!(userinfo.sub, "apple-user-123");
+		assert_eq!(userinfo.email.as_deref(), Some("alice@example.com"));
+		assert_eq!(userinfo.preferred_username.as_deref(), Some("alice"));
+		assert_eq!(userinfo.username.as_deref(), Some("alice"));
+		assert_eq!(userinfo.name.as_deref(), Some("Alice Example"));
+		assert_eq!(userinfo.given_name.as_deref(), Some("Alice"));
+		assert_eq!(userinfo.family_name.as_deref(), Some("Example"));
+	}
+
+	#[test]
+	fn decode_apple_userinfo_from_id_token_requires_sub_claim() {
+		let session = apple_session_with_claims(json!({
+			"email": "alice@example.com"
+		}));
+
+		let error = decode_apple_userinfo_from_id_token(&session)
+			.expect_err("missing sub claim should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("sub claim"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn decode_apple_userinfo_from_id_token_requires_id_token() {
+		let session = Session::default();
+
+		let error = decode_apple_userinfo_from_id_token(&session)
+			.expect_err("missing id_token should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("Missing Apple id_token"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn decode_apple_userinfo_from_id_token_rejects_invalid_payload() {
+		let session = Session {
+			id_token: Some("header.!.signature".to_owned()),
+			..Default::default()
+		};
+
+		let error = decode_apple_userinfo_from_id_token(&session)
+			.expect_err("invalid id_token payload should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("invalid base64"), "unexpected error: {message}");
 	}
 }

--- a/src/service/oauth/sessions.rs
+++ b/src/service/oauth/sessions.rs
@@ -52,6 +52,9 @@ pub struct Session {
 	/// Access token to the provider.
 	pub access_token: Option<String>,
 
+	/// OIDC ID token returned by the provider.
+	pub id_token: Option<String>,
+
 	/// Duration in seconds the access_token is valid for.
 	pub expires_in: Option<u64>,
 


### PR DESCRIPTION
I've been running a Tuwunel deployment for a few months now with Sign in with Apple as the primary login method, and hit this early on: when the `userinfo` request to Apple fails, the whole SSO callback errors out and the user can't log in, even though we already hold a perfectly good `id_token` from the code exchange.

Apple is an outlier among OIDC providers here: it doesn't reliably serve a userinfo endpoint, and delivers all identity claims (`sub`, `email`, name) in the `id_token` from the token endpoint instead. This PR makes the Apple flow fall back to decoding claims out of the `id_token` when the userinfo request fails, so login can still complete.

A few notes on the implementation:

- The fallback only triggers for `appleoidc`-brand providers, and only when `request_userinfo` returns an error. Every other provider is unchanged, and if the fallback itself fails, the original userinfo error is returned.
- `Session` gains an `id_token` field so the token from the code exchange is retained for the fallback.
- The `id_token` payload is decoded without re-verifying the signature. OIDC Core (3.1.3.7) permits this when the token is received directly from the provider's token endpoint over TLS, which is the case here. Happy to add JWKS signature verification if you'd rather have it anyway.
- The fallback path logs a `debug_warn` with the original userinfo error, so it's visible when it kicks in.
- Added unit tests for the claim extraction: `sub` is required, the email localpart becomes `preferred_username`/`username`, and malformed tokens/payloads are rejected.

For context: I maintain a [fork of Tuwunel](https://github.com/mindroom-ai/mindroom-tuwunel) where this change has been in place since March. I keep the fork up to date and rebase it on every upstream release, so this patch has effectively been battle-tested in production (https://mindroom.chat) against each release since then, with daily Apple logins and no issues. Upstreaming it means one less patch to carry, and it should help anyone else wiring up Sign in with Apple.

Verified here on top of current `main` (v1.8.0): `cargo test -p tuwunel_api --lib session::sso` (4 tests pass) and nightly `cargo fmt --check` is clean.
