### PR TITLE
fix: prevent stale read receipt updates

### DIFF
--- a/src/api/client/read_marker/read_markers.rs
+++ b/src/api/client/read_marker/read_markers.rs
@@ -29,19 +29,6 @@ pub(crate) async fn set_read_marker_route(
 ) -> Result<set_read_marker::v3::Response> {
 	let sender_user = body.sender_user();
 
-	if body.private_read_receipt.is_some() || body.read_receipt.is_some() {
-		// Route through the dispatcher so per-thread counts are also cleared;
-		// `/read_markers` predates MSC3771 and carries no thread field.
-		services
-			.pusher
-			.reset_notification_counts_for_thread(
-				sender_user,
-				&body.room_id,
-				&ReceiptThread::Unthreaded,
-			)
-			.await;
-	}
-
 	if let Some(event) = &body.fully_read {
 		let fully_read_event = FullyReadEvent {
 			content: FullyReadEventContent { event_id: event.clone() },
@@ -72,6 +59,17 @@ pub(crate) async fn set_read_marker_route(
 			)));
 		};
 
+		// A private receipt is always a real update. Reset before exposing its
+		// stream position so sync cannot observe stale notification counts.
+		services
+			.pusher
+			.reset_notification_counts_for_thread(
+				sender_user,
+				&body.room_id,
+				&ReceiptThread::Unthreaded,
+			)
+			.await;
+
 		services
 			.read_receipt
 			.private_read_set(
@@ -98,10 +96,15 @@ pub(crate) async fn set_read_marker_route(
 
 		services
 			.read_receipt
-			.readreceipt_update(sender_user, &body.room_id, &ReceiptEvent {
-				content: ReceiptEventContent(receipt_content),
-				room_id: body.room_id.clone(),
-			})
+			.client_readreceipt_update(
+				sender_user,
+				&body.room_id,
+				&ReceiptEvent {
+					content: ReceiptEventContent(receipt_content),
+					room_id: body.room_id.clone(),
+				},
+				body.private_read_receipt.is_some(),
+			)
 			.await;
 
 		services

--- a/src/api/client/read_marker/receipt.rs
+++ b/src/api/client/read_marker/receipt.rs
@@ -69,16 +69,6 @@ pub(crate) async fn create_receipt_route(
 		}
 	}
 
-	if matches!(
-		&body.receipt_type,
-		create_receipt::v3::ReceiptType::Read | create_receipt::v3::ReceiptType::ReadPrivate
-	) {
-		services
-			.pusher
-			.reset_notification_counts_for_thread(sender_user, &body.room_id, &body.thread)
-			.await;
-	}
-
 	match body.receipt_type {
 		| create_receipt::v3::ReceiptType::FullyRead => {
 			let fully_read_event = FullyReadEvent {
@@ -108,10 +98,15 @@ pub(crate) async fn create_receipt_route(
 
 			services
 				.read_receipt
-				.readreceipt_update(sender_user, &body.room_id, &ReceiptEvent {
-					content: ReceiptEventContent(receipt_content),
-					room_id: body.room_id.clone(),
-				})
+				.client_readreceipt_update(
+					sender_user,
+					&body.room_id,
+					&ReceiptEvent {
+						content: ReceiptEventContent(receipt_content),
+						room_id: body.room_id.clone(),
+					},
+					false,
+				)
 				.await;
 
 			services
@@ -137,6 +132,11 @@ pub(crate) async fn create_receipt_route(
 					"Event is a backfilled PDU and cannot be marked as read."
 				)));
 			};
+
+			services
+				.pusher
+				.reset_notification_counts_for_thread(sender_user, &body.room_id, &body.thread)
+				.await;
 
 			services
 				.read_receipt

--- a/src/service/rooms/read_receipt/data.rs
+++ b/src/service/rooms/read_receipt/data.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
 use ruma::{
-	CanonicalJsonObject, RoomId, UserId,
+	CanonicalJsonObject, OwnedEventId, RoomId, UserId,
 	events::{
 		AnySyncEphemeralRoomEvent,
 		receipt::{ReceiptEvent, ReceiptThread},
@@ -35,6 +35,38 @@ impl Data {
 			readreceiptid_readreceipt: db["readreceiptid_readreceipt"].clone(),
 			services: args.services.clone(),
 		}
+	}
+
+	#[inline]
+	pub(super) async fn current_receipt_event_id(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+		thread_kind: &str,
+	) -> Option<OwnedEventId> {
+		type Key<'a> = (&'a RoomId, u64, &'a UserId, &'a str);
+		type KeyVal<'a> = (Key<'a>, Json<ReceiptEvent>);
+
+		let last_possible_key = (room_id, u64::MAX);
+
+		self.readreceiptid_readreceipt
+			.rev_stream_from(&last_possible_key)
+			.ignore_err()
+			.ready_take_while(|((stored_room_id, ..), _): &KeyVal<'_>| *stored_room_id == room_id)
+			.ready_filter_map(|((_, _, stored_user, stored_kind), Json(event)): KeyVal<'_>| {
+				(stored_user == user_id && stored_kind == thread_kind)
+					.then(|| {
+						event
+							.content
+							.into_iter()
+							.next()
+							.map(|(event_id, _)| event_id)
+					})
+					.flatten()
+			})
+			.boxed()
+			.next()
+			.await
 	}
 
 	#[inline]
@@ -280,7 +312,7 @@ impl Data {
 ///
 /// Appended to the receipt-row key as a tolerant trailing field. Pre-
 /// MSC3771 rows have no trailing kind; they round-trip as `""`.
-fn event_thread_kind(event: &ReceiptEvent) -> &str {
+pub(super) fn event_thread_kind(event: &ReceiptEvent) -> &str {
 	debug_assert!(
 		event
 			.content

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -6,7 +6,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use futures::{Stream, StreamExt};
 use ruma::{
-	MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomId, UInt, UserId,
+	EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UInt,
+	UserId,
 	api::appservice::event::push_events::v1::EphemeralData,
 	events::{
 		AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent,
@@ -25,11 +26,11 @@ use tuwunel_core::{
 	smallstr::SmallString,
 	smallvec::SmallVec,
 	trace,
-	utils::IterStream,
+	utils::{IterStream, MutexMap},
 	warn,
 };
 
-use self::data::{Data, ReceiptItem};
+use self::data::{Data, ReceiptItem, event_thread_kind};
 
 /// Private read receipts surfaced by `private_read_get`. One legacy
 /// unthreaded row plus zero or more per-thread rows; inline-1 catches the
@@ -41,10 +42,18 @@ pub type PrivateReadEvents = SmallVec<[Raw<AnySyncEphemeralRoomEvent>; 1]>;
 /// including the leading `$`; 48 bytes inline matches the project's
 /// `StateKey` budget and stays inline for every realistic thread root.
 type ThreadKind = SmallString<[u8; 48]>;
+type ReceiptMutexKey = (OwnedRoomId, OwnedUserId, ThreadKind);
+
+#[derive(Clone, Copy)]
+enum NotificationReset {
+	None,
+	OnAdvance,
+}
 
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
 	db: Data,
+	update_mutex: MutexMap<ReceiptMutexKey, ()>,
 }
 
 impl crate::Service for Service {
@@ -52,6 +61,7 @@ impl crate::Service for Service {
 		Ok(Arc::new(Self {
 			services: args.services.clone(),
 			db: Data::new(args),
+			update_mutex: MutexMap::new(),
 		}))
 	}
 
@@ -59,7 +69,13 @@ impl crate::Service for Service {
 }
 
 impl Service {
-	/// Replaces the previous read receipt.
+	/// Advances a public read receipt within its room/user/thread context.
+	///
+	/// A receipt for the same or an older known timeline position is ignored.
+	/// Distinct event IDs with unavailable ordering information are accepted
+	/// for compatibility with receipts whose events are not locally known.
+	/// This method does not alter local notification counts; client API
+	/// receipts must use [`Self::client_readreceipt_update`].
 	#[tracing::instrument(skip(self), level = "debug", name = "set_receipt")]
 	pub async fn readreceipt_update(
 		&self,
@@ -67,6 +83,89 @@ impl Service {
 		room_id: &RoomId,
 		event: &ReceiptEvent,
 	) {
+		self.readreceipt_update_inner(user_id, room_id, event, NotificationReset::None)
+			.await
+	}
+
+	/// Advances a receipt submitted through the client API.
+	///
+	/// Notification counts are reset after the advancement decision but before
+	/// the accepted receipt becomes visible. Set `notifications_already_reset`
+	/// when a private receipt in the same client request performed the reset
+	/// before publishing its own stream position.
+	#[tracing::instrument(skip(self), level = "debug", name = "set_client_receipt")]
+	pub async fn client_readreceipt_update(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+		event: &ReceiptEvent,
+		notifications_already_reset: bool,
+	) {
+		let notification_reset = if notifications_already_reset {
+			NotificationReset::None
+		} else {
+			NotificationReset::OnAdvance
+		};
+
+		self.readreceipt_update_inner(user_id, room_id, event, notification_reset)
+			.await;
+	}
+
+	async fn readreceipt_update_inner(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+		event: &ReceiptEvent,
+		notification_reset: NotificationReset,
+	) {
+		let thread_kind = event_thread_kind(event);
+		let mutex_key = (room_id.to_owned(), user_id.to_owned(), ThreadKind::from(thread_kind));
+		let _guard = self.update_mutex.lock(&mutex_key).await;
+		let event_id = event
+			.content
+			.keys()
+			.next()
+			.expect("receipt event must carry an event id");
+		let current_event_id = self
+			.db
+			.current_receipt_event_id(user_id, room_id, thread_kind)
+			.await;
+
+		let advances = match current_event_id.as_deref() {
+			| Some(current_event_id) if current_event_id != event_id => {
+				let (current_count, target_count) = futures::future::join(
+					self.services
+						.timeline
+						.get_pdu_count(current_event_id),
+					self.services.timeline.get_pdu_count(event_id),
+				)
+				.await;
+
+				receipt_advances(
+					Some(current_event_id),
+					event_id,
+					current_count.ok(),
+					target_count.ok(),
+				)
+			},
+			| current_event_id => receipt_advances(current_event_id, event_id, None, None),
+		};
+
+		if !advances {
+			return;
+		}
+
+		if matches!(notification_reset, NotificationReset::OnAdvance) {
+			self.services
+				.pusher
+				.reset_notification_counts_for_thread(
+					user_id,
+					room_id,
+					&thread_kind_to_receipt(thread_kind),
+				)
+				.await;
+		}
+
 		// update local
 		self.db
 			.readreceipt_update(user_id, room_id, event)
@@ -260,6 +359,22 @@ impl Service {
 
 	pub async fn delete_all_read_receipts(&self, room_id: &RoomId) -> Result {
 		self.db.delete_all_read_receipts(room_id).await
+	}
+}
+
+fn receipt_advances(
+	current_event_id: Option<&EventId>,
+	target_event_id: &EventId,
+	current_count: Option<PduCount>,
+	target_count: Option<PduCount>,
+) -> bool {
+	if current_event_id.is_some_and(|current| current == target_event_id) {
+		return false;
+	}
+
+	match (current_count, target_count) {
+		| (Some(current), Some(target)) => target > current,
+		| _ => true,
 	}
 }
 

--- a/src/service/rooms/read_receipt/tests.rs
+++ b/src/service/rooms/read_receipt/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
-use ruma::{RoomId, UserId};
+use ruma::{EventId, RoomId, UserId};
+use tuwunel_core::PduCount;
 use tuwunel_database::{Interfix, SEP, serialize_to_vec};
 
 const ROOM: &str = "!room:example.com";
@@ -10,6 +11,71 @@ const COUNT: u64 = 42;
 
 fn room() -> &'static RoomId { ROOM.try_into().unwrap() }
 fn user() -> &'static UserId { USER.try_into().unwrap() }
+fn event(id: &'static str) -> &'static EventId { id.try_into().unwrap() }
+
+mod public_receipt_ordering {
+	use super::*;
+	use crate::rooms::read_receipt::receipt_advances;
+
+	const CURRENT: &str = "$current";
+	const TARGET: &str = "$target";
+
+	#[test]
+	fn no_existing_receipt_accepts_target_without_ordering() {
+		assert!(receipt_advances(None, event(TARGET), None, None));
+	}
+
+	#[test]
+	fn identical_event_is_ignored_even_without_ordering() {
+		assert!(!receipt_advances(Some(event(CURRENT)), event(CURRENT), None, None));
+	}
+
+	#[test]
+	fn strictly_newer_timeline_position_advances() {
+		assert!(receipt_advances(
+			Some(event(CURRENT)),
+			event(TARGET),
+			Some(PduCount::Normal(41)),
+			Some(PduCount::Normal(42)),
+		));
+	}
+
+	#[test]
+	fn identical_timeline_position_is_ignored() {
+		assert!(!receipt_advances(
+			Some(event(CURRENT)),
+			event(TARGET),
+			Some(PduCount::Normal(42)),
+			Some(PduCount::Normal(42)),
+		));
+	}
+
+	#[test]
+	fn older_timeline_position_is_ignored() {
+		assert!(!receipt_advances(
+			Some(event(CURRENT)),
+			event(TARGET),
+			Some(PduCount::Normal(43)),
+			Some(PduCount::Normal(42)),
+		));
+	}
+
+	#[test]
+	fn unknown_ordering_accepts_distinct_target() {
+		assert!(receipt_advances(
+			Some(event(CURRENT)),
+			event(TARGET),
+			Some(PduCount::Normal(42)),
+			None,
+		));
+		assert!(receipt_advances(
+			Some(event(CURRENT)),
+			event(TARGET),
+			None,
+			Some(PduCount::Normal(42)),
+		));
+	}
+}
 
 fn legacy_key() -> Vec<u8> {
 	serialize_to_vec((room(), COUNT, user())).expect("serialize legacy key")


### PR DESCRIPTION
### What does this PR do?

Fixes #516 

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
