### PR TITLE
client/room: Apply a configurable default power-level override.

### DIFF
--- a/src/api/client/room/create.rs
+++ b/src/api/client/room/create.rs
@@ -1,3 +1,5 @@
+mod power_level_defaults;
+
 use std::collections::BTreeMap;
 
 use axum::extract::State;
@@ -33,7 +35,7 @@ use ruma::{
 	serde::{JsonObject, Raw},
 };
 use serde::Deserialize;
-use serde_json::{json, value::to_raw_value};
+use serde_json::{Value as JsonValue, json, value::to_raw_value};
 use tuwunel_core::{
 	Err, Result, debug_info, debug_warn, err, info,
 	matrix::{
@@ -46,6 +48,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::{Services, appservice::RegistrationInfo, rooms::state::RoomMutexGuard};
 
+use self::power_level_defaults::merge_power_level_content_override;
 use crate::{Ruma, client::utils::invite_check};
 
 pub(crate) async fn create_room_route(
@@ -219,6 +222,10 @@ async fn apply_power_levels_pdu(
 
 	let power_levels_content = default_power_levels_content(
 		version_rules,
+		services
+			.config
+			.default_power_level_content_override
+			.as_ref(),
 		body.power_level_content_override.as_ref(),
 		preset,
 		users,
@@ -754,10 +761,11 @@ async fn create_create_event_legacy(
 /// creates the power_levels_content for the PDU builder
 fn default_power_levels_content(
 	version_rules: &RoomVersionRules,
+	default_power_level_content_override: Option<&JsonValue>,
 	power_level_content_override: Option<&Raw<RoomPowerLevelsContentOverride>>,
 	preset: &RoomPreset,
 	users: BTreeMap<OwnedUserId, Int>,
-) -> Result<serde_json::Value> {
+) -> Result<JsonValue> {
 	use serde_json::to_value;
 
 	let mut power_levels_content = RoomPowerLevelsEventContent::new(&version_rules.authorization);
@@ -797,13 +805,18 @@ fn default_power_levels_content(
 		power_levels_content["events"]["org.matrix.msc3401.call.member"] = json!(50);
 	}
 
+	if let Some(default_power_level_content_override) = default_power_level_content_override {
+		let json = default_power_level_content_override
+			.as_object()
+			.expect("default_power_level_content_override is validated at startup");
+		merge_power_level_content_override(&mut power_levels_content, json);
+	}
+
 	if let Some(power_level_content_override) = power_level_content_override {
 		let json: JsonObject = serde_json::from_str(power_level_content_override.json().get())
 			.map_err(|e| err!(Request(BadJson("Invalid power_level_content_override: {e:?}"))))?;
 
-		for (key, value) in json {
-			power_levels_content[key] = value;
-		}
+		merge_power_level_content_override(&mut power_levels_content, &json);
 	}
 
 	Ok(power_levels_content)

--- a/src/api/client/room/create/power_level_defaults.rs
+++ b/src/api/client/room/create/power_level_defaults.rs
@@ -1,0 +1,77 @@
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+/// Merge a top-level `m.room.power_levels` override object into the
+/// power-levels content being built for a new room. Keys present in the
+/// override replace the corresponding top-level keys (e.g. `users_default`,
+/// `events`, `invite`), matching how the client `power_level_content_override`
+/// is applied.
+pub(super) fn merge_power_level_content_override(
+	power_levels_content: &mut JsonValue,
+	override_json: &JsonMap<String, JsonValue>,
+) {
+	let target = power_levels_content
+		.as_object_mut()
+		.expect("power levels content must serialize to an object");
+
+	for (key, value) in override_json {
+		target.insert(key.clone(), value.clone());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::*;
+
+	#[test]
+	fn default_power_levels_content_applies_server_default_override() {
+		let rules = room_version::rules(&RoomVersionId::V11).expect("supported room version");
+
+		let content = default_power_levels_content(
+			&rules,
+			Some(&json!({ "users_default": 50 })),
+			None,
+			&RoomPreset::PrivateChat,
+			BTreeMap::new(),
+		)
+		.expect("power levels content");
+
+		assert_eq!(content["users_default"], json!(50));
+	}
+
+	#[test]
+	fn request_override_wins_over_server_default_override() {
+		let rules = room_version::rules(&RoomVersionId::V11).expect("supported room version");
+		let request_override =
+			Raw::from_json(to_raw_value(&json!({ "users_default": 75 })).expect("raw json"));
+
+		let content = default_power_levels_content(
+			&rules,
+			Some(&json!({ "users_default": 50 })),
+			Some(&request_override),
+			&RoomPreset::PrivateChat,
+			BTreeMap::new(),
+		)
+		.expect("power levels content");
+
+		assert_eq!(content["users_default"], json!(75));
+	}
+
+	#[test]
+	fn default_override_preserves_explicit_user_power_levels() {
+		let rules = room_version::rules(&RoomVersionId::V11).expect("supported room version");
+		let creator = OwnedUserId::try_from("@alice:example.com").expect("valid user id");
+		let users = BTreeMap::from([(creator.clone(), int!(100))]);
+
+		let content = default_power_levels_content(
+			&rules,
+			Some(&json!({ "users_default": 50 })),
+			None,
+			&RoomPreset::PrivateChat,
+			users,
+		)
+		.expect("power levels content");
+
+		assert_eq!(content["users_default"], json!(50));
+		assert_eq!(content["users"][creator.as_str()], json!(100));
+	}
+}

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -405,6 +405,17 @@ fn check_room_version(config: &Config) -> Result {
 		));
 	}
 
+	if config
+		.default_power_level_content_override
+		.as_ref()
+		.is_some_and(|value| !value.is_object())
+	{
+		return Err!(Config(
+			"default_power_level_content_override",
+			"must be a table (a JSON object)"
+		));
+	}
+
 	Ok(())
 }
 

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1139,6 +1139,22 @@ pub struct Config {
 	#[serde(default = "default_default_room_version")]
 	pub default_room_version: RoomVersionId,
 
+	/// Default power-level overrides applied when this homeserver creates a new
+	/// room.
+	///
+	/// Uses the same top-level shape as the client `/createRoom`
+	/// `power_level_content_override` parameter and is merged before any
+	/// per-request override, so a client can still override it per room. Only
+	/// affects newly created rooms. Top-level keys replace wholesale rather
+	/// than deep-merging (matching the client parameter): setting `users` or
+	/// `events` replaces the entire computed default submap for that key.
+	///
+	/// reloadable: yes
+	/// default: unset
+	/// config-example: { users_default = 50 }
+	#[serde(default)]
+	pub default_power_level_content_override: Option<serde_json::Value>,
+
 	// external structure; separate section
 	#[serde(default)]
 	pub well_known: WellKnownConfig,

--- a/src/core/config/tests.rs
+++ b/src/core/config/tests.rs
@@ -304,3 +304,32 @@ fn pgp_key_rejects_raw_material_and_bare_fingerprints() {
 	let err = check_support_pgp_key("openpgp4fpr:nothex").unwrap_err();
 	assert!(err.to_string().contains("hex fingerprint"), "{err}");
 }
+
+#[test]
+fn default_power_level_content_override_accepts_a_table() {
+	let config = config_from_toml(
+		r"[global]
+[global.default_power_level_content_override]
+users_default = 50
+",
+	)
+	.expect("a table value parses");
+
+	check(&config)
+		.expect("a table default_power_level_content_override should pass config check");
+}
+
+#[test]
+fn default_power_level_content_override_rejects_a_non_table() {
+	let config = config_from_toml(
+		r"[global]
+default_power_level_content_override = false
+",
+	)
+	.expect("a scalar value parses into config");
+
+	let err = check(&config)
+		.expect_err("a non-table default_power_level_content_override must be rejected")
+		.to_string();
+	assert!(err.contains("default_power_level_content_override"), "{err}");
+}

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -958,6 +958,20 @@
 #
 #default_room_version =
 
+# Default power-level overrides applied when this homeserver creates a new
+# room.
+#
+# Uses the same top-level shape as the client `/createRoom`
+# `power_level_content_override` parameter and is merged before any
+# per-request override, so a client can still override it per room. Only
+# affects newly created rooms. Top-level keys replace wholesale rather
+# than deep-merging (matching the client parameter): setting `users` or
+# `events` replaces the entire computed default submap for that key.
+#
+# reloadable: yes
+#
+#default_power_level_content_override = { users_default = 50 }
+
 # This item is undocumented. Please contribute documentation for it.
 #
 #allow_jaeger = false


### PR DESCRIPTION
## Default power-level override for newly created rooms

This adds a `default_power_level_content_override` server config option that is applied to `m.room.power_levels` whenever the homeserver creates a room. It uses the same top-level shape as the client `/createRoom` `power_level_content_override` parameter and is merged **before** any per-request override, so clients can still override it per room. It only affects newly created rooms.

The typical use is a server-wide `users_default` (e.g. 50) so new rooms start with everyone able to moderate — without every client having to send `power_level_content_override` on each create:

```toml
[global.default_power_level_content_override]
users_default = 50
```

### Prior art

Synapse has had a config option of the same name since 1.60.0 ([docs](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#default_power_level_content_override)), which is why this reuses the name. Synapse's version is **per-preset** (`private_chat` / `trusted_private_chat` / `public_chat`); this one is a single, preset-agnostic override merged onto whatever preset defaults tuwunel already computes. Happy to move to a per-preset shape if you'd prefer to match Synapse more closely — this was just the smallest thing that covered our need.

### Why

We maintain a small downstream tuwunel fork for MindRoom — AI agents that run inside Matrix rooms — and those rooms need a non-default power-level baseline. We have carried this patch in the fork and run it in production for several months; it is small and general enough that it seemed worth offering upstream rather than keeping private. Fork: https://github.com/mindroom-ai/mindroom-tuwunel

### Notes

- Off by default — no behaviour change unless configured.
- The request-level `power_level_content_override` still wins (it is merged after the server default).
- Validated as a table/object at startup.
- The request override and the new server default now share one small merge helper (`merge_power_level_content_override`).
- Tests cover: the server default is applied, a request override wins over it, and explicit per-user power levels are preserved.
