### PR TITLE
Fix stale typing notifications in sliding sync

### DIFF
--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -165,13 +165,14 @@ pub(crate) async fn sync_events_v5_route(
 		);
 
 		let window;
+		let typing_window;
 		let watchers = services
 			.sync
 			.watch(sender_user, sender_device, services.state_cache.rooms_joined(sender_user))
 			.await;
 
 		conn.next_batch = services.globals.wait_pending().await?;
-		(window, response.lists) = selector::selector(&mut conn, sync_info)
+		(window, typing_window, response.lists) = selector::selector(&mut conn, sync_info)
 			.boxed()
 			.await;
 
@@ -179,8 +180,9 @@ pub(crate) async fn sync_events_v5_route(
 			let rooms = rooms::handle(sync_info, &conn, &window)
 				.map_ok(|response_rooms| response.rooms = response_rooms);
 
-			let extensions = extensions::handle(sync_info, &conn, &window)
-				.map_ok(|response_extensions| response.extensions = response_extensions);
+			let extensions =
+				extensions::handle(sync_info, &conn, &window, typing_window.as_ref())
+					.map_ok(|response_extensions| response.extensions = response_extensions);
 
 			try_join(rooms, extensions).boxed().await?;
 

--- a/src/api/client/sync/v5/extensions.rs
+++ b/src/api/client/sync/v5/extensions.rs
@@ -23,6 +23,7 @@ use super::{SyncInfo, Window, share_encrypted_room};
 	fields(
 		next_batch = conn.next_batch,
 		window = window.len(),
+		typing_window = typing_window.map(Window::len),
 		rooms = conn.rooms.len(),
 		subs = conn.subscriptions.len(),
 	)
@@ -31,6 +32,7 @@ pub(super) async fn handle(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window: &Window,
+	typing_window: Option<&Window>,
 ) -> Result<response::Extensions> {
 	let SyncInfo { .. } = sync_info;
 
@@ -53,7 +55,7 @@ pub(super) async fn handle(
 		.typing
 		.enabled
 		.unwrap_or(false)
-		.then_async(|| typing::collect(sync_info, conn, window));
+		.then_async(|| typing::collect(sync_info, conn, typing_window.unwrap_or(window)));
 
 	let to_device = conn
 		.extensions

--- a/src/api/client/sync/v5/extensions/typing.rs
+++ b/src/api/client/sync/v5/extensions/typing.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use ruma::{
+	OwnedRoomId, RoomId,
 	api::client::sync::sync_events::v5::response,
 	events::typing::{SyncTypingEvent, TypingEventContent},
 	serde::Raw,
@@ -12,6 +13,9 @@ use tuwunel_core::{
 };
 
 use super::{Connection, SyncInfo, Window, selector};
+
+#[cfg(test)]
+mod tests;
 
 #[tracing::instrument(name = "typing", level = "trace", skip_all, ret)]
 pub(super) async fn collect(
@@ -40,24 +44,48 @@ pub(super) async fn collect(
 	selector(sync_info, conn, window, implicit, explicit)
 		.stream()
 		.filter_map(async |room_id| {
+			if !services
+				.state_cache
+				.is_joined(sender_user, room_id)
+				.await
+			{
+				return None;
+			}
+
+			let last_typing_update = services
+				.typing
+				.last_typing_update(room_id)
+				.inspect_err(|e| debug_error!(%room_id, "Failed to get typing update count: {e}"))
+				.await
+				.ok()?;
+
+			if last_typing_update <= conn.globalsince || last_typing_update > conn.next_batch {
+				return None;
+			}
+
 			services
 				.typing
 				.typing_users_for_user(room_id, sender_user)
 				.inspect_err(|e| debug_error!(%room_id, "Failed to get typing events: {e}"))
 				.await
 				.ok()
-				.filter(|users| !users.is_empty())
+				.filter(|users| conn.globalsince != 0 || !users.is_empty())
 				.map(|users| (room_id, users))
 		})
-		.ready_filter_map(|(room_id, users)| {
-			let content = TypingEventContent::new(users);
-			let event = SyncTypingEvent { content };
-			let event = Raw::new(&event);
-
-			Some((room_id.to_owned(), event.ok()?))
-		})
+		.ready_filter_map(|(room_id, users)| room_typing_event(room_id, users))
 		.collect::<BTreeMap<_, _>>()
 		.map(|rooms| Typing { rooms })
 		.map(Ok)
 		.await
+}
+
+fn room_typing_event(
+	room_id: &RoomId,
+	users: Vec<ruma::OwnedUserId>,
+) -> Option<(OwnedRoomId, Raw<SyncTypingEvent>)> {
+	let content = TypingEventContent::new(users);
+	let event = SyncTypingEvent { content };
+	let event = Raw::new(&event);
+
+	Some((room_id.to_owned(), event.ok()?))
 }

--- a/src/api/client/sync/v5/extensions/typing/tests.rs
+++ b/src/api/client/sync/v5/extensions/typing/tests.rs
@@ -1,0 +1,27 @@
+use ruma::{events::typing::SyncTypingEvent, room_id, serde::Raw, user_id};
+
+use super::room_typing_event;
+
+#[test]
+fn room_typing_event_preserves_empty_user_list() {
+	let room_id = room_id!("!room:example.com");
+	let (_, raw) = room_typing_event(room_id, Vec::new()).expect("valid typing event");
+	let event = raw
+		.deserialize()
+		.expect("typing event should deserialize");
+
+	assert!(event.content.user_ids.is_empty());
+}
+
+#[test]
+fn room_typing_event_preserves_typing_users() {
+	let room_id = room_id!("!room:example.com");
+	let user_id = user_id!("@alice:example.com").to_owned();
+	let (_, raw): (_, Raw<SyncTypingEvent>) =
+		room_typing_event(room_id, vec![user_id.clone()]).expect("valid typing event");
+	let event = raw
+		.deserialize()
+		.expect("typing event should deserialize");
+
+	assert_eq!(event.content.user_ids, [user_id]);
+}

--- a/src/api/client/sync/v5/selector.rs
+++ b/src/api/client/sync/v5/selector.rs
@@ -23,11 +23,14 @@ use super::{
 	filter::{filter_room, filter_room_meta},
 };
 
+#[cfg(test)]
+mod tests;
+
 #[tracing::instrument(level = "debug", skip_all)]
 pub(super) async fn selector(
 	conn: &mut Connection,
 	sync_info: SyncInfo<'_>,
-) -> (Window, ResponseLists) {
+) -> (Window, Option<Window>, ResponseLists) {
 	use MembershipState::*;
 
 	let SyncInfo { services, sender_user, .. } = sync_info;
@@ -77,10 +80,18 @@ pub(super) async fn selector(
 	let lists = response_lists(rooms.iter());
 
 	trace!(?lists);
-	let window = window(sync_info, conn, rooms.iter(), &lists, invites_blocked).await;
+	let gated_window = window(sync_info, conn, rooms.iter(), &lists, true, invites_blocked).await;
 
-	trace!(?window);
-	(window, lists)
+	let typing_window = conn
+		.extensions
+		.typing
+		.enabled
+		.unwrap_or(false)
+		.then_async(|| window(sync_info, conn, rooms.iter(), &lists, false, invites_blocked))
+		.await;
+
+	trace!(?gated_window);
+	(gated_window, typing_window, lists)
 }
 
 #[tracing::instrument(
@@ -206,56 +217,22 @@ async fn matcher(
 #[tracing::instrument(
 	level = "debug",
 	skip_all,
-	fields(rooms = rooms.clone().count())
+	fields(rooms = rooms.clone().count(), gated)
 )]
 async fn window<'a, Rooms>(
 	sync_info: SyncInfo<'_>,
-	conn: &Connection,
+	conn: &'a Connection,
 	rooms: Rooms,
-	lists: &ResponseLists,
+	lists: &'a ResponseLists,
+	gated: bool,
 	invites_blocked: bool,
 ) -> Window
 where
-	Rooms: Iterator<Item = &'a WindowRoom> + Clone + Send + Sync,
+	Rooms: Iterator<Item = &'a WindowRoom> + Clone + Send + Sync + 'a,
 {
-	static FULL_RANGE: (UInt, UInt) = (UInt::MIN, UInt::MAX);
-
 	let SyncInfo { services, sender_user, .. } = sync_info;
 
-	let selections = lists
-		.keys()
-		.cloned()
-		.filter_map(|id| conn.lists.get(&id).map(|list| (id, list)))
-		.flat_map(|(id, list)| {
-			let full_range = list
-				.ranges
-				.is_empty()
-				.then_some(&FULL_RANGE)
-				.into_iter();
-
-			list.ranges
-				.iter()
-				.chain(full_range)
-				.map(apply!(2, usize_from_ruma))
-				.map(move |range| (id.clone(), range))
-		})
-		.flat_map(|(id, (start, end))| {
-			rooms
-				.clone()
-				.filter(move |&room| room.lists.contains(&id))
-				.filter(|&room| {
-					conn.rooms
-						.get(&room.room_id)
-						.is_some_and(|conn_room| {
-							conn_room.roomsince == 0 || room.last_count > conn_room.roomsince
-						})
-				})
-				.enumerate()
-				.skip_while(move |&(i, _)| i < start)
-				.take(end.saturating_add(1).saturating_sub(start))
-				.map(|(_, room)| (room.room_id.clone(), room.clone()))
-		})
-		.stream();
+	let selections = list_selections(conn, rooms, lists, gated).stream();
 
 	let subscriptions = conn
 		.subscriptions
@@ -284,6 +261,54 @@ where
 		.map(|room| (room.room_id.clone(), room));
 
 	subscriptions.chain(selections).collect().await
+}
+
+fn list_selections<'a, Rooms>(
+	conn: &'a Connection,
+	rooms: Rooms,
+	lists: &'a ResponseLists,
+	gated: bool,
+) -> impl Iterator<Item = (OwnedRoomId, WindowRoom)> + 'a
+where
+	Rooms: Iterator<Item = &'a WindowRoom> + Clone + Send + Sync + 'a,
+{
+	static FULL_RANGE: (UInt, UInt) = (UInt::MIN, UInt::MAX);
+
+	lists
+		.keys()
+		.cloned()
+		.filter_map(|id| conn.lists.get(&id).map(|list| (id, list)))
+		.flat_map(|(id, list)| {
+			let full_range = list
+				.ranges
+				.is_empty()
+				.then_some(&FULL_RANGE)
+				.into_iter();
+
+			list.ranges
+				.iter()
+				.chain(full_range)
+				.map(apply!(2, usize_from_ruma))
+				.map(move |range| (id.clone(), range))
+		})
+		.flat_map(move |(id, (start, end))| {
+			rooms
+				.clone()
+				.filter(move |&room| room.lists.contains(&id))
+				.filter(move |&room| {
+					!gated
+						|| conn
+							.rooms
+							.get(&room.room_id)
+							.is_some_and(|conn_room| {
+								conn_room.roomsince == 0 || room.last_count > conn_room.roomsince
+							})
+				})
+				.enumerate()
+				.skip_while(move |&(i, _)| i < start)
+				.take(end.saturating_add(1).saturating_sub(start))
+				.map(|(_, room)| (room.room_id.clone(), room.clone()))
+		})
 }
 
 fn response_lists<'a, Rooms>(rooms: Rooms) -> ResponseLists

--- a/src/api/client/sync/v5/selector/tests.rs
+++ b/src/api/client/sync/v5/selector/tests.rs
@@ -1,0 +1,78 @@
+use ruma::{
+	api::client::sync::sync_events::v5::{ListId, request},
+	room_id, uint,
+};
+use tuwunel_service::sync::{Connection, Room};
+
+use super::{ListIds, ResponseLists, WindowRoom, list_selections};
+
+fn list_id() -> ListId { "all_rooms".into() }
+
+fn list_ids(list_id: &ListId) -> ListIds {
+	let mut lists = ListIds::new();
+	lists.push(list_id.clone());
+	lists
+}
+
+#[test]
+fn gated_list_window_excludes_room_without_persistent_delta() {
+	let list_id = list_id();
+	let room_id = room_id!("!quiet:example.com").to_owned();
+	let room = WindowRoom {
+		room_id: room_id.clone(),
+		membership: None,
+		lists: list_ids(&list_id),
+		ranked: 0,
+		last_count: 10,
+	};
+
+	let mut conn = Connection::default();
+	conn.lists.insert(list_id.clone(), request::List {
+		ranges: [(uint!(0), uint!(0))].into_iter().collect(),
+		..Default::default()
+	});
+	conn.rooms
+		.insert(room_id.clone(), Room { roomsince: 20 });
+
+	let mut response_lists = ResponseLists::new();
+	response_lists.insert(list_id, Default::default());
+	let rooms = [room];
+
+	let gated = list_selections(&conn, rooms.iter(), &response_lists, true).collect::<Vec<_>>();
+	assert!(gated.is_empty());
+
+	let ungated = list_selections(&conn, rooms.iter(), &response_lists, false)
+		.map(|(room_id, _)| room_id)
+		.collect::<Vec<_>>();
+	assert_eq!(ungated, [room_id]);
+}
+
+#[test]
+fn gated_list_window_includes_room_with_persistent_delta() {
+	let list_id = list_id();
+	let room_id = room_id!("!active:example.com").to_owned();
+	let room = WindowRoom {
+		room_id: room_id.clone(),
+		membership: None,
+		lists: list_ids(&list_id),
+		ranked: 0,
+		last_count: 30,
+	};
+
+	let mut conn = Connection::default();
+	conn.lists.insert(list_id.clone(), request::List {
+		ranges: [(uint!(0), uint!(0))].into_iter().collect(),
+		..Default::default()
+	});
+	conn.rooms
+		.insert(room_id.clone(), Room { roomsince: 20 });
+
+	let mut response_lists = ResponseLists::new();
+	response_lists.insert(list_id, Default::default());
+	let rooms = [room];
+
+	let gated = list_selections(&conn, rooms.iter(), &response_lists, true)
+		.map(|(room_id, _)| room_id)
+		.collect::<Vec<_>>();
+	assert_eq!(gated, [room_id]);
+}

--- a/src/api/client/sync/v5/selector/tests.rs
+++ b/src/api/client/sync/v5/selector/tests.rs
@@ -28,7 +28,7 @@ fn gated_list_window_excludes_room_without_persistent_delta() {
 
 	let mut conn = Connection::default();
 	conn.lists.insert(list_id.clone(), request::List {
-		ranges: [(uint!(0), uint!(0))].into_iter().collect(),
+		ranges: std::iter::once((uint!(0), uint!(0))).collect(),
 		..Default::default()
 	});
 	conn.rooms
@@ -38,8 +38,11 @@ fn gated_list_window_excludes_room_without_persistent_delta() {
 	response_lists.insert(list_id, Default::default());
 	let rooms = [room];
 
-	let gated = list_selections(&conn, rooms.iter(), &response_lists, true).collect::<Vec<_>>();
-	assert!(gated.is_empty());
+	assert!(
+		list_selections(&conn, rooms.iter(), &response_lists, true)
+			.next()
+			.is_none()
+	);
 
 	let ungated = list_selections(&conn, rooms.iter(), &response_lists, false)
 		.map(|(room_id, _)| room_id)
@@ -61,7 +64,7 @@ fn gated_list_window_includes_room_with_persistent_delta() {
 
 	let mut conn = Connection::default();
 	conn.lists.insert(list_id.clone(), request::List {
-		ranges: [(uint!(0), uint!(0))].into_iter().collect(),
+		ranges: std::iter::once((uint!(0), uint!(0))).collect(),
 		..Default::default()
 	});
 	conn.rooms

--- a/src/service/rooms/typing/mod.rs
+++ b/src/service/rooms/typing/mod.rs
@@ -1,6 +1,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use futures::{FutureExt, StreamExt, TryStreamExt, future::try_join};
+use async_trait::async_trait;
+use futures::{
+	FutureExt, StreamExt, TryStreamExt,
+	future::{Abortable, Aborted, try_join},
+	stream::FuturesUnordered,
+};
+use loole::{Receiver, Sender};
 use ruma::{
 	OwnedRoomId, OwnedUserId, RoomId, UserId,
 	api::{
@@ -11,31 +17,112 @@ use ruma::{
 };
 use tokio::sync::{RwLock, broadcast};
 use tuwunel_core::{
-	Result, Server, debug_info, trace,
+	Result, Server, debug_error, debug_info,
+	result::LogErr,
+	trace,
 	utils::{self, BoolExt, IterStream},
 };
 
 use crate::sending::EduBuf;
 
+mod state;
+mod timer;
+
+#[cfg(test)]
+mod tests;
+
+use self::{
+	state::{StateTransition, TypingEntry, TypingState},
+	timer::{FiredTimer, ScheduledTimer, TimerFired, TimerQueue, TypingTimer, typing_timer},
+};
+
 pub struct Service {
 	server: Arc<Server>,
 	services: Arc<crate::services::OnceServices>,
-	/// u64 is unix timestamp of timeout
-	pub typing: RwLock<BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, u64>>>,
+	state: RwLock<TypingState>,
 	/// timestamp of the last change to typing users
-	pub last_typing_update: RwLock<BTreeMap<OwnedRoomId, u64>>,
-	pub typing_update_sender: broadcast::Sender<OwnedRoomId>,
+	last_typing_update: RwLock<BTreeMap<OwnedRoomId, u64>>,
+	typing_update_sender: broadcast::Sender<OwnedRoomId>,
+	timer_channel: (Sender<TypingTimer>, Receiver<TypingTimer>),
 }
 
+#[async_trait]
 impl crate::Service for Service {
 	fn build(args: &crate::Args<'_>) -> Result<Arc<Self>> {
 		Ok(Arc::new(Self {
 			server: args.server.clone(),
 			services: args.services.clone(),
-			typing: RwLock::new(BTreeMap::new()),
+			state: RwLock::new(TypingState::default()),
 			last_typing_update: RwLock::new(BTreeMap::new()),
 			typing_update_sender: broadcast::channel(100).0,
+			timer_channel: loole::unbounded(),
 		}))
+	}
+
+	async fn worker(self: Arc<Self>) -> Result {
+		let receiver = self.timer_channel.1.clone();
+		let mut timers = FuturesUnordered::new();
+		let mut timer_queue = TimerQueue::default();
+
+		while !receiver.is_closed() && self.server.is_running() {
+			tokio::select! {
+				Some(result) = timers.next() => {
+					let result: std::result::Result<TimerFired, Aborted> = result;
+					let Ok((room_id, user_id, entry)) = result else {
+						continue;
+					};
+
+					let key = (room_id.clone(), user_id);
+					let now_ms = utils::millis_since_unix_epoch();
+					match timer_queue.fired(&key, entry, now_ms) {
+						| FiredTimer::Stale => {
+							trace!(?room_id, ?entry, "Skipping stale typing timer");
+						},
+						| FiredTimer::Reschedule(registration) => {
+							trace!(?room_id, ?entry, "Rescheduling typing timer after clock change");
+							timers.push(Abortable::new(
+								typing_timer(room_id, key.1.clone(), entry),
+								registration,
+							));
+						},
+						| FiredTimer::Expire => {
+							self.expire_typing(&room_id, &key.1, entry, now_ms)
+								.await
+								.log_err()
+								.ok();
+						},
+					}
+				},
+				event = receiver.recv_async() => match event {
+					Ok(event) => {
+						if let Some(ScheduledTimer {
+							room_id,
+							user_id,
+							entry,
+							registration,
+						}) = timer_queue.update(event)
+						{
+							timers.push(Abortable::new(
+								typing_timer(room_id, user_id, entry),
+								registration,
+							));
+						}
+					},
+					Err(_) => break,
+				},
+			}
+		}
+
+		// Make future state transitions observe that active expiry is unavailable
+		// instead of silently accumulating commands after the worker stops.
+		receiver.close();
+		Ok(())
+	}
+
+	async fn interrupt(&self) {
+		if !self.timer_channel.0.is_closed() {
+			self.timer_channel.0.close();
+		}
 	}
 
 	fn name(&self) -> &str { crate::service::make_name(std::module_path!()) }
@@ -44,83 +131,46 @@ impl crate::Service for Service {
 impl Service {
 	/// Sets a user as typing until the timeout timestamp is reached or
 	/// roomtyping_remove is called.
-	pub async fn typing_add(&self, user_id: &UserId, room_id: &RoomId, timeout: u64) -> Result {
-		debug_info!("typing started {user_id:?} in {room_id:?} timeout:{timeout:?}");
+	pub async fn typing_add(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+		expires_at_ms: u64,
+	) -> Result {
+		debug_info!("typing started {user_id:?} in {room_id:?} expires_at_ms:{expires_at_ms:?}");
 
-		// update clients
-		self.typing
-			.write()
-			.await
-			.entry(room_id.to_owned())
-			.or_default()
-			.insert(user_id.to_owned(), timeout);
+		let started = self
+			.transition_state(|state| state.start(room_id, user_id, expires_at_ms))
+			.await;
 
-		let count = self.services.globals.next_count();
-
-		self.last_typing_update
-			.write()
-			.await
-			.insert(room_id.to_owned(), *count);
-
-		drop(count);
-
-		if self
-			.typing_update_sender
-			.send(room_id.to_owned())
-			.is_err()
-		{
-			trace!("receiver found what it was looking for and is no longer interested");
+		if started {
+			self.announce_update(room_id).await;
+			self.appservice_send(room_id).await?;
 		}
 
-		// update appservices
-		let appservice_send = self.appservice_send(room_id);
+		// Federation typing has no deadline, so a refresh must still be relayed
+		// even though it is not an observer-visible local state transition.
+		if self.services.globals.user_is_local(user_id) {
+			self.federation_send(room_id, user_id, true)
+				.await?;
+		}
 
-		// update federation
-		let federation_send = self
-			.services
-			.globals
-			.user_is_local(user_id)
-			.then_async(|| self.federation_send(room_id, user_id, true))
-			.map(Option::transpose);
-
-		try_join(appservice_send, federation_send)
-			.await
-			.map(|_| ())
+		Ok(())
 	}
 
 	/// Removes a user from typing before the timeout is reached.
 	pub async fn typing_remove(&self, user_id: &UserId, room_id: &RoomId) -> Result {
 		debug_info!("typing stopped {user_id:?} in {room_id:?}");
 
-		// update clients
-		self.typing
-			.write()
+		if !self
+			.transition_state(|state| state.stop(room_id, user_id))
 			.await
-			.entry(room_id.to_owned())
-			.or_default()
-			.remove(user_id);
-
-		let count = self.services.globals.next_count();
-
-		self.last_typing_update
-			.write()
-			.await
-			.insert(room_id.to_owned(), *count);
-
-		drop(count);
-
-		if self
-			.typing_update_sender
-			.send(room_id.to_owned())
-			.is_err()
 		{
-			trace!("receiver found what it was looking for and is no longer interested");
+			return Ok(());
 		}
 
-		// update appservices
+		self.announce_update(room_id).await;
 		let appservice_send = self.appservice_send(room_id);
-
-		// update federation
 		let federation_send = self
 			.services
 			.globals
@@ -134,7 +184,7 @@ impl Service {
 	}
 
 	pub async fn wait_for_update(&self, room_id: &RoomId) {
-		let mut receiver = self.typing_update_sender.subscribe();
+		let mut receiver = self.subscribe();
 		while let Ok(next) = receiver.recv().await {
 			if next == room_id {
 				break;
@@ -145,56 +195,46 @@ impl Service {
 	/// Makes sure that typing events with old timestamps get removed.
 	async fn typings_maintain(&self, room_id: &RoomId) -> Result {
 		let current_timestamp = utils::millis_since_unix_epoch();
-		let mut removable = Vec::new();
+		let removable = self
+			.transition_state(|state| state.expire_room(room_id, current_timestamp))
+			.await;
 
-		let typing = self.typing.read().await;
-		let Some(room) = typing.get(room_id) else {
+		self.announce_expired(room_id, &removable).await
+	}
+
+	async fn expire_typing(
+		&self,
+		room_id: &RoomId,
+		user_id: &UserId,
+		expected_entry: TypingEntry,
+		now_ms: u64,
+	) -> Result {
+		let removed = self
+			.transition_state(|state| state.expire(room_id, user_id, expected_entry, now_ms))
+			.await;
+
+		if !removed {
 			return Ok(());
-		};
-
-		for (user, timeout) in room {
-			if *timeout < current_timestamp {
-				removable.push(user.clone());
-			}
 		}
 
-		drop(typing);
-
-		if removable.is_empty() {
-			return Ok(());
-		}
-
-		let mut typing = self.typing.write().await;
-		let room = typing.entry(room_id.to_owned()).or_default();
-		for user in &removable {
-			debug_info!("typing timeout {user:?} in {room_id:?}");
-			room.remove(user);
-		}
-
-		drop(typing);
-
-		// update clients
-		let count = self.services.globals.next_count();
-		self.last_typing_update
-			.write()
+		let user_id = user_id.to_owned();
+		self.announce_expired(room_id, std::slice::from_ref(&user_id))
 			.await
-			.insert(room_id.to_owned(), *count);
+	}
 
-		drop(count);
-
-		if self
-			.typing_update_sender
-			.send(room_id.to_owned())
-			.is_err()
-		{
-			trace!("receiver found what it was looking for and is no longer interested");
+	async fn announce_expired(&self, room_id: &RoomId, users: &[OwnedUserId]) -> Result {
+		if users.is_empty() {
+			return Ok(());
 		}
 
-		// update appservices
-		let appservice_send = self.appservice_send(room_id);
+		for user_id in users {
+			debug_info!("typing timeout {user_id:?} in {room_id:?}");
+		}
 
-		// update federation
-		let federation_sends = removable
+		self.announce_update(room_id).await;
+
+		let appservice_send = self.appservice_send(room_id);
+		let federation_sends = users
 			.iter()
 			.filter(|user_id| self.services.globals.user_is_local(user_id))
 			.try_stream()
@@ -204,6 +244,23 @@ impl Service {
 			.boxed()
 			.await
 			.map(|_| ())
+	}
+
+	async fn announce_update(&self, room_id: &RoomId) {
+		let count = self.services.globals.next_count();
+		self.last_typing_update
+			.write()
+			.await
+			.insert(room_id.to_owned(), *count);
+		drop(count);
+
+		if self
+			.typing_update_sender
+			.send(room_id.to_owned())
+			.is_err()
+		{
+			trace!("receiver found what it was looking for and is no longer interested");
+		}
 	}
 
 	/// Returns the count of the last typing update in this room.
@@ -221,14 +278,8 @@ impl Service {
 
 	/// Returns the typing content with all typing users in the room.
 	async fn typings_content(&self, room_id: &RoomId) -> TypingEventContent {
-		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
-
-		let Some(typing_indicators) = room_typing_indicators else {
-			return TypingEventContent { user_ids: Vec::new() };
-		};
-
 		TypingEventContent {
-			user_ids: typing_indicators.into_keys().collect(),
+			user_ids: self.state.read().await.users(room_id),
 		}
 	}
 
@@ -255,14 +306,12 @@ impl Service {
 		room_id: &RoomId,
 		sender_user: &UserId,
 	) -> Result<Vec<OwnedUserId>> {
-		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
-
-		let Some(typing_indicators) = room_typing_indicators else {
-			return Ok(Vec::new());
-		};
-
-		let user_ids: Vec<_> = typing_indicators
-			.into_keys()
+		let user_ids: Vec<_> = self
+			.state
+			.read()
+			.await
+			.users(room_id)
+			.into_iter()
 			.stream()
 			.filter_map(async |typing_user_id| {
 				self.services
@@ -300,5 +349,38 @@ impl Service {
 			.await?;
 
 		Ok(())
+	}
+
+	pub fn subscribe(&self) -> broadcast::Receiver<OwnedRoomId> {
+		self.typing_update_sender.subscribe()
+	}
+
+	fn send_timer(&self, timer: TypingTimer) {
+		if self.timer_channel.0.send(timer).is_err() {
+			// The worker closes the channel before exiting. During shutdown no
+			// timer is needed; if it stopped early, sync's lazy maintenance still
+			// prevents expired state from being returned.
+			if self.server.is_running() {
+				debug_error!("typing timer worker stopped while the server is running");
+			} else {
+				trace!("typing timer worker is stopped");
+			}
+		}
+	}
+
+	async fn transition_state<T>(
+		&self,
+		transition: impl FnOnce(&mut TypingState) -> StateTransition<T>,
+	) -> T {
+		// Queue timer commands before releasing the state lock. This serializes
+		// their order with concurrent state changes; generations additionally
+		// protect against timer futures which completed before cancellation.
+		let mut state = self.state.write().await;
+		let StateTransition { output, timers } = transition(&mut state);
+		for timer in timers {
+			self.send_timer(timer);
+		}
+
+		output
 	}
 }

--- a/src/service/rooms/typing/state.rs
+++ b/src/service/rooms/typing/state.rs
@@ -107,9 +107,8 @@ impl TypingState {
 			.get(room_id)
 			.into_iter()
 			.flat_map(BTreeMap::iter)
-			.filter_map(|(user_id, entry)| {
-				(entry.expires_at_ms <= now_ms).then(|| user_id.clone())
-			})
+			.filter(|(_, entry)| entry.expires_at_ms <= now_ms)
+			.map(|(user_id, _)| user_id.clone())
 			.collect::<Vec<_>>();
 		let timers = expired
 			.iter()

--- a/src/service/rooms/typing/state.rs
+++ b/src/service/rooms/typing/state.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeMap;
+
+use ruma::{OwnedRoomId, OwnedUserId, RoomId, UserId};
+
+use super::timer::TypingTimer;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct TypingEntry {
+	pub(super) expires_at_ms: u64,
+	/// Distinguishes refreshes, including refreshes with the same deadline.
+	pub(super) generation: u64,
+}
+
+#[derive(Default)]
+pub(super) struct TypingState {
+	pub(super) rooms: BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, TypingEntry>>,
+	next_generation: u64,
+}
+
+#[must_use = "typing transitions include timer commands which must be queued"]
+pub(super) struct StateTransition<T> {
+	pub(super) output: T,
+	pub(super) timers: Vec<TypingTimer>,
+}
+
+impl TypingState {
+	pub(super) fn start(
+		&mut self,
+		room_id: &RoomId,
+		user_id: &UserId,
+		expires_at_ms: u64,
+	) -> StateTransition<bool> {
+		self.next_generation = self
+			.next_generation
+			.checked_add(1)
+			.expect("typing generation overflow");
+		let entry = TypingEntry {
+			expires_at_ms,
+			generation: self.next_generation,
+		};
+		let started = self
+			.rooms
+			.entry(room_id.to_owned())
+			.or_default()
+			.insert(user_id.to_owned(), entry)
+			.is_none();
+
+		StateTransition {
+			output: started,
+			timers: vec![TypingTimer::Add {
+				room_id: room_id.to_owned(),
+				user_id: user_id.to_owned(),
+				entry,
+			}],
+		}
+	}
+
+	pub(super) fn stop(&mut self, room_id: &RoomId, user_id: &UserId) -> StateTransition<bool> {
+		let Some(entry) = self
+			.rooms
+			.get_mut(room_id)
+			.and_then(|room| room.remove(user_id))
+		else {
+			return StateTransition { output: false, timers: Vec::new() };
+		};
+		self.prune(room_id);
+
+		StateTransition {
+			output: true,
+			timers: vec![TypingTimer::Remove {
+				room_id: room_id.to_owned(),
+				user_id: user_id.to_owned(),
+				generation: entry.generation,
+			}],
+		}
+	}
+
+	pub(super) fn expire(
+		&mut self,
+		room_id: &RoomId,
+		user_id: &UserId,
+		expected_entry: TypingEntry,
+		now_ms: u64,
+	) -> StateTransition<bool> {
+		let Some(entry) = self
+			.rooms
+			.get(room_id)
+			.and_then(|room| room.get(user_id))
+			.copied()
+		else {
+			return StateTransition { output: false, timers: Vec::new() };
+		};
+		if entry != expected_entry || entry.expires_at_ms > now_ms {
+			return StateTransition { output: false, timers: Vec::new() };
+		}
+
+		self.stop(room_id, user_id)
+	}
+
+	pub(super) fn expire_room(
+		&mut self,
+		room_id: &RoomId,
+		now_ms: u64,
+	) -> StateTransition<Vec<OwnedUserId>> {
+		let expired = self
+			.rooms
+			.get(room_id)
+			.into_iter()
+			.flat_map(BTreeMap::iter)
+			.filter_map(|(user_id, entry)| {
+				(entry.expires_at_ms <= now_ms).then(|| user_id.clone())
+			})
+			.collect::<Vec<_>>();
+		let timers = expired
+			.iter()
+			.flat_map(|user_id| self.stop(room_id, user_id).timers)
+			.collect();
+
+		StateTransition { output: expired, timers }
+	}
+
+	pub(super) fn users(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
+		self.rooms
+			.get(room_id)
+			.into_iter()
+			.flat_map(BTreeMap::keys)
+			.cloned()
+			.collect()
+	}
+
+	fn prune(&mut self, room_id: &RoomId) {
+		if self
+			.rooms
+			.get(room_id)
+			.is_some_and(BTreeMap::is_empty)
+		{
+			self.rooms.remove(room_id);
+		}
+	}
+}

--- a/src/service/rooms/typing/tests.rs
+++ b/src/service/rooms/typing/tests.rs
@@ -41,9 +41,13 @@ fn timer_queue_stop_then_restart_keeps_restart() {
 	let restarted = entry(2000, 2);
 	let mut queue = TimerQueue::default();
 
-	let _ = queue.update(add(&key, first));
-	let _ = queue.update(remove(&key, first.generation));
-	let _ = queue.update(add(&key, restarted));
+	assert!(queue.update(add(&key, first)).is_some());
+	assert!(
+		queue
+			.update(remove(&key, first.generation))
+			.is_none()
+	);
+	assert!(queue.update(add(&key, restarted)).is_some());
 
 	assert_eq!(queue.current(&key), Some(restarted));
 }
@@ -55,10 +59,14 @@ fn timer_queue_refresh_replaces_previous_generation() {
 	let refreshed = entry(2000, 2);
 	let mut queue = TimerQueue::default();
 
-	let _ = queue.update(add(&key, first));
-	let _ = queue.update(add(&key, refreshed));
+	assert!(queue.update(add(&key, first)).is_some());
+	assert!(queue.update(add(&key, refreshed)).is_some());
 	// A late cancellation for the old generation must not cancel the refresh.
-	let _ = queue.update(remove(&key, first.generation));
+	assert!(
+		queue
+			.update(remove(&key, first.generation))
+			.is_none()
+	);
 
 	assert_eq!(queue.current(&key), Some(refreshed));
 }
@@ -70,8 +78,8 @@ fn stale_fired_timer_does_not_consume_current_timer() {
 	let current = entry(2000, 2);
 	let mut queue = TimerQueue::default();
 
-	let _ = queue.update(add(&key, stale));
-	let _ = queue.update(add(&key, current));
+	assert!(queue.update(add(&key, stale)).is_some());
+	assert!(queue.update(add(&key, current)).is_some());
 
 	assert!(matches!(queue.fired(&key, stale, 1000), FiredTimer::Stale));
 	assert_eq!(queue.current(&key), Some(current));
@@ -83,7 +91,7 @@ fn matching_timer_is_rescheduled_until_wall_deadline() {
 	let current = entry(1000, 1);
 	let mut queue = TimerQueue::default();
 
-	let _ = queue.update(add(&key, current));
+	assert!(queue.update(add(&key, current)).is_some());
 	assert!(matches!(queue.fired(&key, current, 999), FiredTimer::Reschedule(_)));
 	assert_eq!(queue.current(&key), Some(current));
 
@@ -99,9 +107,9 @@ fn expired_typing_users_include_deadline_boundary_and_prune_room() {
 	let active = user_id!("@active:example.com");
 	let mut state = TypingState::default();
 
-	let _ = state.start(room_id, expired, 999);
-	let _ = state.start(room_id, boundary, 1000);
-	let _ = state.start(room_id, active, 1001);
+	assert!(state.start(room_id, expired, 999).output);
+	assert!(state.start(room_id, boundary, 1000).output);
+	assert!(state.start(room_id, active, 1001).output);
 
 	let transition = state.expire_room(room_id, 1000);
 	let expired_users = transition.output;

--- a/src/service/rooms/typing/tests.rs
+++ b/src/service/rooms/typing/tests.rs
@@ -1,0 +1,243 @@
+use std::time::Duration;
+
+use ruma::{room_id, user_id};
+
+use super::{
+	state::{TypingEntry, TypingState},
+	timer::{FiredTimer, TimerKey, TimerQueue, TypingTimer, typing_timer},
+};
+
+fn entry(expires_at_ms: u64, generation: u64) -> TypingEntry {
+	TypingEntry { expires_at_ms, generation }
+}
+
+fn add(key: &TimerKey, entry: TypingEntry) -> TypingTimer {
+	TypingTimer::Add {
+		room_id: key.0.clone(),
+		user_id: key.1.clone(),
+		entry,
+	}
+}
+
+fn remove(key: &TimerKey, generation: u64) -> TypingTimer {
+	TypingTimer::Remove {
+		room_id: key.0.clone(),
+		user_id: key.1.clone(),
+		generation,
+	}
+}
+
+fn timer_key() -> TimerKey {
+	(
+		room_id!("!room:example.com").to_owned(),
+		user_id!("@alice:example.com").to_owned(),
+	)
+}
+
+#[test]
+fn timer_queue_stop_then_restart_keeps_restart() {
+	let key = timer_key();
+	let first = entry(1000, 1);
+	let restarted = entry(2000, 2);
+	let mut queue = TimerQueue::default();
+
+	let _ = queue.update(add(&key, first));
+	let _ = queue.update(remove(&key, first.generation));
+	let _ = queue.update(add(&key, restarted));
+
+	assert_eq!(queue.current(&key), Some(restarted));
+}
+
+#[test]
+fn timer_queue_refresh_replaces_previous_generation() {
+	let key = timer_key();
+	let first = entry(1000, 1);
+	let refreshed = entry(2000, 2);
+	let mut queue = TimerQueue::default();
+
+	let _ = queue.update(add(&key, first));
+	let _ = queue.update(add(&key, refreshed));
+	// A late cancellation for the old generation must not cancel the refresh.
+	let _ = queue.update(remove(&key, first.generation));
+
+	assert_eq!(queue.current(&key), Some(refreshed));
+}
+
+#[test]
+fn stale_fired_timer_does_not_consume_current_timer() {
+	let key = timer_key();
+	let stale = entry(1000, 1);
+	let current = entry(2000, 2);
+	let mut queue = TimerQueue::default();
+
+	let _ = queue.update(add(&key, stale));
+	let _ = queue.update(add(&key, current));
+
+	assert!(matches!(queue.fired(&key, stale, 1000), FiredTimer::Stale));
+	assert_eq!(queue.current(&key), Some(current));
+}
+
+#[test]
+fn matching_timer_is_rescheduled_until_wall_deadline() {
+	let key = timer_key();
+	let current = entry(1000, 1);
+	let mut queue = TimerQueue::default();
+
+	let _ = queue.update(add(&key, current));
+	assert!(matches!(queue.fired(&key, current, 999), FiredTimer::Reschedule(_)));
+	assert_eq!(queue.current(&key), Some(current));
+
+	assert!(matches!(queue.fired(&key, current, 1000), FiredTimer::Expire));
+	assert_eq!(queue.current(&key), None);
+}
+
+#[test]
+fn expired_typing_users_include_deadline_boundary_and_prune_room() {
+	let room_id = room_id!("!room:example.com");
+	let expired = user_id!("@expired:example.com");
+	let boundary = user_id!("@boundary:example.com");
+	let active = user_id!("@active:example.com");
+	let mut state = TypingState::default();
+
+	let _ = state.start(room_id, expired, 999);
+	let _ = state.start(room_id, boundary, 1000);
+	let _ = state.start(room_id, active, 1001);
+
+	let transition = state.expire_room(room_id, 1000);
+	let expired_users = transition.output;
+	assert_eq!(expired_users, vec![boundary.to_owned(), expired.to_owned()]);
+	assert_eq!(transition.timers.len(), 2);
+	assert_eq!(state.users(room_id), vec![active.to_owned()]);
+
+	let transition = state.expire_room(room_id, 1001);
+	assert_eq!(transition.output, vec![active.to_owned()]);
+	assert!(state.users(room_id).is_empty());
+	assert!(!state.rooms.contains_key(room_id));
+}
+
+#[test]
+fn stale_timer_does_not_remove_refreshed_typing_even_with_same_deadline() {
+	let room_id = room_id!("!room:example.com");
+	let user_id = user_id!("@alice:example.com");
+	let mut state = TypingState::default();
+
+	let first_timer = state
+		.start(room_id, user_id, 1000)
+		.timers
+		.remove(0);
+	let second_timer = state
+		.start(room_id, user_id, 1000)
+		.timers
+		.remove(0);
+	let TypingTimer::Add { entry: first_entry, .. } = first_timer else {
+		panic!("start should schedule a timer");
+	};
+	let TypingTimer::Add { entry: second_entry, .. } = second_timer else {
+		panic!("refresh should schedule a timer");
+	};
+
+	assert_ne!(first_entry.generation, second_entry.generation);
+	assert!(
+		!state
+			.expire(room_id, user_id, first_entry, 1000)
+			.output
+	);
+	assert_eq!(state.rooms[room_id][user_id], second_entry);
+	assert!(
+		state
+			.expire(room_id, user_id, second_entry, 1000)
+			.output
+	);
+	assert!(state.users(room_id).is_empty());
+}
+
+#[test]
+fn stop_then_restart_uses_generation_qualified_timer_commands() {
+	let room_id = room_id!("!room:example.com");
+	let user_id = user_id!("@alice:example.com");
+	let mut state = TypingState::default();
+
+	let first_timer = state
+		.start(room_id, user_id, 1000)
+		.timers
+		.remove(0);
+	let remove_timer = state
+		.stop(room_id, user_id)
+		.timers
+		.pop()
+		.expect("active typing should stop");
+	let restarted_timer = state
+		.start(room_id, user_id, 2000)
+		.timers
+		.remove(0);
+
+	let TypingTimer::Add { entry: first_entry, .. } = first_timer else {
+		panic!("start should schedule a timer");
+	};
+	let TypingTimer::Remove { generation: removed_generation, .. } = remove_timer else {
+		panic!("stop should cancel a timer");
+	};
+	let TypingTimer::Add { entry: restarted_entry, .. } = restarted_timer else {
+		panic!("restart should schedule a timer");
+	};
+
+	assert_eq!(removed_generation, first_entry.generation);
+	assert_ne!(removed_generation, restarted_entry.generation);
+	assert_eq!(state.rooms[room_id][user_id], restarted_entry);
+}
+
+#[tokio::test]
+async fn elapsed_timer_can_expire_state_without_a_sync_read() {
+	let room_id = room_id!("!room:example.com").to_owned();
+	let user_id = user_id!("@alice:example.com").to_owned();
+	let expires_at_ms = tuwunel_core::utils::millis_since_unix_epoch().saturating_sub(1);
+	let mut state = TypingState::default();
+	let timer = state
+		.start(&room_id, &user_id, expires_at_ms)
+		.timers
+		.remove(0);
+	let TypingTimer::Add { entry, .. } = timer else {
+		panic!("start should schedule a timer");
+	};
+
+	let (_, _, fired_entry) = tokio::time::timeout(
+		Duration::from_millis(50),
+		typing_timer(room_id.clone(), user_id.clone(), entry),
+	)
+	.await
+	.expect("elapsed typing timer should fire immediately");
+
+	assert_eq!(fired_entry, entry);
+	assert!(
+		state
+			.expire(
+				&room_id,
+				&user_id,
+				fired_entry,
+				tuwunel_core::utils::millis_since_unix_epoch(),
+			)
+			.output
+	);
+	assert!(state.users(&room_id).is_empty());
+}
+
+#[test]
+fn matching_timer_only_expires_at_or_after_deadline() {
+	let room_id = room_id!("!room:example.com");
+	let user_id = user_id!("@alice:example.com");
+	let mut state = TypingState::default();
+	let timer = state
+		.start(room_id, user_id, 1000)
+		.timers
+		.remove(0);
+	let TypingTimer::Add { entry, .. } = timer else {
+		panic!("start should schedule a timer");
+	};
+
+	assert!(!state.expire(room_id, user_id, entry, 999).output);
+	assert_eq!(state.rooms[room_id][user_id], TypingEntry {
+		expires_at_ms: 1000,
+		generation: entry.generation,
+	});
+	assert!(state.expire(room_id, user_id, entry, 1000).output);
+}

--- a/src/service/rooms/typing/timer.rs
+++ b/src/service/rooms/typing/timer.rs
@@ -1,0 +1,119 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use futures::future::{AbortHandle, AbortRegistration};
+use ruma::{OwnedRoomId, OwnedUserId};
+use tuwunel_core::utils;
+
+use super::state::TypingEntry;
+
+pub(super) type TimerKey = (OwnedRoomId, OwnedUserId);
+pub(super) type TimerFired = (OwnedRoomId, OwnedUserId, TypingEntry);
+
+#[derive(Default)]
+pub(super) struct TimerQueue {
+	handles: BTreeMap<TimerKey, (TypingEntry, AbortHandle)>,
+}
+
+pub(super) struct ScheduledTimer {
+	pub(super) room_id: OwnedRoomId,
+	pub(super) user_id: OwnedUserId,
+	pub(super) entry: TypingEntry,
+	pub(super) registration: AbortRegistration,
+}
+
+pub(super) enum FiredTimer {
+	Stale,
+	Reschedule(AbortRegistration),
+	Expire,
+}
+
+#[derive(Debug)]
+pub(super) enum TypingTimer {
+	Add {
+		room_id: OwnedRoomId,
+		user_id: OwnedUserId,
+		entry: TypingEntry,
+	},
+	Remove {
+		room_id: OwnedRoomId,
+		user_id: OwnedUserId,
+		generation: u64,
+	},
+}
+
+impl TimerQueue {
+	pub(super) fn update(&mut self, timer: TypingTimer) -> Option<ScheduledTimer> {
+		match timer {
+			| TypingTimer::Add { room_id, user_id, entry } => {
+				let key = (room_id.clone(), user_id.clone());
+				let registration = self.schedule(key, entry);
+
+				Some(ScheduledTimer { room_id, user_id, entry, registration })
+			},
+			| TypingTimer::Remove { room_id, user_id, generation } => {
+				let key = (room_id, user_id);
+				if self
+					.handles
+					.get(&key)
+					.is_some_and(|(entry, _)| entry.generation == generation)
+					&& let Some((_, handle)) = self.handles.remove(&key)
+				{
+					handle.abort();
+				}
+
+				None
+			},
+		}
+	}
+
+	pub(super) fn fired(
+		&mut self,
+		key: &TimerKey,
+		entry: TypingEntry,
+		now_ms: u64,
+	) -> FiredTimer {
+		if !self
+			.handles
+			.get(key)
+			.is_some_and(|(current_entry, _)| *current_entry == entry)
+		{
+			return FiredTimer::Stale;
+		}
+
+		self.handles.remove(key);
+		if now_ms < entry.expires_at_ms {
+			FiredTimer::Reschedule(self.schedule(key.clone(), entry))
+		} else {
+			FiredTimer::Expire
+		}
+	}
+
+	fn schedule(&mut self, key: TimerKey, entry: TypingEntry) -> AbortRegistration {
+		if let Some((_, handle)) = self.handles.remove(&key) {
+			handle.abort();
+		}
+
+		let (handle, registration) = AbortHandle::new_pair();
+		self.handles.insert(key, (entry, handle));
+
+		registration
+	}
+
+	#[cfg(test)]
+	pub(super) fn current(&self, key: &TimerKey) -> Option<TypingEntry> {
+		self.handles.get(key).map(|(entry, _)| *entry)
+	}
+}
+
+pub(super) async fn typing_timer(
+	room_id: OwnedRoomId,
+	user_id: OwnedUserId,
+	entry: TypingEntry,
+) -> TimerFired {
+	let delay = entry
+		.expires_at_ms
+		.saturating_sub(utils::millis_since_unix_epoch());
+	tokio::time::sleep(Duration::from_millis(delay)).await;
+
+	(room_id, user_id, entry)
+}

--- a/src/service/sync/watch.rs
+++ b/src/service/sync/watch.rs
@@ -135,11 +135,7 @@ where
 		);
 		// Typing: subscribe synchronously so the receiver is registered before
 		// this fn returns; `wait_for_update` would defer until poll.
-		let mut typing_rx = self
-			.services
-			.typing
-			.typing_update_sender
-			.subscribe();
+		let mut typing_rx = self.services.typing.subscribe();
 
 		let typing_room_id = room_id.to_owned();
 		futures.push(


### PR DESCRIPTION
### What does this PR do?

Fixes typing indicators that can remain visible indefinitely in Sliding Sync clients such as Element X.

- Stopping typing now clears the indicator
  - When the final user stops typing, sliding sync now sends an explicit empty typing list. 
  - Previously, the room was omitted from the response, leaving clients with the last state they received.

- Typing indicators now expire automatically
  - Typing timeouts are actively scheduled by the typing service. They no longer depend on a classic sync request happening to clean up expired entries.
  - An expiry wakes waiting sync requests, so clients receive the cleared state promptly even when the server is otherwise quiet.

- Typing-only updates reach sliding sync
  - Rooms are now considered for the typing extension even when typing is their only change.

- Concurrent updates cannot lose the active timeout
  - Starting, refreshing, stopping, and expiring typing state now update the state and its timer as one ordered operation.


### Changes

I've divided the typing subsystem into the following:

- `state.rs`: authoritative typing state and transitions.
- `timer.rs`: expiry scheduling, timer generations, and command reduction.
- `mod.rs`: service orchestration, sync notifications, appservice delivery, and federation.

#### Sliding Sync delivery

- `sync/v5/extensions/typing.rs` and its tests now send authoritative empty typing state when the final user stops or expires, while suppressing unnecessary initial empties and restricting results to joined rooms.
- `sync/v5/selector.rs` and its tests provide a typing-specific room scope, ensuring typing-only changes are included even when a room has no timeline or persistent-state update.
- `sync/v5.rs` and `sync/v5/extensions.rs` carry that typing scope through the response pipeline.

#### Typing state and expiry

- `rooms/typing/state.rs` owns typing sessions and generation-based transitions, preventing stale work from affecting refreshed or restarted sessions.
- `rooms/typing/timer.rs` owns active expiry scheduling, cancellation, stale-timer handling, and clock-change rescheduling.
- `rooms/typing/mod.rs` coordinates state changes with sync revisions, client wakeups, appservice delivery, and federation.

#### Reliability and regression coverage

- `sync/watch.rs` registers its typing listener synchronously so updates cannot be missed when entering long-poll.
- `rooms/typing/tests.rs`, `sync/v5/selector/tests.rs`, and `sync/v5/extensions/typing/tests.rs` cover expiry, empty clears, typing-only updates, refresh/stop races, stale timers, and clock movement.



### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
