### PR TITLE
URL preview media proxying and custom useragents

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -62,6 +62,7 @@ All allowlist checks are evaluated before the denylist check.
 | `url_preview_check_root_domain` | `false` | When enabled, domain allowlist checks are applied to the root domain. Allows all subdomains of any allowed domain — e.g. allowing `wikipedia.org` also allows `en.m.wikipedia.org`. |
 | `url_preview_max_spider_size` | `256000` | Maximum bytes fetched from a URL when generating a preview (default: 256 KB). |
 | `url_preview_bound_interface` | — | Network interface name or IP address to bind when making URL preview requests. Example: `"eth0"` or `"1.2.3.4"`. |
+| `url_preview_user_agent` | — | User-Agent header sent when fetching pages and media for previews. Defaults to the versioned server User-Agent, e.g. `"Tuwunel/1.8.1 preview"`. |
 
 > [!NOTE]
 > Setting any allowlist to `["*"]` opens significant attack surface — a

--- a/docs/media.md
+++ b/docs/media.md
@@ -68,6 +68,22 @@ All allowlist checks are evaluated before the denylist check.
 > malicious client could cause the server to make requests to arbitrary URLs
 > on the local network. Use explicit allowlists wherever possible.
 
+`og:image`, `og:video`, and `og:audio` (and direct links to image, video,
+and audio files) resolve to an `mxc://` URI on this server rather than the
+third-party URL, and none of the content is stored: requests for that
+`mxc://` URI are relayed — the server fetches the source URL on the client's
+behalf (subject to the same SSRF/CIDR checks as everything else on this
+page, and capped at `max_response_size`) and passes the content through, so
+the third party sees the server's address rather than the client's, and the
+server hosts nothing. Images are additionally downloaded once while
+generating the preview to measure `og:image:width`/`og:image:height` and
+`matrix:image:size`, then discarded. `og:video:width`/`og:video:height` are
+populated when the page declares them. Clients cache the results themselves
+per the immutable cache headers on media downloads. Because nothing is
+stored, a preview's `mxc://` URI is only as durable as its source URL: if
+the source expires or changes, later fetches reflect that, unlike uploaded
+media. Upstream error responses are never relayed as media.
+
 ## Blurhash
 
 Tuwunel can generate [blurhashes](https://blurha.sh/) for uploaded images,

--- a/docs/media.md
+++ b/docs/media.md
@@ -62,7 +62,8 @@ All allowlist checks are evaluated before the denylist check.
 | `url_preview_check_root_domain` | `false` | When enabled, domain allowlist checks are applied to the root domain. Allows all subdomains of any allowed domain — e.g. allowing `wikipedia.org` also allows `en.m.wikipedia.org`. |
 | `url_preview_max_spider_size` | `256000` | Maximum bytes fetched from a URL when generating a preview (default: 256 KB). |
 | `url_preview_bound_interface` | — | Network interface name or IP address to bind when making URL preview requests. Example: `"eth0"` or `"1.2.3.4"`. |
-| `url_preview_user_agent` | — | User-Agent header sent when fetching pages and media for previews. Defaults to the versioned server User-Agent, e.g. `"Tuwunel/1.8.1 preview"`. |
+| `url_preview_user_agent` | — | User-Agent header sent when fetching pages to extract their OpenGraph tags. Defaults to the versioned server User-Agent, e.g. `"Tuwunel/1.8.1 preview"`. |
+| `url_preview_media_user_agent` | — | User-Agent header sent when fetching and relaying preview media files themselves. Falls back to `url_preview_user_agent`. |
 
 > [!NOTE]
 > Setting any allowlist to `["*"]` opens significant attack surface — a

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -400,6 +400,12 @@ fn check_url_previews(config: &Config) -> Result {
 		return Err!(Config("url_preview_user_agent", "Not a valid HTTP header value."));
 	}
 
+	if let Some(user_agent) = config.url_preview_media_user_agent.as_deref()
+		&& HeaderValue::from_str(user_agent).is_err()
+	{
+		return Err!(Config("url_preview_media_user_agent", "Not a valid HTTP header value."));
+	}
+
 	Ok(())
 }
 

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -1,6 +1,7 @@
 use std::{env::consts::OS, fs::read_to_string, net::SocketAddr};
 
 use either::Either;
+use http::HeaderValue;
 use itertools::Itertools;
 use regex::RegexSet;
 use url::Url;
@@ -391,6 +392,12 @@ fn check_url_previews(config: &Config) -> Result {
 			"url_preview_bound_interface",
 			"Not a valid IP address. Interface names not supported on {OS}."
 		));
