### PR TITLE
signals: actually shut down on Ctrl+C on non-unix targets

### DIFF
--- a/src/main/signals.rs
+++ b/src/main/signals.rs
@@ -53,8 +53,8 @@ pub async fn enable(server: Arc<Server>) {
 			() = server.server.until_shutdown() => break,
 			_ = signal::ctrl_c() => {
 				warn!("Received Ctrl+C");
-				if let Err(e) = server.server.signal.send("SIGINT") {
-					debug_error!("signal channel: {e}");
+				if let Err(e) = server.server.shutdown() {
+					debug_error!("shutdown: {e}");
 				}
 			},
 		}


### PR DESCRIPTION
### What does this PR do?

On non-unix targets the Ctrl+C handler published `"SIGINT"` to the signal
channel via `server.server.signal.send("SIGINT")`. Nothing consumes that
channel on these targets, so pressing Ctrl+C logged the event but never
initiated shutdown, and the server kept running.

This calls `server.server.shutdown()` directly, mirroring the unix path where
a terminating signal (SIGINT without console, SIGTERM, SIGQUIT) resolves to
`shutdown()`. Ctrl+C now cleanly stops the server on non-unix targets.

The change is confined to the `#[cfg(not(unix))]` branch of
`src/main/signals.rs`; the unix signal handling path is untouched.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.