### PR TITLE
users: preserve zero one-time-key counts

### DIFF
--- a/src/service/users/keys.rs
+++ b/src/service/users/keys.rs
@@ -310,51 +310,17 @@ pub async fn count_one_time_keys(
 
 /// Keep zero-count algorithms visible to clients after an OTK pool is drained.
 ///
-/// An empty map is omitted from `/sync` by ruma. Some clients, including nio,
-/// interpret an omitted count as "unknown" and therefore do not replenish a
-/// previously-uploaded Olm account. `curve25519` is retained for compatibility
-/// with clients which still require the legacy count in `/keys/upload`.
+/// An empty map is omitted from `/sync` by ruma. Some clients interpret an
+/// omitted count as "unknown" and therefore do not replenish a
+/// previously-uploaded Olm account. Only `signed_curve25519` is seeded,
+/// matching Synapse; clients do not maintain unsigned curve25519 keys.
 fn complete_one_time_key_counts(
 	mut counts: BTreeMap<OneTimeKeyAlgorithm, UInt>,
 ) -> BTreeMap<OneTimeKeyAlgorithm, UInt> {
 	counts
-		.entry(OneTimeKeyAlgorithm::from("curve25519"))
-		.or_default();
-	counts
 		.entry(OneTimeKeyAlgorithm::SignedCurve25519)
 		.or_default();
 	counts
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn empty_one_time_key_counts_include_supported_zeroes() {
-		let counts = complete_one_time_key_counts(BTreeMap::new());
-
-		assert_eq!(
-			counts.get(&OneTimeKeyAlgorithm::from("curve25519")),
-			Some(&UInt::from(0_u32))
-		);
-		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(0_u32)));
-	}
-
-	#[test]
-	fn existing_one_time_key_counts_are_preserved() {
-		let mut counts = BTreeMap::new();
-		counts.insert(OneTimeKeyAlgorithm::from("curve25519"), UInt::from(11_u32));
-		counts.insert(OneTimeKeyAlgorithm::SignedCurve25519, UInt::from(17_u32));
-
-		let counts = complete_one_time_key_counts(counts);
-
-		assert_eq!(
-			counts.get(&OneTimeKeyAlgorithm::from("curve25519")),
-			Some(&UInt::from(11_u32))
-		);
-		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(17_u32)));
-	}
 }
 
 /// MSC4225: drop the `excess` oldest rows for this `(user, device)`. Forward
@@ -786,4 +752,32 @@ where
 	}
 
 	Ok(cross_signing_key)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn empty_one_time_key_counts_include_signed_zero() {
+		let counts = complete_one_time_key_counts(BTreeMap::new());
+
+		assert_eq!(counts.len(), 1);
+		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(0_u32)));
+	}
+
+	#[test]
+	fn existing_one_time_key_counts_are_preserved() {
+		let mut counts = BTreeMap::new();
+		counts.insert(OneTimeKeyAlgorithm::from("curve25519"), UInt::from(11_u32));
+		counts.insert(OneTimeKeyAlgorithm::SignedCurve25519, UInt::from(17_u32));
+
+		let counts = complete_one_time_key_counts(counts);
+
+		assert_eq!(
+			counts.get(&OneTimeKeyAlgorithm::from("curve25519")),
+			Some(&UInt::from(11_u32))
+		);
+		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(17_u32)));
+	}
 }

--- a/src/service/users/keys.rs
+++ b/src/service/users/keys.rs
@@ -276,6 +276,8 @@ pub async fn count_one_time_keys(
 	device_id: &DeviceId,
 ) -> BTreeMap<OneTimeKeyAlgorithm, UInt> {
 	let Some(otk) = self.db.onetimekeyid4225_otk.as_ref() else {
+		// Without the MSC4225 column this node cannot observe the authoritative
+		// pool, so preserve "unknown" instead of falsely reporting zero keys.
 		return BTreeMap::new();
 	};
 
@@ -303,7 +305,56 @@ pub async fn count_one_time_keys(
 			.await;
 	}
 
-	algorithm_counts
+	complete_one_time_key_counts(algorithm_counts)
+}
+
+/// Keep zero-count algorithms visible to clients after an OTK pool is drained.
+///
+/// An empty map is omitted from `/sync` by ruma. Some clients, including nio,
+/// interpret an omitted count as "unknown" and therefore do not replenish a
+/// previously-uploaded Olm account. `curve25519` is retained for compatibility
+/// with clients which still require the legacy count in `/keys/upload`.
+fn complete_one_time_key_counts(
+	mut counts: BTreeMap<OneTimeKeyAlgorithm, UInt>,
+) -> BTreeMap<OneTimeKeyAlgorithm, UInt> {
+	counts
+		.entry(OneTimeKeyAlgorithm::from("curve25519"))
+		.or_default();
+	counts
+		.entry(OneTimeKeyAlgorithm::SignedCurve25519)
+		.or_default();
+	counts
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn empty_one_time_key_counts_include_supported_zeroes() {
+		let counts = complete_one_time_key_counts(BTreeMap::new());
+
+		assert_eq!(
+			counts.get(&OneTimeKeyAlgorithm::from("curve25519")),
+			Some(&UInt::from(0_u32))
+		);
+		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(0_u32)));
+	}
+
+	#[test]
+	fn existing_one_time_key_counts_are_preserved() {
+		let mut counts = BTreeMap::new();
+		counts.insert(OneTimeKeyAlgorithm::from("curve25519"), UInt::from(11_u32));
+		counts.insert(OneTimeKeyAlgorithm::SignedCurve25519, UInt::from(17_u32));
+
+		let counts = complete_one_time_key_counts(counts);
+
+		assert_eq!(
+			counts.get(&OneTimeKeyAlgorithm::from("curve25519")),
+			Some(&UInt::from(11_u32))
+		);
+		assert_eq!(counts.get(&OneTimeKeyAlgorithm::SignedCurve25519), Some(&UInt::from(17_u32)));
+	}
 }
 
 /// MSC4225: drop the `excess` oldest rows for this `(user, device)`. Forward


### PR DESCRIPTION
While testing encrypted MatrixRTC voice calls for MindRoom agents, I hit a failure once the agent's signed Curve25519 one-time-key pool had been fully consumed. Tuwunel builds the count map from rows currently in the store; after the last key is claimed the map becomes empty, and Ruma omits the empty `device_one_time_keys_count` from `/sync`. Clients that distinguish an omitted count (no update / unknown) from an explicit zero can then leave an already-initialized device without replenishing its pool, so fresh peers cannot establish Olm sessions.

This keeps `signed_curve25519` visible at zero after a pool is drained, matching Synapse and the algorithm clients use for Olm one-time keys. Existing non-zero counts and any other algorithms already present in the map are preserved. The missing-MSC4225-column path still returns an empty map, because that node cannot observe the authoritative pool and should not manufacture a zero count.

Although we found this through encrypted MatrixRTC media-key exchange, the issue is general to any E2EE device whose one-time-key pool reaches zero. For context, this surfaced during the [MindRoom MatrixRTC voice-call work](https://github.com/mindroom-ai/mindroom/pull/1452); the client-side half of the drained-pool recovery is described in [mindroom-ai/mindroom#1499](https://github.com/mindroom-ai/mindroom/pull/1499).

Verified on top of current `main`:

- `cargo +nightly fmt --all -- --check`
- `cargo test -p tuwunel_service one_time_key_counts_` — 2 tests pass
- `cargo clippy -p tuwunel_service --tests -- -D warnings`
