### PR TITLE
oauth: Remove the grant-session cookie with a matching path attribute.

### DIFF
--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -75,6 +75,14 @@ struct GrantCookie<'a> {
 
 static GRANT_SESSION_COOKIE: &str = "tuwunel_grant_session";
 
+/// Path attribute for the grant-session cookie. The set and removal cookies
+/// must use the same value: a cookie is only replaced (and thus removed) when
+/// its name, domain and path all match (RFC 6265 5.3), and a Set-Cookie
+/// without an explicit path defaults to the request-URI's directory.
+fn grant_session_cookie_path(callback_url: Option<&Url>) -> &str {
+	callback_url.map(Url::path).unwrap_or("/")
+}
+
 fn decode_apple_userinfo_from_id_token(session: &Session) -> Result<UserInfo> {
 	let id_token = session.id_token.as_deref().ok_or_else(|| {
 		err!(Request(Unauthorized("Missing Apple id_token in token response.")))
@@ -278,11 +286,7 @@ async fn handle_sso_login(
 		redirect_uri: redirect_url.as_str().into(),
 	};
 
-	let cookie_path = provider
-		.callback_url
-		.as_ref()
-		.map(Url::path)
-		.unwrap_or("/");
+	let cookie_path = grant_session_cookie_path(provider.callback_url.as_ref());
 
 	let cookie_max_age = provider
 		.grant_session_duration
@@ -466,6 +470,7 @@ pub(crate) async fn sso_callback_route(
 	}
 
 	let cookie = Cookie::build((GRANT_SESSION_COOKIE, EMPTY))
+		.path(grant_session_cookie_path(provider.callback_url.as_ref()))
 		.removal()
 		.build()
 		.to_string()
@@ -993,5 +998,44 @@ mod tests {
 
 		let message = format!("{error}");
 		assert!(message.contains("invalid base64"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn grant_session_cookie_path_uses_the_callback_path() {
+		let callback = Url::parse(
+			"https://matrix.example/_matrix/client/unstable/login/sso/callback/tuwunel_abc",
+		)
+		.expect("valid URL");
+
+		assert_eq!(
+			grant_session_cookie_path(Some(&callback)),
+			"/_matrix/client/unstable/login/sso/callback/tuwunel_abc"
+		);
+		assert_eq!(grant_session_cookie_path(None), "/");
+	}
+
+	#[test]
+	fn grant_session_removal_cookie_path_matches_the_set_cookie_path() {
+		let callback = Url::parse(
+			"https://matrix.example/_matrix/client/unstable/login/sso/callback/tuwunel_abc",
+		)
+		.expect("valid URL");
+
+		let set = Cookie::build((GRANT_SESSION_COOKIE, "grant"))
+			.path(grant_session_cookie_path(Some(&callback)))
+			.build();
+
+		let removal = Cookie::build((GRANT_SESSION_COOKIE, EMPTY))
+			.path(grant_session_cookie_path(Some(&callback)))
+			.removal()
+			.build();
+
+		assert_eq!(set.path(), removal.path());
+		assert!(
+			removal
+				.to_string()
+				.contains("Path=/_matrix/client/unstable/login/sso/callback/tuwunel_abc"),
+			"unexpected removal cookie: {removal}"
+		);
 	}
 }


### PR DESCRIPTION
While going through the SSO cookie handling in our fork against current `main`, I noticed the `tuwunel_grant_session` removal cookie never actually removes anything. The set cookie is scoped with an explicit `Path` (the provider's callback path), but the removal cookie is built without one, so the browser fills in the default path — the *directory* of the callback request URI. RFC 6265 (5.3) only replaces (and therefore removes) a cookie when name, domain **and** path all match, and the full callback path is never equal to its own directory. So after every SSO login the grant cookie — state, nonce, redirect_uri — just stays in the browser until `grant_session_duration` runs out (300s by default) instead of being cleared, and keeps being sent along on any further callback requests in that window.

The fix is one attribute: give the removal cookie the same explicit path as the set cookie. A few notes:

- I pulled the path computation into a small shared helper (`grant_session_cookie_path`) used by both the set and removal sites, so the two can't drift apart again. Happy to inline it at both call sites instead if you prefer the smaller diff.
- No behaviour change for the set cookie — it keeps the tight callback-path scoping it has today.
- Added two unit tests: one pinning the helper's output (callback path, `/` fallback when no callback URL is configured), and one asserting the rendered removal cookie carries the exact same `Path` as the set cookie.

For context: this is another one from the MindRoom fork (https://github.com/mindroom-ai/mindroom-tuwunel), same as #495/#496. The fork carries a broader variant of this (it scopes the cookie to `/_matrix/client/`); for upstream I kept your tighter per-callback scoping and only fixed the removal side, which is the actual bug.

Verified on top of current `main`: `cargo test -p tuwunel_api --lib session::sso` — 6 tests pass (4 existing + 2 new).