### PR TITLE
fix(pusher): refresh badges after read updates

### DIFF
--- a/src/api/client/read_marker/read_markers.rs
+++ b/src/api/client/read_marker/read_markers.rs
@@ -40,6 +40,9 @@ pub(crate) async fn set_read_marker_route(
 				&ReceiptThread::Unthreaded,
 			)
 			.await;
+		services
+			.pusher
+			.schedule_badge_update(sender_user.to_owned());
 	}
 
 	if let Some(event) = &body.fully_read {

--- a/src/api/client/read_marker/receipt.rs
+++ b/src/api/client/read_marker/receipt.rs
@@ -77,6 +77,9 @@ pub(crate) async fn create_receipt_route(
 			.pusher
 			.reset_notification_counts_for_thread(sender_user, &body.room_id, &body.thread)
 			.await;
+		services
+			.pusher
+			.schedule_badge_update(sender_user.to_owned());
 	}
 
 	match body.receipt_type {

--- a/src/database/maps.rs
+++ b/src/database/maps.rs
@@ -367,6 +367,11 @@ pub(super) static MAPS: &[Descriptor] = &[
 		..descriptor::RANDOM_SMALL
 	},
 	Descriptor {
+		name: "senderkey_lastbadge",
+		val_size_hint: Some(8),
+		..descriptor::RANDOM_SMALL
+	},
+	Descriptor {
 		name: "senderkey_pusher",
 		..descriptor::RANDOM_SMALL
 	},

--- a/src/main/tests/pusher_notify.rs
+++ b/src/main/tests/pusher_notify.rs
@@ -31,6 +31,7 @@ const APP_ID: &str = "app.tuwunel.test";
 const EVENT_ID: &str = "$push:remote.example";
 const SENDER: &str = "@alice:remote.example";
 const NOTIFY_PATH: &str = "/_matrix/push/v1/notify";
+const REGISTERED_NOTIFY_PATH: &str = "/custom/push/notify";
 
 /// Inputs shared by the delivery cases; the event is driven straight through
 /// the pusher service rather than through a real room and timeline.
@@ -57,6 +58,8 @@ fn pusher_notify() -> Result {
 		.push(format!("database_path=\"{db_path}\""));
 	args.option
 		.push("ip_range_denylist=[]".to_owned());
+	args.option
+		.push(format!("notification_push_path=\"{REGISTERED_NOTIFY_PATH}\""));
 
 	let runtime = Runtime::new(Some(&args))?;
 	let server = Server::new(Some(&args), Some(&runtime))?;
@@ -104,10 +107,124 @@ async fn run_cases(services: &Services) -> Result {
 	};
 
 	reject_bad_url(&fixture).await?;
+	badge_only_delivery_and_dedupe(&fixture).await?;
+	badge_opt_out_requires_true(&fixture).await?;
 	full_format_delivery(&fixture).await?;
 	event_id_only_delivery(&fixture).await?;
 	rejected_pushkey_removed(&fixture).await?;
 	foreign_rejected_key_noop(&fixture).await
+}
+
+/// A counts-only update carries an explicit zero with no event fields, then
+/// dedupes the same successful badge value for this pusher.
+async fn badge_only_delivery_and_dedupe(fixture: &Fixture<'_>) -> Result {
+	let pushkey = "pk-badge";
+	let listener = TcpListener::bind("127.0.0.1:0").await?;
+	let url = format!("http://{}{REGISTERED_NOTIFY_PATH}", listener.local_addr()?);
+	let action = pusher_action_with_badge_setting(
+		pushkey,
+		url,
+		false,
+		Some(("org.matrix.msc4076.disable_badge_count", false)),
+	);
+	fixture
+		.services
+		.pusher
+		.set_pusher(fixture.user, fixture.device, &action)
+		.await?;
+
+	let (tx, mut rx) = unbounded_channel();
+	let stub = spawn(stub_gateway(listener, tx, r#"{"rejected":[]}"#.to_owned()));
+
+	fixture
+		.services
+		.pusher
+		.schedule_badge_update(fixture.user.to_owned());
+	let (path, body) = recv(&mut rx).await?;
+	if path != NOTIFY_PATH {
+		return Err!("badge-only notification hit unexpected path {path}");
+	}
+
+	let body: Value = serde_json::from_slice(&body)?;
+	let notification = notification(&body)?;
+	if notification
+		.pointer("/counts/unread")
+		.and_then(Value::as_u64)
+		!= Some(0)
+	{
+		return Err!("badge-only notification did not serialize unread=0: {notification}");
+	}
+	for field in ["event_id", "room_id", "type", "sender", "content"] {
+		expect_absent(notification, field)?;
+	}
+
+	fixture
+		.services
+		.pusher
+		.schedule_badge_update(fixture.user.to_owned());
+	expect_no_delivery(&mut rx).await?;
+
+	fixture
+		.services
+		.pusher
+		.delete_pusher(fixture.user, pushkey)
+		.await;
+	stub.abort();
+
+	Ok(())
+}
+
+/// Only boolean true disables badges. Replacing the same pusher with false
+/// clears its dedupe state and allows a fresh counts-only update.
+async fn badge_opt_out_requires_true(fixture: &Fixture<'_>) -> Result {
+	let pushkey = "pk-badge-optout";
+	let listener = TcpListener::bind("127.0.0.1:0").await?;
+	let url = format!("http://{}{REGISTERED_NOTIFY_PATH}", listener.local_addr()?);
+	let (tx, mut rx) = unbounded_channel();
+	let stub = spawn(stub_gateway(listener, tx, r#"{"rejected":[]}"#.to_owned()));
+
+	let disabled = pusher_action_with_badge_setting(
+		pushkey,
+		url.clone(),
+		false,
+		Some(("disable_badge_count", true)),
+	);
+	fixture
+		.services
+		.pusher
+		.set_pusher(fixture.user, fixture.device, &disabled)
+		.await?;
+	fixture
+		.services
+		.pusher
+		.schedule_badge_update(fixture.user.to_owned());
+	expect_no_delivery(&mut rx).await?;
+
+	let enabled = pusher_action_with_badge_setting(
+		pushkey,
+		url,
+		false,
+		Some(("disable_badge_count", false)),
+	);
+	fixture
+		.services
+		.pusher
+		.set_pusher(fixture.user, fixture.device, &enabled)
+		.await?;
+	fixture
+		.services
+		.pusher
+		.schedule_badge_update(fixture.user.to_owned());
+	recv(&mut rx).await?;
+
+	fixture
+		.services
+		.pusher
+		.delete_pusher(fixture.user, pushkey)
+		.await;
+	stub.abort();
+
+	Ok(())
 }
 
 fn message_event(room_id: &str) -> Result<Pdu> {
@@ -251,7 +368,7 @@ async fn deliver(
 	response_body: &str,
 ) -> Result<(String, Value)> {
 	let listener = TcpListener::bind("127.0.0.1:0").await?;
-	let url = format!("http://{}{NOTIFY_PATH}", listener.local_addr()?);
+	let url = format!("http://{}{REGISTERED_NOTIFY_PATH}", listener.local_addr()?);
 
 	let action = pusher_action(pushkey, url, event_id_only);
 
@@ -287,8 +404,20 @@ async fn deliver(
 }
 
 fn pusher_action(pushkey: &str, url: String, event_id_only: bool) -> PusherAction {
+	pusher_action_with_badge_setting(pushkey, url, event_id_only, None)
+}
+
+fn pusher_action_with_badge_setting(
+	pushkey: &str,
+	url: String,
+	event_id_only: bool,
+	badge_setting: Option<(&str, bool)>,
+) -> PusherAction {
 	let mut data = HttpPusherData::new(url);
 	data.format = event_id_only.then_some(PushFormat::EventIdOnly);
+	if let Some((key, value)) = badge_setting {
+		data.data.insert(key.to_owned(), value.into());
+	}
 
 	let pusher: Pusher = PusherInit {
 		ids: PusherIds::new(pushkey.to_owned(), APP_ID.to_owned()),
@@ -301,6 +430,15 @@ fn pusher_action(pushkey: &str, url: String, event_id_only: bool) -> PusherActio
 	.into();
 
 	SetPusherRequest::post(pusher).action
+}
+
+async fn expect_no_delivery(rx: &mut UnboundedReceiver<(String, Vec<u8>)>) -> Result {
+	match timeout(Duration::from_millis(300), rx.recv()).await {
+		| Err(_) => Ok(()),
+		| Ok(Some((path, body))) =>
+			Err!("unexpected push delivery to {path}: {}", String::from_utf8_lossy(&body)),
+		| Ok(None) => Err!("stub gateway channel closed while checking for no delivery"),
+	}
 }
 
 async fn recv(rx: &mut UnboundedReceiver<(String, Vec<u8>)>) -> Result<(String, Vec<u8>)> {

--- a/src/service/pusher/badge.rs
+++ b/src/service/pusher/badge.rs
@@ -1,0 +1,159 @@
+use ruma::{
+	OwnedUserId, UInt, UserId,
+	api::{
+		client::push::{Pusher, PusherKind},
+		push_gateway::send_event_notification::v1::Device,
+	},
+	push::HttpPusherData,
+};
+use serde::Serialize;
+use tuwunel_core::{Result, implement, warn};
+use tuwunel_database::Deserialized;
+
+/// Schedule one non-blocking badge fanout after a successful unread reset.
+#[implement(super::Service)]
+pub fn schedule_badge_update(&self, user_id: OwnedUserId) {
+	let pusher = self.services.pusher.clone();
+	let runtime = self.services.server.runtime();
+	runtime.spawn(async move {
+		pusher.send_badge_notices(&user_id).await;
+	});
+}
+
+#[implement(super::Service)]
+async fn send_badge_notices(&self, user_id: &UserId) {
+	for pusher in self.get_pushers(user_id).await {
+		if let Err(e) = self.send_badge_notice(user_id, &pusher).await {
+			warn!(%user_id, pushkey = %pusher.ids.pushkey, "Failed to send updated push badge: {e}");
+		}
+	}
+}
+
+#[implement(super::Service)]
+#[tracing::instrument(level = "debug", skip_all)]
+async fn send_badge_notice(&self, user_id: &UserId, pusher: &Pusher) -> Result {
+	let pushkey = pusher.ids.pushkey.clone();
+	let mutex_key = (user_id.to_owned(), pushkey.clone());
+	let _lock = self.badge_send_mutex.lock(&mutex_key).await;
+	let Ok(pusher) = self.get_pusher(user_id, &pushkey).await else {
+		return Ok(());
+	};
+	let PusherKind::Http(http) = &pusher.kind else {
+		return Ok(());
+	};
+
+	if badge_count_disabled(http) {
+		return Ok(());
+	}
+
+	let unread = self.badge_count(user_id).await;
+	let unread_state: u64 = unread.into();
+	if self.last_badge(user_id, &pushkey).await == Some(unread_state) {
+		return Ok(());
+	}
+
+	let mut device = Device::new(pusher.ids.app_id.clone(), pushkey.clone());
+	device.data.data.clone_from(&http.data);
+	device.data.format.clone_from(&http.format);
+
+	let body = serde_json::to_vec(&BadgeRequest {
+		notification: BadgeNotification {
+			counts: BadgeCounts { unread },
+			devices: vec![device],
+		},
+	})?;
+	let response = self.send_raw_request(&http.url, body).await?;
+
+	if response.rejected.contains(&pushkey) {
+		warn!(url = %http.url, %pushkey, "Push gateway rejected the pushkey; removing pusher");
+		self.delete_pusher_unlocked(user_id, &pushkey)
+			.await;
+	} else {
+		self.store_last_badge(user_id, &pushkey, unread_state);
+	}
+
+	Ok(())
+}
+
+#[implement(super::Service)]
+pub(super) async fn badge_count(&self, user_id: &UserId) -> UInt {
+	self.global_notification_count(user_id)
+		.await
+		.try_into()
+		.unwrap_or(UInt::MAX)
+}
+
+#[implement(super::Service)]
+async fn last_badge(&self, user_id: &UserId, pushkey: &str) -> Option<u64> {
+	self.db
+		.senderkey_lastbadge
+		.qry(&(user_id, pushkey))
+		.await
+		.deserialized()
+		.ok()
+}
+
+#[implement(super::Service)]
+pub(super) fn store_last_badge(&self, user_id: &UserId, pushkey: &str, unread: u64) {
+	self.db
+		.senderkey_lastbadge
+		.put((user_id, pushkey), unread);
+}
+
+pub(super) fn badge_count_disabled(http: &HttpPusherData) -> bool {
+	["org.matrix.msc4076.disable_badge_count", "disable_badge_count"]
+		.into_iter()
+		.any(|key| {
+			http.data
+				.get(key)
+				.and_then(serde_json::Value::as_bool)
+				== Some(true)
+		})
+}
+
+/// Counts-only wire types deliberately do not skip zero. Ruma's general
+/// `NotificationCounts` serializer does, but unread=0 is the badge-clear
+/// signal.
+#[derive(Serialize)]
+struct BadgeRequest {
+	notification: BadgeNotification,
+}
+
+#[derive(Serialize)]
+struct BadgeNotification {
+	counts: BadgeCounts,
+	devices: Vec<Device>,
+}
+
+#[derive(Serialize)]
+struct BadgeCounts {
+	unread: UInt,
+}
+
+#[cfg(test)]
+mod tests {
+	use ruma::{api::push_gateway::send_event_notification::v1::Device, uint};
+	use serde_json::json;
+
+	use super::{BadgeCounts, BadgeNotification, BadgeRequest};
+
+	#[test]
+	fn zero_badge_payload_is_explicit_and_eventless() {
+		let payload = BadgeRequest {
+			notification: BadgeNotification {
+				counts: BadgeCounts { unread: uint!(0) },
+				devices: vec![Device::new("app".into(), "pushkey".into())],
+			},
+		};
+
+		assert_eq!(
+			serde_json::to_value(payload).expect("badge payload serializes"),
+			json!({
+				"notification": {
+					"counts": { "unread": 0 },
+					"devices": [{ "app_id": "app", "pushkey": "pushkey" }],
+				}
+			})
+		);
+	}
+}

--- a/src/service/pusher/mod.rs
+++ b/src/service/pusher/mod.rs
@@ -1,4 +1,5 @@
 mod append;
+mod badge;
 mod notification;
 mod request;
 mod send;
@@ -32,6 +33,7 @@ pub use self::append::Notified;
 
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
+	badge_send_mutex: MutexMap<(OwnedUserId, String), ()>,
 	notification_increment_mutex: MutexMap<(OwnedRoomId, OwnedUserId), ()>,
 	highlight_increment_mutex: MutexMap<(OwnedRoomId, OwnedUserId), ()>,
 	db: Data,
@@ -41,6 +43,7 @@ pub struct Service {
 struct Data {
 	db: Arc<Database>,
 	senderkey_pusher: Arc<Map>,
+	senderkey_lastbadge: Arc<Map>,
 	pushkey_deviceid: Arc<Map>,
 	useridcount_notification: Arc<Map>,
 	userroomid_highlightcount: Arc<Map>,
@@ -52,11 +55,13 @@ impl crate::Service for Service {
 	fn build(args: &crate::Args<'_>) -> Result<Arc<Self>> {
 		Ok(Arc::new(Self {
 			services: args.services.clone(),
+			badge_send_mutex: MutexMap::new(),
 			notification_increment_mutex: MutexMap::new(),
 			highlight_increment_mutex: MutexMap::new(),
 			db: Data {
 				db: args.db.clone(),
 				senderkey_pusher: args.db["senderkey_pusher"].clone(),
+				senderkey_lastbadge: args.db["senderkey_lastbadge"].clone(),
 				pushkey_deviceid: args.db["pushkey_deviceid"].clone(),
 				useridcount_notification: args.db["useridcount_notification"].clone(),
 				userroomid_highlightcount: args.db["userroomid_highlightcount"].clone(),
@@ -125,7 +130,10 @@ pub async fn set_pusher(
 
 			let pushkey = data.pusher.ids.pushkey.as_str();
 			let key = (sender, pushkey);
+			let mutex_key = (sender.to_owned(), pushkey.to_owned());
+			let _lock = self.badge_send_mutex.lock(&mutex_key).await;
 			self.db.senderkey_pusher.put(key, Json(pusher));
+			self.db.senderkey_lastbadge.del(key);
 			self.db
 				.pushkey_deviceid
 				.insert(pushkey, sender_device);
@@ -141,8 +149,16 @@ pub async fn set_pusher(
 
 #[implement(Service)]
 pub async fn delete_pusher(&self, sender: &UserId, pushkey: &str) {
+	let mutex_key = (sender.to_owned(), pushkey.to_owned());
+	let _lock = self.badge_send_mutex.lock(&mutex_key).await;
+	self.delete_pusher_unlocked(sender, pushkey).await;
+}
+
+#[implement(Service)]
+async fn delete_pusher_unlocked(&self, sender: &UserId, pushkey: &str) {
 	let key = (sender, pushkey);
 	self.db.senderkey_pusher.del(key);
+	self.db.senderkey_lastbadge.del(key);
 	self.db.pushkey_deviceid.remove(pushkey);
 	self.clear_suppressed_pushkey(sender, pushkey);
 

--- a/src/service/pusher/notification.rs
+++ b/src/service/pusher/notification.rs
@@ -146,6 +146,22 @@ pub async fn notification_count(&self, user_id: &UserId, room_id: &RoomId) -> u6
 		.unwrap_or(0)
 }
 
+/// Total unread notifications for a user across all room-main and thread rows.
+///
+/// Push Gateway `counts.unread` is a global value, so event and counts-only
+/// pushes must both use this single aggregation path.
+#[implement(super::Service)]
+#[tracing::instrument(level = "debug", skip(self), ret(level = "trace"))]
+pub async fn global_notification_count(&self, user_id: &UserId) -> u64 {
+	self.db
+		.userroomid_notificationcount
+		.stream_prefix(&(user_id, Interfix))
+		.ignore_err()
+		.map(|(_, count): (Ignore, u64)| count)
+		.ready_fold(0_u64, u64::saturating_add)
+		.await
+}
+
 #[implement(super::Service)]
 #[tracing::instrument(level = "debug", skip(self), ret(level = "trace"))]
 pub async fn highlight_count(&self, user_id: &UserId, room_id: &RoomId) -> u64 {

--- a/src/service/pusher/request.rs
+++ b/src/service/pusher/request.rs
@@ -1,9 +1,12 @@
 use std::{fmt::Debug, mem};
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use ipaddress::IPAddress;
 use ruma::api::{
-	IncomingResponse, OutgoingRequest, auth_scheme::AuthScheme, path_builder::PathBuilder,
+	IncomingResponse, OutgoingRequest,
+	auth_scheme::AuthScheme,
+	path_builder::PathBuilder,
+	push_gateway::send_event_notification::v1::{Notification, Request, Response},
 };
 use tuwunel_core::{
 	Err, Result, debug_warn, err, implement, trace, utils::string_from_bytes, warn,
@@ -19,10 +22,42 @@ where
 	for<'a> T::Authentication: AuthScheme<Input<'a> = ()>,
 	for<'a> T::PathBuilder: PathBuilder<Input<'a> = ()>,
 {
-	let dest = dest.replace(&self.services.config.notification_push_path, "");
+	let (dest, http_request) = self.build_request(dest, request)?;
+	let reqwest_request = reqwest::Request::try_from(http_request)?;
+	let response = self
+		.execute_request(reqwest_request, &dest)
+		.await?;
+	T::IncomingResponse::try_from_http_response(response).map_err(|e| {
+		err!(BadServerResponse(warn!("Push gateway {dest} returned invalid response: {e}")))
+	})
+}
+
+#[implement(super::Service)]
+pub(super) async fn send_raw_request(&self, dest: &str, body: Vec<u8>) -> Result<Response> {
+	// Build from the Ruma endpoint request so custom notification_push_path
+	// stripping, the spec path, method, and headers cannot drift from events.
+	let template = Request::new(Notification::new(Vec::new()));
+	let (dest, mut request) = self.build_request(dest, template)?;
+	*request.body_mut() = body.into();
+
+	let request = reqwest::Request::try_from(request)?;
+	let response = self.execute_request(request, &dest).await?;
+	Response::try_from_http_response(response).map_err(|e| {
+		err!(BadServerResponse(warn!("Push gateway {dest} returned invalid response: {e}")))
+	})
+}
+
+#[implement(super::Service)]
+fn build_request<T>(&self, dest: &str, request: T) -> Result<(String, http::Request<Bytes>)>
+where
+	T: OutgoingRequest + Debug + Send,
+	for<'a> T::Authentication: AuthScheme<Input<'a> = ()>,
+	for<'a> T::PathBuilder: PathBuilder<Input<'a> = ()>,
+{
+	let dest = configured_destination(dest, &self.services.config.notification_push_path);
 	trace!("Push gateway destination: {dest}");
 
-	let http_request = request
+	let request = request
 		.try_into_http_request::<BytesMut>(&dest, (), ())
 		.map_err(|e| {
 			err!(BadServerResponse(warn!(
@@ -31,7 +66,19 @@ where
 		})?
 		.map(BytesMut::freeze);
 
-	let reqwest_request = reqwest::Request::try_from(http_request)?;
+	Ok((dest, request))
+}
+
+fn configured_destination(dest: &str, notification_push_path: &str) -> String {
+	dest.replace(notification_push_path, "")
+}
+
+#[implement(super::Service)]
+async fn execute_request(
+	&self,
+	reqwest_request: reqwest::Request,
+	dest: &str,
+) -> Result<http::Response<Bytes>> {
 	if let Some(url_host) = reqwest_request.url().host_str() {
 		trace!("Checking request URL for IP");
 		if let Ok(ip) = IPAddress::parse(url_host)
@@ -82,21 +129,29 @@ where
 				)));
 			}
 
-			let response = T::IncomingResponse::try_from_http_response(
-				http_response_builder
-					.body(body)
-					.expect("reqwest body is valid http body"),
-			);
-
-			response.map_err(|e| {
-				err!(BadServerResponse(warn!(
-					"Push gateway {dest} returned invalid response: {e}"
-				)))
-			})
+			Ok(http_response_builder
+				.body(body)
+				.expect("reqwest body is valid http body"))
 		},
 		| Err(e) => {
 			warn!("Could not send request to pusher {dest}: {e}");
 			Err(e.into())
 		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::configured_destination;
+
+	#[test]
+	fn custom_notification_path_is_stripped_before_endpoint_rebuild() {
+		assert_eq!(
+			configured_destination(
+				"https://push.example/custom/push/notify",
+				"/custom/push/notify",
+			),
+			"https://push.example"
+		);
 	}
 }

--- a/src/service/pusher/send.rs
+++ b/src/service/pusher/send.rs
@@ -1,7 +1,6 @@
-use futures::future::join;
 use ipaddress::IPAddress;
 use ruma::{
-	UInt, UserId,
+	UserId,
 	api::{
 		client::push::{Pusher, PusherKind},
 		push_gateway::send_event_notification::v1::{
@@ -13,6 +12,8 @@ use ruma::{
 	uint,
 };
 use tuwunel_core::{Err, Result, err, implement, matrix::Event, warn};
+
+use super::badge::badge_count_disabled;
 
 #[implement(super::Service)]
 #[tracing::instrument(level = "debug", skip_all)]
@@ -61,28 +62,7 @@ where
 	}
 
 	if notify == Some(true) || self.services.config.push_everything {
-		// MSC3771/MSC3773: badge count merges main and per-thread notifications.
-		let (main, threads) = join(
-			self.services
-				.pusher
-				.notification_count(user_id, event.room_id()),
-			self.services
-				.pusher
-				.thread_notification_counts(user_id, event.room_id()),
-		)
-		.await;
-
-		let thread_total: u64 = threads
-			.values()
-			.map(|(notifications, _)| *notifications)
-			.sum();
-
-		let unread: UInt = main
-			.saturating_add(thread_total)
-			.try_into()
-			.unwrap_or_else(|_| uint!(1));
-
-		self.send_notice(user_id, unread, pusher, tweaks, event)
+		self.send_notice(user_id, pusher, tweaks, event)
 			.await?;
 	}
 
@@ -94,14 +74,25 @@ where
 async fn send_notice<Pdu: Event>(
 	&self,
 	user_id: &UserId,
-	unread: UInt,
 	pusher: &Pusher,
 	tweaks: Vec<Tweak>,
 	event: &Pdu,
 ) -> Result {
 	// TODO: email
 	match &pusher.kind {
-		| PusherKind::Http(http) => {
+		| PusherKind::Http(_) => {
+			let mutex_key = (user_id.to_owned(), pusher.ids.pushkey.clone());
+			let _lock = self.badge_send_mutex.lock(&mutex_key).await;
+			let Ok(pusher) = self
+				.get_pusher(user_id, &pusher.ids.pushkey)
+				.await
+			else {
+				return Ok(());
+			};
+			let PusherKind::Http(http) = &pusher.kind else {
+				return Ok(());
+			};
+			let unread = self.badge_count(user_id).await;
 			let url = &http.url;
 			let url = url::Url::parse(&http.url).map_err(|e| {
 				err!(Request(InvalidParam(
@@ -143,11 +134,8 @@ async fn send_notice<Pdu: Event>(
 
 			notify.event_id = Some(event.event_id().to_owned());
 			notify.room_id = Some(event.room_id().to_owned());
-			if http
-				.data
-				.get("org.matrix.msc4076.disable_badge_count")
-				.is_none() && http.data.get("disable_badge_count").is_none()
-			{
+			let sends_badge = !badge_count_disabled(http);
+			if sends_badge {
 				notify.counts = NotificationCounts::new(unread, uint!(0));
 			} else {
 				// counts will not be serialised if it's the default (0, 0)
@@ -206,7 +194,10 @@ async fn send_notice<Pdu: Event>(
 				let pushkey = &pusher.ids.pushkey;
 
 				warn!(%url, %pushkey, "Push gateway rejected the pushkey; removing pusher");
-				self.delete_pusher(user_id, pushkey).await;
+				self.delete_pusher_unlocked(user_id, pushkey)
+					.await;
+			} else if sends_badge {
+				self.store_last_badge(user_id, &pusher.ids.pushkey, unread.into());
 			}
 
 			Ok(())

--- a/src/service/rooms/timeline/append.rs
+++ b/src/service/rooms/timeline/append.rs
@@ -209,6 +209,9 @@ where
 	self.append_pdu_json(&pdu_id, pdu, &pdu_json);
 
 	drop(insert_lock);
+	self.services
+		.pusher
+		.schedule_badge_update(pdu.sender().to_owned());
 
 	self.services
 		.pusher


### PR DESCRIPTION
### What does this PR do?

Push badge counts were only sent to a push gateway as part of a normal event notification.

When a user read messages, tuwunel correctly reset the server-side unread counters, but it did not tell registered pushers that the count had changed. Clients (such as Element X) could therefore continue displaying a stale badge until another event happened to generate a push.

### Changes

Send a counts-only push update after an operation clears unread notification counts.

These updates are triggered when:

- A read receipt advances.
- A read marker advances.
- A locally sent event clears the sender’s unread count.

The counts-only payload contains the current global unread count and target device, but no event ID, room ID, content, sender, notification type, or alert tweaks. It can therefore update or clear the application badge without representing a new message notification.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
