### PR TITLE
sys/usage: fix Usage on non-unix and macOS thread_usage

### DIFF
--- a/src/core/utils/sys/usage.rs
+++ b/src/core/utils/sys/usage.rs
@@ -1,8 +1,18 @@
-pub use nix::sys::resource::Usage;
 #[cfg(unix)]
-use nix::sys::resource::{UsageWho, getrusage};
+use nix::sys::resource::{Usage as NixUsage, UsageWho, getrusage};
 
 use crate::{Result, expected};
+
+/// Resource usage wrapper. On Unix this is the nix `Usage` struct populated
+/// by `getrusage()`. On Windows (and any platform where `getrusage` is
+/// unavailable) this is a zero-field Debug stub so that tracing macros like
+/// `?resource_usage` still work.
+#[cfg(unix)]
+pub type Usage = NixUsage;
+
+#[cfg(not(unix))]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Usage;
 
 pub fn virt() -> Result<usize> {
 	Ok(statm_bytes()?
@@ -74,8 +84,13 @@ pub fn statm() -> Result<impl Iterator<Item = usize>> { Ok([0, 0, 0, 0, 0, 0].in
 pub fn usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_SELF).map_err(Into::into) }
 
 #[cfg(not(unix))]
-pub fn usage() -> Result<Usage> { Ok(Usage::default()) }
+pub fn usage() -> Result<Usage> { Ok(Usage) }
 
+/// Per-thread resource usage. On Linux/FreeBSD/OpenBSD, `RUSAGE_THREAD` is
+/// available. On other Unix platforms (macOS, etc.) the thread variant does
+/// not exist, so we fall back to the process-wide `getrusage(RUSAGE_SELF)`
+/// which returns a non-zero, well-defined `Usage` value — better than
+/// relying on `Usage::default()` (which nix does not implement).
 #[cfg(any(
 	target_os = "linux",
 	target_os = "freebsd",
@@ -83,11 +98,15 @@ pub fn usage() -> Result<Usage> { Ok(Usage::default()) }
 ))]
 pub fn thread_usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_THREAD).map_err(Into::into) }
 
-#[cfg(not(any(
-	target_os = "linux",
-	target_os = "freebsd",
-	target_os = "openbsd"
-)))]
-pub fn thread_usage() -> Result<Usage> {
-	unimplemented!("RUSAGE_THREAD available on this platform")
-}
+#[cfg(all(
+	unix,
+	not(any(
+		target_os = "linux",
+		target_os = "freebsd",
+		target_os = "openbsd"
+	))
+))]
+pub fn thread_usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_SELF).map_err(Into::into) }
+
+#[cfg(not(unix))]
+pub fn thread_usage() -> Result<Usage> { Ok(Usage) }


### PR DESCRIPTION
### What does this PR do?

Fixes two related resource-usage problems on non-Linux targets.

1. On non-unix targets `usage()` returned `Ok(Usage::default())`, but the
   re-exported nix `Usage` type does not implement `Default`, so the code did
   not compile on those targets. This introduces a small `#[cfg(not(unix))]`
   zero-field `Usage` stub (deriving `Debug`/`Default`/`Clone`/`Copy`) and
   keeps the nix `Usage` as a type alias on unix, so tracing on the type still
   works everywhere.

2. On unix platforms without `RUSAGE_THREAD` (macOS and others),
   `thread_usage()` was `unimplemented!()` and panicked when called. This falls
   back to the process-wide `getrusage(RUSAGE_SELF)`, which returns a
   well-defined value, and provides a matching non-unix stub.

The Linux/FreeBSD/OpenBSD `thread_usage()` path (using `RUSAGE_THREAD`) is
unchanged; only the non-`RUSAGE_THREAD` unix arm and the non-unix arms are
affected.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.