### PR TITLE
api/client: allow MatrixRTC transport discovery without a token

### DIFF
--- a/src/api/client/versions.rs
+++ b/src/api/client/versions.rs
@@ -73,7 +73,7 @@ static VERSIONS: [&str; 27] = [
 	"v1.19",  /* mutual rooms (MSC2666) */
 ];
 
-static UNSTABLE_FEATURES: [&str; 37] = [
+static UNSTABLE_FEATURES: [&str; 38] = [
 	"org.matrix.e2e_cross_signing",
 	// private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285)
 	"org.matrix.msc2285.stable",
@@ -101,6 +101,8 @@ static UNSTABLE_FEATURES: [&str; 37] = [
 	"org.matrix.msc3916.stable",
 	// intentional mentions (https://github.com/matrix-org/matrix-spec-proposals/pull/3952)
 	"org.matrix.msc3952_intentional_mentions",
+	// MatrixRTC transport discovery (https://github.com/matrix-org/matrix-spec-proposals/pull/4143)
+	"org.matrix.msc4143",
 	// MSC4133 (custom profile fields) and MSC4175 (m.tz) stabilized in
 	// Matrix 1.16; advertise the historical unstable prefixes alongside
 	// the post-merge `.stable` flags for clients that haven't migrated.

--- a/src/api/router/auth/dispatch.rs
+++ b/src/api/router/auth/dispatch.rs
@@ -7,6 +7,7 @@ use ruma::{
 			AccessToken, AccessTokenOptional, AppserviceToken, AppserviceTokenOptional,
 			AuthScheme, NoAccessToken, NoAuthentication,
 		},
+		client::rtc::transports,
 		error::{ErrorKind, UnknownTokenErrorData},
 		federation::authentication::ServerSignatures,
 	},
@@ -102,7 +103,7 @@ impl AuthDispatch for AccessToken {
 		request: &mut Request,
 		_json_body: Option<&CanonicalJsonValue>,
 		token: Token,
-		_route: TypeId,
+		route: TypeId,
 	) -> Result<Auth> {
 		match token {
 			| Token::Invalid => unknown_token(),
@@ -114,10 +115,18 @@ impl AuthDispatch for AccessToken {
 				_expires_at: user.2,
 				..Auth::default()
 			}),
+			| Token::None if allows_missing_access_token(route) => Ok(Auth::default()),
 
 			| Token::None => Err!(Request(MissingToken("Missing access token."))),
 		}
 	}
+}
+
+/// MSC4143 transport discovery happens before Element Call attaches Matrix
+/// authentication. The response contains only operator-configured public SFU
+/// metadata, matching the same data exposed through client `.well-known`.
+fn allows_missing_access_token(route: TypeId) -> bool {
+	route == TypeId::of::<transports::v1::Request>()
 }
 
 impl AuthDispatch for AccessTokenOptional {
@@ -237,4 +246,17 @@ async fn expired_token(services: &Services, access_token: &str) -> Result<Auth> 
 		ErrorKind::UnknownToken(UnknownTokenErrorData { soft_logout: true }),
 		"Expired access token.",
 	))
+}
+
+#[cfg(test)]
+mod tests {
+	use ruma::api::client::discovery::get_supported_versions;
+
+	use super::*;
+
+	#[test]
+	fn only_rtc_transport_discovery_bypasses_access_token_auth() {
+		assert!(allows_missing_access_token(TypeId::of::<transports::v1::Request>()));
+		assert!(!allows_missing_access_token(TypeId::of::<get_supported_versions::Request>()));
+	}
 }


### PR DESCRIPTION
While bringing up MatrixRTC voice calls for MindRoom agents, Element Call failed with `MISSING_MATRIX_RTC_TRANSPORT` even though Tuwunel's transport endpoint and LiveKit focus were configured correctly. The discovery request reached `/_matrix/client/unstable/org.matrix.msc4143/rtc/transports` without an Authorization header; because Ruma classifies that request as `AccessToken`, Tuwunel's generic auth dispatch rejected it before the configured transport could be returned. The same unauthenticated request behavior has also been reported against Element clients in [element-hq/element-call#3825](https://github.com/element-hq/element-call/issues/3825).

This adds a narrow compatibility exception for exactly `transports::v1::Request` when no token is present. Invalid and expired tokens still fail, and every other access-token endpoint keeps its current behavior. The response contains only operator-configured transport metadata already exposed publicly through `/.well-known/matrix/client`; it contains no user, device, or room data.

The PR also advertises `org.matrix.msc4143` in `/versions`, matching the MatrixRTC endpoint Tuwunel already implements and the feature flag used by Synapse.

For context, this surfaced while implementing [MindRoom agents that join MatrixRTC voice calls](https://github.com/mindroom-ai/mindroom/pull/1452). We carry the fix in the [MindRoom Tuwunel fork](https://github.com/mindroom-ai/mindroom-tuwunel), but both the failure mode and the endpoint are general to MatrixRTC deployments.

Verified on top of current `main`:

- `cargo +nightly fmt --all -- --check`
- `cargo test -p tuwunel_api only_rtc_transport_discovery_bypasses_access_token_auth` — 1 test passes
- `cargo clippy -p tuwunel_api --tests -- -D warnings`
