### PR TITLE
fix: appservice presence exclusion

### DIFF
--- a/src/api/client/profile.rs
+++ b/src/api/client/profile.rs
@@ -135,6 +135,7 @@ pub(crate) async fn set_profile_field_route(
 			body.sender_device.as_deref(),
 			Some(client),
 			&PresenceState::Online,
+			body.appservice_info.as_ref().into(),
 		)
 		.await?;
 
@@ -177,6 +178,7 @@ pub(crate) async fn delete_profile_field_route(
 			body.sender_device.as_deref(),
 			Some(client),
 			&PresenceState::Online,
+			body.appservice_info.as_ref().into(),
 		)
 		.await?;
 

--- a/src/api/client/read_marker/read_markers.rs
+++ b/src/api/client/read_marker/read_markers.rs
@@ -111,6 +111,7 @@ pub(crate) async fn set_read_marker_route(
 				body.sender_device.as_deref(),
 				Some(client),
 				&PresenceState::Online,
+				body.appservice_info.as_ref().into(),
 			)
 			.await
 			.ok();

--- a/src/api/client/read_marker/receipt.rs
+++ b/src/api/client/read_marker/receipt.rs
@@ -121,6 +121,7 @@ pub(crate) async fn create_receipt_route(
 					body.sender_device.as_deref(),
 					Some(client),
 					&PresenceState::Online,
+					body.appservice_info.as_ref().into(),
 				)
 				.await
 				.ok();

--- a/src/api/client/sync/v3.rs
+++ b/src/api/client/sync/v3.rs
@@ -236,12 +236,15 @@ pub(crate) async fn sync_events_route(
 			body.sender_device.as_deref(),
 			Some(client),
 			set_presence,
+			body.appservice_info.as_ref().into(),
 		)
 		.inspect_err(inspect_log)
 		.ok();
 
 	// Record user as actively syncing for push suppression heuristic.
-	let note_sync = services.presence.note_sync(sender_user);
+	let note_sync = services
+		.presence
+		.note_sync(sender_user, body.appservice_info.as_ref().into());
 
 	let (filter, ..) = join3(filter, ping_presence, note_sync).await;
 

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -110,7 +110,13 @@ pub(crate) async fn sync_events_v5_route(
 	let conn = conn_val.lock();
 	let ping_presence = services
 		.presence
-		.maybe_ping_presence(sender_user, sender_device, Some(client), &request.set_presence)
+		.maybe_ping_presence(
+			sender_user,
+			sender_device,
+			Some(client),
+			&request.set_presence,
+			body.appservice_info.as_ref().into(),
+		)
 		.inspect_err(inspect_log)
 		.ok();
 

--- a/src/api/client/typing.rs
+++ b/src/api/client/typing.rs
@@ -72,6 +72,7 @@ pub(crate) async fn create_typing_event_route(
 			body.sender_device.as_deref(),
 			Some(client),
 			&PresenceState::Online,
+			body.appservice_info.as_ref().into(),
 		)
 		.await?;
 

--- a/src/service/presence/mod.rs
+++ b/src/service/presence/mod.rs
@@ -27,6 +27,30 @@ use tuwunel_core::{
 };
 
 use self::{aggregate::PresenceAggregator, data::Data};
+use crate::appservice::RegistrationInfo;
+
+/// Authentication origin for activity inferred from a request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InferredActivityOrigin {
+	User,
+	Appservice,
+	Server,
+}
+
+impl InferredActivityOrigin {
+	#[must_use]
+	const fn is_allowed(self) -> bool { !matches!(self, Self::Appservice) }
+}
+
+impl From<Option<&RegistrationInfo>> for InferredActivityOrigin {
+	fn from(appservice: Option<&RegistrationInfo>) -> Self {
+		if appservice.is_some() {
+			Self::Appservice
+		} else {
+			Self::User
+		}
+	}
+}
 
 /// Represents data required to be kept in order to implement the presence
 /// specification.
@@ -88,6 +112,7 @@ impl crate::Service for Service {
 				None,
 				None,
 				&PresenceState::Online,
+				InferredActivityOrigin::Server,
 			)
 			.await;
 
@@ -140,6 +165,7 @@ impl crate::Service for Service {
 				None,
 				None,
 				&PresenceState::Offline,
+				InferredActivityOrigin::Server,
 			)
 			.await;
 
@@ -159,8 +185,8 @@ impl crate::Service for Service {
 impl Service {
 	/// record that a user has just successfully completed a /sync (or
 	/// equivalent activity)
-	pub async fn note_sync(&self, user_id: &UserId) {
-		if !self.services.config.suppress_push_when_active {
+	pub async fn note_sync(&self, user_id: &UserId, origin: InferredActivityOrigin) {
+		if !origin.is_allowed() || !self.services.config.suppress_push_when_active {
 			return;
 		}
 
@@ -290,5 +316,17 @@ impl Service {
 				displayname,
 			},
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::InferredActivityOrigin;
+
+	#[test]
+	fn appservices_do_not_imply_user_activity() {
+		assert!(InferredActivityOrigin::User.is_allowed());
+		assert!(InferredActivityOrigin::Server.is_allowed());
+		assert!(!InferredActivityOrigin::Appservice.is_allowed());
 	}
 }

--- a/src/service/presence/pipeline.rs
+++ b/src/service/presence/pipeline.rs
@@ -19,7 +19,7 @@ use tuwunel_core::{
 };
 
 use super::{
-	Service, TimerFired,
+	InferredActivityOrigin, Service, TimerFired,
 	aggregate::{self, StatusMsg},
 };
 
@@ -217,18 +217,26 @@ impl Service {
 		.await
 	}
 
-	/// Pings the presence of the given user, setting the specified state. When
-	/// device_id is supplied.
+	/// Pings the presence of the given user, setting the specified state.
+	///
+	/// Requests authenticated with an appservice token do not imply user
+	/// activity. In particular, they must not update presence or device
+	/// last-seen data. Explicit appservice presence updates use
+	/// [`Self::set_presence_for_device`] instead.
 	pub async fn maybe_ping_presence(
 		&self,
 		user_id: &UserId,
 		device_id: Option<&DeviceId>,
 		client_ip: Option<IpAddr>,
 		new_state: &PresenceState,
+		origin: InferredActivityOrigin,
 	) -> Result {
 		const REFRESH_TIMEOUT: u64 = 30 * 1000;
 
-		if !self.services.server.config.allow_local_presence || self.services.db.is_read_only() {
+		if !origin.is_allowed()
+			|| !self.services.server.config.allow_local_presence
+			|| self.services.db.is_read_only()
+		{
 			return Ok(());
 		}
 


### PR DESCRIPTION
### What does this PR do?

Fixes #515 

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