+	}
+
+	if let Some(user_agent) = config.url_preview_user_agent.as_deref()
+		&& HeaderValue::from_str(user_agent).is_err()
+	{
+		return Err!(Config("url_preview_user_agent", "Not a valid HTTP header value."));
 	}
 
 	Ok(())

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -2499,6 +2499,14 @@ pub struct Config {
 	#[serde(default)]
 	pub url_preview_check_root_domain: bool,
 
+	/// User-Agent header the URL preview client sends when fetching pages
+	/// and media for previews. When unset, the versioned server User-Agent
+	/// is used followed by "preview", e.g. "Tuwunel/1.8.1 preview".
+	///
+	/// default:
+	#[serde(default)]
+	pub url_preview_user_agent: Option<String>,
+
 	/// List of forbidden room aliases and room IDs as strings of regex
 	/// patterns.
 	///

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -2500,12 +2500,22 @@ pub struct Config {
 	pub url_preview_check_root_domain: bool,
 
 	/// User-Agent header the URL preview client sends when fetching pages
-	/// and media for previews. When unset, the versioned server User-Agent
-	/// is used followed by "preview", e.g. "Tuwunel/1.8.1 preview".
+	/// to extract their OpenGraph tags. When unset, the versioned server
+	/// User-Agent is used followed by "preview", e.g. "Tuwunel/1.8.1
+	/// preview".
 	///
 	/// default:
 	#[serde(default)]
 	pub url_preview_user_agent: Option<String>,
+
+	/// User-Agent header sent when fetching and relaying URL preview media
+	/// files themselves (og:image, og:video, og:audio, and direct links),
+	/// as opposed to the pages they appear on. When unset, falls back to
+	/// `url_preview_user_agent`, then to the versioned server User-Agent.
+	///
+	/// default:
+	#[serde(default)]
+	pub url_preview_media_user_agent: Option<String>,
 
 	/// List of forbidden room aliases and room IDs as strings of regex
 	/// patterns.

--- a/src/database/maps.rs
+++ b/src/database/maps.rs
@@ -150,6 +150,10 @@ pub(super) static MAPS: &[Descriptor] = &[
 		..descriptor::RANDOM_SMALL
 	},
 	Descriptor {
+		name: "mediaid_lazy",
+		..descriptor::RANDOM_SMALL
+	},
+	Descriptor {
 		name: "mediaid_pending",
 		ttl: 60 * 60 * 24 * 7,
 		..descriptor::RANDOM_SMALL_CACHE

--- a/src/service/client/mod.rs
+++ b/src/service/client/mod.rs
@@ -17,6 +17,7 @@ type DisableEncoding = fn(ClientBuilder) -> ClientBuilder;
 pub struct Clients {
 	pub default: Client,
 	pub url_preview: Client,
+	pub url_preview_media: Client,
 	pub extern_media: Client,
 	pub well_known: Client,
 	pub federation: Client,
@@ -79,29 +80,27 @@ fn make_clients(services: &Services) -> Result<Clients> {
 	Ok(Clients {
 		default: with!(cb => cb.dns_resolver(Arc::clone(&services.resolver.resolver))),
 
-		url_preview: with!("preview", cb => {
-			let interface = &services
+		url_preview: with!("preview", cb => preview_builder(
+			services,
+			cb,
+			services
 				.config
-				.url_preview_bound_interface;
+				.url_preview_user_agent
+				.as_deref(),
+		)?),
 
-			let bind_addr = interface.clone().and_then(Either::left);
-			let bind_iface = interface.clone().and_then(Either::right);
-
-			let resolver = Validating::new(
-				Arc::clone(&services.resolver.resolver),
-				Arc::clone(&services.client.cidr_range_denylist),
-			);
-
-			let cb = match &services.config.url_preview_user_agent {
-				| Some(user_agent) => cb.user_agent(user_agent.as_str()),
-				| None => cb,
-			};
-
-			builder_interface(cb, bind_iface.as_deref())?
-				.local_address(bind_addr)
-				.dns_resolver(resolver)
-				.redirect(redirect::Policy::limited(3))
-		}),
+		url_preview_media: with!("preview", cb => preview_builder(
+			services,
+			cb,
+			services
+				.config
+				.url_preview_media_user_agent
+				.as_deref()
+				.or(services
+					.config
+					.url_preview_user_agent
+					.as_deref()),
+		)?),
 
 		extern_media: with!(cb => cb
 			.dns_resolver(Validating::new(
@@ -172,6 +171,35 @@ fn make_clients(services: &Services) -> Result<Clients> {
 			.redirect(redirect::Policy::limited(0))
 			.pool_max_idle_per_host(1)),
 	})
+}
+
+/// Shared construction for the URL preview clients: bound to the configured
+/// interface, resolving through the CIDR-validating resolver, with an
+/// optional User-Agent override.
+fn preview_builder(
+	services: &Services,
+	builder: ClientBuilder,
+	user_agent: Option<&str>,
+) -> Result<ClientBuilder> {
+	let interface = &services.config.url_preview_bound_interface;
+
+	let bind_addr = interface.clone().and_then(Either::left);
+	let bind_iface = interface.clone().and_then(Either::right);
+
+	let resolver = Validating::new(
+		Arc::clone(&services.resolver.resolver),
+		Arc::clone(&services.client.cidr_range_denylist),
+	);
+
+	let builder = match user_agent {
+		| Some(user_agent) => builder.user_agent(user_agent),
+		| None => builder,
+	};
+
+	Ok(builder_interface(builder, bind_iface.as_deref())?
+		.local_address(bind_addr)
+		.dns_resolver(resolver)
+		.redirect(redirect::Policy::limited(3)))
 }
 
 fn base(config: &Config, name: Option<&str>) -> Result<ClientBuilder> {

--- a/src/service/client/mod.rs
+++ b/src/service/client/mod.rs
@@ -92,6 +92,11 @@ fn make_clients(services: &Services) -> Result<Clients> {
 				Arc::clone(&services.client.cidr_range_denylist),
 			);
 
+			let cb = match &services.config.url_preview_user_agent {
+				| Some(user_agent) => cb.user_agent(user_agent.as_str()),
+				| None => cb,
+			};
+
 			builder_interface(cb, bind_iface.as_deref())?
 				.local_address(bind_addr)
 				.dns_resolver(resolver)

--- a/src/service/media/data.rs
+++ b/src/service/media/data.rs
@@ -16,6 +16,7 @@ use super::{preview::UrlPreviewData, thumbnail::Dim};
 
 pub(crate) struct Data {
 	mediaid_file: Arc<Map>,
+	mediaid_lazy: Arc<Map>,
 	mediaid_pending: Arc<Map>,
 	mediaid_user: Arc<Map>,
 	url_previews: Arc<Map>,
@@ -32,6 +33,7 @@ impl Data {
 	pub(super) fn new(db: &Arc<Database>) -> Self {
 		Self {
 			mediaid_file: db["mediaid_file"].clone(),
+			mediaid_lazy: db["mediaid_lazy"].clone(),
 			mediaid_pending: db["mediaid_pending"].clone(),
 			mediaid_user: db["mediaid_user"].clone(),
 			url_previews: db["url_previews"].clone(),
@@ -105,6 +107,31 @@ impl Data {
 			.map(|(expires_at, user_id): Value<'_>| (user_id, expires_at))
 			.inspect(|(user_id, expires_at)| debug!(?mxc, ?user_id, ?expires_at, "Found pending"))
 			.map_err(|e| err!(Request(NotFound("Pending not found or error: {e}"))))
+	}
+
+	/// Register an MXC URI as a lazy reference to an external URL: the
+	/// content is never stored, only relayed to requesting clients (see
+	/// `Service::fetch_lazy_media`). Used for URL preview media, so a preview
+	/// can hand out an mxc:// URI without the server downloading or hosting
+	/// potentially large third-party files.
+	#[cfg(feature = "url_preview")]
+	pub(super) fn insert_lazy_media(&self, mxc: &Mxc<'_>, url: &str) {
+		debug!(?mxc, ?url, "Registering lazy media");
+
+		self.mediaid_lazy
+			.insert(&mxc.to_string(), url.as_bytes());
+	}
+
+	/// Remove a lazy media reference by its mxc:// URI string, unregistering
+	/// the mxc.
+	pub(super) fn remove_lazy_media(&self, mxc: &str) { self.mediaid_lazy.remove(mxc); }
+
+	/// Look up the external URL a lazy media MXC URI refers to.
+	pub(super) async fn search_lazy_media(&self, mxc: &Mxc<'_>) -> Result<String> {
+		let handle = self.mediaid_lazy.get(&mxc.to_string()).await?;
+
+		string_from_bytes(&handle)
+			.map_err(|e| err!(Database(error!(?mxc, "Lazy media URL is invalid: {e}"))))
 	}
 
 	pub(super) async fn delete_file_mxc(&self, mxc: &Mxc<'_>) {

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -421,9 +421,9 @@ impl Service {
 		// per mxc; requests for the same mxc queue rather than fan out
 		let _lock = self.federation_mutex.lock(&mxc.to_string()).await;
 
-		// lazy media is URL-preview traffic: use the preview client so
-		// url_preview_bound_interface and related policy still apply
-		self.location_request(&self.services.client.url_preview, &url)
+		// lazy media is URL-preview traffic: use the preview media client so
+		// url_preview_bound_interface and url_preview_media_user_agent apply
+		self.location_request(&self.services.client.url_preview_media, &url)
 			.await
 	}
 

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -248,6 +248,14 @@ impl Service {
 				Ok(())
 			},
 			| _ => {
+				// lazy URL-preview media has no file keys; deleting the
+				// reference unregisters the mxc
+				if self.db.search_lazy_media(mxc).await.is_ok() {
+					self.db
+						.remove_lazy_media(mxc.to_string().as_str());
+					return Ok(());
+				}
+
 				Err!(Database(error!(
 					"Failed to find any media keys for MXC {mxc} in our database."
 				)))
@@ -372,7 +380,7 @@ impl Service {
 			.await;
 
 		let Ok(Metadata { content_type, content_disposition, key }) = meta else {
-			return Err!(Request(NotFound("Media not found.")));
+			return self.fetch_lazy_media(mxc).await;
 		};
 
 		let path = self.get_media_name_sha256(&key);
@@ -397,6 +405,26 @@ impl Service {
 			content_type,
 			content_disposition,
 		})
+	}
+
+	/// Relay media that a URL preview registered as a lazy reference to an
+	/// external URL. The content is fetched on the client's behalf for every
+	/// request and never persisted locally: the server acts only as a proxy
+	/// so the client's address is not revealed to the third party.
+	#[tracing::instrument(level = "debug", skip(self))]
+	async fn fetch_lazy_media(&self, mxc: &Mxc<'_>) -> Result<Media> {
+		let Ok(url) = self.db.search_lazy_media(mxc).await else {
+			return Err!(Request(NotFound("Media not found.")));
+		};
+
+		// bound outbound amplification and buffering to one in-flight fetch
+		// per mxc; requests for the same mxc queue rather than fan out
+		let _lock = self.federation_mutex.lock(&mxc.to_string()).await;
+
+		// lazy media is URL-preview traffic: use the preview client so
+		// url_preview_bound_interface and related policy still apply
+		self.location_request(&self.services.client.url_preview, &url)
+			.await
 	}
 
 	/// Presigned redirect URL for locally-stored media (MSC3860).

--- a/src/service/media/preview.rs
+++ b/src/service/media/preview.rs
@@ -89,8 +89,18 @@ pub struct UrlPreviewData {
 }
 
 #[implement(Service)]
-pub fn remove_url_preview(&self, url: &str) -> Result {
-	// TODO: also remove the downloaded image
+pub async fn remove_url_preview(&self, url: &str) -> Result {
+	// unregister the preview's lazy media references; media stored by
+	// previews generated before relaying was introduced is not removed
+	if let Ok(preview) = self.db.get_url_preview(url).await {
+		for mxc in [&preview.image, &preview.video, &preview.audio]
+			.into_iter()
+			.flatten()
+		{
+			self.db.remove_lazy_media(mxc);
+		}
+	}
+
 	self.db.remove_url_preview(url)
 }
 
@@ -136,6 +146,15 @@ pub async fn request_url_preview(&self, url: &Url) -> Result<UrlPreviewData> {
 		}
 	}
 
+	// an upstream error response must not be turned into a cached preview
+	if !response.status().is_success() {
+		return Err!(Request(NotFound(debug_warn!(
+			status = ?response.status(),
+			%url,
+			"URL preview request failed"
+		))));
+	}
+
 	let content_type = response
 		.headers()
 		.get(reqwest::header::CONTENT_TYPE)
@@ -147,6 +166,8 @@ pub async fn request_url_preview(&self, url: &Url) -> Result<UrlPreviewData> {
 	let data = match content_type.as_str() {
 		| html if html.starts_with("text/html") => self.download_html(url, response).await?,
 		| img if img.starts_with("image/") => self.download_image(response).await?,
+		| video if video.starts_with("video/") => self.download_video(response).await?,
+		| audio if audio.starts_with("audio/") => self.download_audio(response).await?,
 		| _ => return Err!(Request(Unknown("Unsupported Content-Type"))),
 	};
 
@@ -159,18 +180,13 @@ pub async fn request_url_preview(&self, url: &Url) -> Result<UrlPreviewData> {
 #[implement(Service)]
 pub async fn download_image(&self, response: reqwest::Response) -> Result<UrlPreviewData> {
 	use image::ImageReader;
-	use ruma::Mxc;
-	use tuwunel_core::utils::random_string;
 
+	// the image is downloaded here only to be measured: clients expect the
+	// preview to carry its size and dimensions. the bytes are not stored;
+	// requests for the mxc are relayed from the source like video/audio.
+	let url = response.url().clone();
 	let limit = self.services.config.max_response_size;
 	let image = crate::client::read_response_capped(response, limit).await?;
-	let mxc = Mxc {
-		server_name: self.services.globals.server_name(),
-		media_id: &random_string(super::MXC_LENGTH),
-	};
-
-	self.create(&mxc, None, None, None, &image)
-		.await?;
 
 	let cursor = std::io::Cursor::new(&image);
 	let (width, height) = match ImageReader::new(cursor).with_guessed_format() {
@@ -182,7 +198,7 @@ pub async fn download_image(&self, response: reqwest::Response) -> Result<UrlPre
 	};
 
 	Ok(UrlPreviewData {
-		image: Some(mxc.to_string()),
+		image: Some(self.register_lazy_media(url.as_str())),
 		image_size: Some(image.len()),
 		image_width: width,
 		image_height: height,
@@ -194,6 +210,68 @@ pub async fn download_image(&self, response: reqwest::Response) -> Result<UrlPre
 #[implement(Service)]
 #[expect(clippy::unused_async)]
 pub async fn download_image(&self, _response: reqwest::Response) -> Result<UrlPreviewData> {
+	Err!(FeatureDisabled("url_preview"))
+}
+
+/// Mint a local mxc:// URI that lazily resolves to `url`: no bytes are
+/// fetched now, and requests for the mxc are relayed from the source without
+/// storing anything (see `Service::fetch_lazy_media` in the media service).
+/// Keeps preview generation cheap regardless of how large the underlying
+/// file is, while still routing clients through this server rather than
+/// handing out the third-party URL directly.
+#[cfg(feature = "url_preview")]
+#[implement(Service)]
+fn register_lazy_media(&self, url: &str) -> String {
+	use ruma::Mxc;
+	use tuwunel_core::utils::random_string;
+
+	let mxc = Mxc {
+		server_name: self.services.globals.server_name(),
+		media_id: &random_string(super::MXC_LENGTH),
+	};
+
+	self.db.insert_lazy_media(&mxc, url);
+
+	mxc.to_string()
+}
+
+#[cfg(feature = "url_preview")]
+#[implement(Service)]
+#[expect(clippy::unused_async)]
+pub async fn download_video(&self, response: reqwest::Response) -> Result<UrlPreviewData> {
+	Ok(UrlPreviewData {
+		video: Some(self.register_lazy_media(response.url().as_str())),
+		video_size: response
+			.content_length()
+			.and_then(|len| usize::try_from(len).ok()),
+		..Default::default()
+	})
+}
+
+#[cfg(not(feature = "url_preview"))]
+#[implement(Service)]
+#[expect(clippy::unused_async)]
+pub async fn download_video(&self, _response: reqwest::Response) -> Result<UrlPreviewData> {
+	Err!(FeatureDisabled("url_preview"))
+}
+
+#[cfg(feature = "url_preview")]
+#[implement(Service)]
+#[expect(clippy::unused_async)]
+pub async fn download_audio(&self, response: reqwest::Response) -> Result<UrlPreviewData> {
+	Ok(UrlPreviewData {
+		audio: Some(self.register_lazy_media(response.url().as_str())),
+		audio_size: response
+			.content_length()
+			.and_then(|len| usize::try_from(len).ok()),
+		..Default::default()
+	})
+}
+
+#[cfg(not(feature = "url_preview"))]
+#[implement(Service)]
+#[expect(clippy::unused_async)]
+pub async fn download_audio(&self, _response: reqwest::Response) -> Result<UrlPreviewData> {
 	Err!(FeatureDisabled("url_preview"))
 }
 
@@ -247,9 +325,52 @@ async fn download_html(
 				}
 			}
 
-			self.download_image(image_response).await?
+			// a failing og:image must not become a preview mxc the relay is
+			// guaranteed to reject; skip it and keep the textual preview
+			if image_response.status().is_success() {
+				self.download_image(image_response).await?
+			} else {
+				debug!(
+					?image_url,
+					status = ?image_response.status(),
+					"Skipping og:image with unsuccessful response"
+				);
+
+				UrlPreviewData::default()
+			}
 		},
 	};
+
+	// og:video/og:audio are registered as lazy media (see register_lazy_media)
+	// rather than fetched here, so a page with a large og:video never costs a
+	// preview request any bandwidth; the URL is only fetched, SSRF-checked,
+	// and relayed when a client asks for the resulting mxc:// URI.
+	// check_url_host screens IP-literal URLs here only so a preview never
+	// hands out an mxc that the same check at relay time is guaranteed to
+	// reject.
+	if let Some(obj) = html.opengraph.videos.first()
+		&& let Ok(video_url) = url.join(&obj.url)
+		&& ["http", "https"].contains(&video_url.scheme())
+		&& self.check_url_host(&video_url).is_ok()
+	{
+		data.video = Some(self.register_lazy_media(video_url.as_str()));
+		data.video_width = obj
+			.properties
+			.get("width")
+			.and_then(|w| w.parse().ok());
+		data.video_height = obj
+			.properties
+			.get("height")
+			.and_then(|h| h.parse().ok());
+	}
+
+	if let Some(obj) = html.opengraph.audios.first()
+		&& let Ok(audio_url) = url.join(&obj.url)
+		&& ["http", "https"].contains(&audio_url.scheme())
+		&& self.check_url_host(&audio_url).is_ok()
+	{
+		data.audio = Some(self.register_lazy_media(audio_url.as_str()));
+	}
 
 	let props = html.opengraph.properties;
 

--- a/src/service/media/preview.rs
+++ b/src/service/media/preview.rs
@@ -146,14 +146,30 @@ pub async fn request_url_preview(&self, url: &Url) -> Result<UrlPreviewData> {
 		}
 	}
 
-	// an upstream error response must not be turned into a cached preview
-	if !response.status().is_success() {
+	// an upstream error response must not be turned into a cached preview.
+	// origins commonly gate pages and media differently by agent, so when a
+	// distinct media agent is configured, a page-agent rejection is not
+	// final: the URL may be a direct media link acceptable to the media
+	// client (see media_refetch for the successful counterpart).
+	let status = response.status();
+	let mut via_media_client = false;
+	let response = if status.is_success() {
+		response
+	} else if self
+		.services
+		.config
+		.url_preview_media_user_agent
+		.is_some()
+	{
+		via_media_client = true;
+		self.media_response(url).await?
+	} else {
 		return Err!(Request(NotFound(debug_warn!(
-			status = ?response.status(),
+			?status,
 			%url,
 			"URL preview request failed"
 		))));
-	}
+	};
 
 	let content_type = response
 		.headers()
@@ -164,10 +180,40 @@ pub async fn request_url_preview(&self, url: &Url) -> Result<UrlPreviewData> {
 		.to_owned();
 
 	let data = match content_type.as_str() {
-		| html if html.starts_with("text/html") => self.download_html(url, response).await?,
-		| img if img.starts_with("image/") => self.download_image(response).await?,
-		| video if video.starts_with("video/") => self.download_video(response).await?,
-		| audio if audio.starts_with("audio/") => self.download_audio(response).await?,
+		| html if html.starts_with("text/html") => {
+			// pages are only crawled with the page client; its rejection
+			// stands even when the media client was served a page
+			if via_media_client {
+				return Err!(Request(NotFound(debug_warn!(
+					?status,
+					%url,
+					"URL preview request failed"
+				))));
+			}
+
+			self.download_html(url, response).await?
+		},
+		| img if img.starts_with("image/") => {
+			let response = self
+				.media_refetch(url, response, via_media_client)
+				.await?;
+
+			self.download_image(response).await?
+		},
+		| video if video.starts_with("video/") => {
+			let response = self
+				.media_refetch(url, response, via_media_client)
+				.await?;
+
+			self.download_video(response).await?
+		},
+		| audio if audio.starts_with("audio/") => {
+			let response = self
+				.media_refetch(url, response, via_media_client)
+				.await?;
+
+			self.download_audio(response).await?
+		},
 		| _ => return Err!(Request(Unknown("Unsupported Content-Type"))),
 	};
 
@@ -211,6 +257,65 @@ pub async fn download_image(&self, response: reqwest::Response) -> Result<UrlPre
 #[expect(clippy::unused_async)]
 pub async fn download_image(&self, _response: reqwest::Response) -> Result<UrlPreviewData> {
 	Err!(FeatureDisabled("url_preview"))
+}
+
+/// Fetch a URL with the media client, applying the same address and status
+/// screening as the page fetch. Direct preview media is measured and
+/// registered from the media client's response so it matches what the relay
+/// will serve.
+#[cfg(feature = "url_preview")]
+#[implement(Service)]
+async fn media_response(&self, url: &Url) -> Result<reqwest::Response> {
+	let client = &self.services.client.url_preview_media;
+	let response = client.get(url.as_str()).send().await?;
+
+	if let Some(remote_addr) = response.remote_addr()
+		&& let Ok(ip) = IPAddress::parse(remote_addr.ip().to_string())
+		&& !self.services.client.valid_cidr_range(&ip)
+	{
+		return Err!(Request(Forbidden("Requesting from this address is forbidden")));
+	}
+
+	if !response.status().is_success() {
+		return Err!(Request(NotFound(debug_warn!(
+			status = ?response.status(),
+			%url,
+			"URL preview media request failed"
+		))));
+	}
+
+	Ok(response)
+}
+
+#[cfg(not(feature = "url_preview"))]
+#[implement(Service)]
+#[expect(clippy::unused_async)]
+async fn media_response(&self, _url: &Url) -> Result<reqwest::Response> {
+	Err!(FeatureDisabled("url_preview"))
+}
+
+/// Replace a page-client response with the media client's for a direct media
+/// URL. When no distinct media agent is configured the two clients are
+/// identical and the original response is used as-is, avoiding a second
+/// request.
+#[implement(Service)]
+async fn media_refetch(
+	&self,
+	url: &Url,
+	response: reqwest::Response,
+	via_media_client: bool,
+) -> Result<reqwest::Response> {
+	if via_media_client
+		|| self
+			.services
+			.config
+			.url_preview_media_user_agent
+			.is_none()
+	{
+		return Ok(response);
+	}
+
+	self.media_response(url).await
 }
 
 /// Mint a local mxc:// URI that lazily resolves to `url`: no bytes are
@@ -304,7 +409,11 @@ async fn download_html(
 
 	// `webpage` does not resolve relative URLs in `og:` meta tags; resolve
 	// against the page URL so e.g. `og:image=test.png` becomes absolute.
-	let client = &self.services.client.url_preview;
+	//
+	// the measurement fetch is a media fetch: it must use the same client
+	// as the relay, or the origin could serve the measurement different
+	// content than the relayed mxc.
+	let client = &self.services.client.url_preview_media;
 	let mut data = match html.opengraph.images.first() {
 		| None => UrlPreviewData::default(),
 		| Some(obj) => {

--- a/src/service/media/remote.rs
+++ b/src/service/media/remote.rs
@@ -246,7 +246,7 @@ async fn handle_content_file(&self, mxc: &Mxc<'_>, content: Content) -> Result<M
 
 #[implement(super::Service)]
 async fn handle_location(&self, mxc: &Mxc<'_>, location: &str) -> Result<Media> {
-	self.location_request(location)
+	self.location_request(&self.services.client.extern_media, location)
 		.await
 		.map_err(|error| {
 			err!(Request(NotFound(
@@ -256,19 +256,17 @@ async fn handle_location(&self, mxc: &Mxc<'_>, location: &str) -> Result<Media> 
 }
 
 #[implement(super::Service)]
-async fn location_request(&self, location: &str) -> Result<Media> {
+pub(super) async fn location_request(
+	&self,
+	client: &reqwest::Client,
+	location: &str,
+) -> Result<Media> {
 	let url = Url::parse(location)
 		.map_err(|e| err!(Request(Unknown("Invalid media location URL: {e}"))))?;
 
 	self.check_url_host(&url)?;
 
-	let response = self
-		.services
-		.client
-		.extern_media
-		.get(url.as_str())
-		.send()
-		.await?;
+	let response = client.get(url.as_str()).send().await?;
 
 	if let Some(remote_addr) = response.remote_addr()
 		&& !self
@@ -277,6 +275,15 @@ async fn location_request(&self, location: &str) -> Result<Media> {
 			.valid_cidr_range_ip(remote_addr.ip())
 	{
 		return Err!(Request(Forbidden("Requesting from this address is forbidden")));
+	}
+
+	// an upstream error document must not be relayed as media
+	if !response.status().is_success() {
+		return Err!(Request(NotFound(debug_warn!(
+			status = ?response.status(),
+			%url,
+			"Fetching media from location failed"
+		))));
 	}
 
 	let content_type = response

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -160,10 +160,16 @@ impl super::Service {
 			return self.get_thumbnail_saved(metadata).await;
 		}
 
-		let metadata = self
+		// the original may be lazy URL-preview media, which is relayed rather
+		// than stored, leaving nothing to thumbnail; serve the original like
+		// the unparsable-media fallback does
+		let Ok(metadata) = self
 			.db
 			.search_file_metadata(mxc, &Dim::default())
-			.await?;
+			.await
+		else {
+			return self.get_stored(mxc).await;
+		};
 
 		self.get_thumbnail_generate(mxc, &dim, metadata)
 			.await

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2206,10 +2206,18 @@
 #url_preview_check_root_domain = false
 
 # User-Agent header the URL preview client sends when fetching pages
-# and media for previews. When unset, the versioned server User-Agent
-# is used followed by "preview", e.g. "Tuwunel/1.8.1 preview".
+# to extract their OpenGraph tags. When unset, the versioned server
+# User-Agent is used followed by "preview", e.g. "Tuwunel/1.8.1
+# preview".
 #
 #url_preview_user_agent =
+
+# User-Agent header sent when fetching and relaying URL preview media
+# files themselves (og:image, og:video, og:audio, and direct links),
+# as opposed to the pages they appear on. When unset, falls back to
+# `url_preview_user_agent`, then to the versioned server User-Agent.
+#
+#url_preview_media_user_agent =
 
 # List of forbidden room aliases and room IDs as strings of regex
 # patterns.

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -2205,6 +2205,12 @@
 #
 #url_preview_check_root_domain = false
 
+# User-Agent header the URL preview client sends when fetching pages
+# and media for previews. When unset, the versioned server User-Agent
+# is used followed by "preview", e.g. "Tuwunel/1.8.1 preview".
+#
+#url_preview_user_agent =
+
 # List of forbidden room aliases and room IDs as strings of regex
 # patterns.
 #


### PR DESCRIPTION
<!--
Thanks for contributing to Tuwunel! Please read the contributing guide before
opening a pull request:
https://github.com/matrix-construct/tuwunel/blob/main/CONTRIBUTING.md

Your pull request can target either the `dev` branch or the `main` branch.
If the work is unfinished, open it as a draft so its status is clear.
-->

### What does this PR do?

<!--
Describe the change and the motivation behind it. If it addresses an open
issue, link it with "fixes #123" (bugs) or "closes #123".
-->

the motivation for this PR is primarily to close #394 , but it also basically completely changes how url previews are handled. 

currently, any media url preview (for images only, because anything else is unsupported) downloads the preview image to the media folder, with no functional cleanup method (it is marked // TODO). this same pattern should not be extended to other media types (as continuwuity has done, for video especially) because they can be much larger and would take much more storage space to download and then serve to the client.

other applications that show URL previews simply proxy the media request through their servers to prevent leaking client IP addresses, they do not permanently save the media to serve later. this implements that same behaviour by creating a table of mxc urls that are to be proxied instead of served from the media folder.

additionally, this PR adds the ability to change the user agent used by the media preview and media proxy clients. some websites serve different content depending on the user agent of the client, so it may be in the interest of server administrators to have their servers identify as a common preview-generating bot/crawler (discordbot for example) when fetching opengraph tags, and to use a different UA when proxying direct media requests for the client (eg, identify as a common browser, because this is not a bot-driven crawling request, but a user requesting media through a proxy. this is the same behaviour used by (for example) [discord](https://github.com/discord/discord-api-docs/issues/1600#issuecomment-628529359))

---

as a note, this PR specifically does *not* fix the issues with the url preview table schema that causes returned tags to be mislabeled (as noted in the latter part of issue #394) . this was discussed in the Tuwunel Fanclub Support channel and there is a general agreement that that table is kinda broken, and needs to be changed to json or cbor at some point. i think that's a little out of scope for this PR, so the existing incorrect behaviour will remain and will also affect this PR's preview generation. It'll probably get resolved by unbreaking that schema.

---

additionally, i'd like to fully disclose that this PR was developed using AI tools. I haven't tried to disguise this, as you can see by the co-author on each commit. I have reviewed this PR personally, gotten a separate top tier AI agent (gpt-5.6-sol) that did not participate in development to review it as well, and deployed and tested it on my own home server (matrix.crafty.moe). it works pretty well. if you'd like me to amend all the commits to remove the claude co-author i can do that.

I understand being hesitant with merging in AI-generated code, so i have followed the advice given to me in creating this pr

```
az4521 (@az4521:matrix.crafty.moe)
can I be clauding it or nah

grin (@grin:grin.hu)
Nah I guess. Or review it so much that it's indistinguishable from the code of a thinking human. AI is a junior coder, it needs a sr. reviewer.
```

i believe this code is on par with a thinking human's code, and it is at the very least a big improvement from the existing inherited semi-broken unfinished drive-filling preview generation code. please let me know if you find any issues with it, and I will do my best to resolve them.

---

btw, it might be a good idea to add some more tests to complement for the UA behaviour and for other media types' previews. this thing passes the existing test but it's a pretty weak one ngl

### Checklist

- [X] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [X] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [X] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [X] User-facing changes are reflected in `docs/`.
- [X] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
