### PR TITLE
fix: avoid redundant thumbnail re-encoding

### DIFF
--- a/src/service/media/tests.rs
+++ b/src/service/media/tests.rs
@@ -1,5 +1,83 @@
 #![cfg(test)]
 
+use ruma::media::Method;
+
+use super::Dim;
+
+fn scale(width: u32, height: u32) -> Dim { Dim::new(width, height, Some(Method::Scale)) }
+fn crop(width: u32, height: u32) -> Dim { Dim::new(width, height, Some(Method::Crop)) }
+fn source(width: u32, height: u32) -> Dim { Dim::new(width, height, None) }
+
+/// The source already carries the requested dimensions, so scaling is a no-op
+/// and re-encoding would only discard the original's format and metadata.
+#[test]
+fn passthrough_when_scale_request_matches_source() {
+	assert!(
+		scale(800, 600)
+			.is_passthrough(&source(800, 600))
+			.unwrap()
+	);
+}
+
+/// `scaled` covers the requested box rather than fitting inside it, so a source
+/// already meeting the requested height cannot shrink: the generated thumbnail
+/// would be the source itself.
+#[test]
+fn passthrough_when_one_side_already_meets_request() {
+	assert!(
+		scale(800, 600)
+			.is_passthrough(&source(1000, 600))
+			.unwrap()
+	);
+}
+
+/// A genuinely larger source must still be thumbnailed.
+#[test]
+fn generates_when_source_is_larger_in_both_dimensions() {
+	assert!(
+		!scale(800, 600)
+			.is_passthrough(&source(4000, 3000))
+			.unwrap()
+	);
+}
+
+/// Crop reaches the requested size by cropping, so a source that is larger in
+/// only one dimension must still be generated. Widening the upscale guard to
+/// `>=` would wrongly pass this through.
+#[test]
+fn generates_when_crop_source_is_larger_in_one_dimension() {
+	assert!(
+		!crop(96, 96)
+			.is_passthrough(&source(500, 96))
+			.unwrap()
+	);
+}
+
+/// Servers must not upscale; a source smaller than the request is served as-is.
+#[test]
+fn passthrough_when_request_exceeds_source() {
+	assert!(
+		crop(96, 96)
+			.is_passthrough(&source(50, 50))
+			.unwrap()
+	);
+	assert!(
+		scale(800, 600)
+			.is_passthrough(&source(1000, 400))
+			.unwrap()
+	);
+}
+
+/// Crop at exactly the source size reproduces the source.
+#[test]
+fn passthrough_when_crop_request_matches_source() {
+	assert!(
+		crop(96, 96)
+			.is_passthrough(&source(96, 96))
+			.unwrap()
+	);
+}
+
 #[tokio::test]
 #[cfg(disable)] //TODO: fixme
 async fn long_file_names_works() {

--- a/src/service/media/thumbnail.rs
+++ b/src/service/media/thumbnail.rs
@@ -225,7 +225,8 @@ async fn get_thumbnail_generate(
 		return Ok(into_media(data, media.content));
 	};
 
-	if dim.width > image.width() || dim.height > image.height() {
+	let source = Dim::new(image.width(), image.height(), None);
+	if dim.is_passthrough(&source)? {
 		return Ok(into_media(data, media.content));
 	}
 
@@ -344,6 +345,24 @@ impl Dim {
 			height: y,
 			method: Method::Scale,
 		})
+	}
+
+	/// Returns true when generation cannot improve on the source and the
+	/// original should be served instead: either the request would upscale, or
+	/// the generated thumbnail would carry the source's own dimensions.
+	pub fn is_passthrough(&self, source: &Self) -> Result<bool> {
+		if self.width > source.width || self.height > source.height {
+			return Ok(true);
+		}
+
+		let (width, height) = if self.crop() {
+			(self.width, self.height)
+		} else {
+			let scaled = self.scaled(source)?;
+			(scaled.width, scaled.height)
+		};
+
+		Ok(width == source.width && height == source.height)
 	}
 
 	/// Returns width, height of the thumbnail and whether it should be cropped.


### PR DESCRIPTION
### What does this PR do?

Stops the server re-encoding thumbnails it didn't need to generate.

Generating a thumbnail decodes the image, resizes it, re-encodes it as PNG and stores it. But the resize often returns an image the same size as the source, so all that work happens for identical pixels, and the PNG re-encode throws away the original's format and colour profile **(I will be opening a separate PR to fix this issue)**.

The old guard only skipped generation when the request was *larger* than the source. However, the following cases should be accounted for:

- **Request matches the source exactly**: a client-uploaded 800×600 thumbnail requested at 800×600. This is a significant value as this is the size of the thumbnail that Element X creates when uploading images.
- **One side already meets the request**: a 1000×600 source requested at 800×600. Shrinking would drop the height below the requested 600, which the spec forbids, so the resize returns 1000×600.

`Dim::is_passthrough()` replaces it. Instead of comparing the *requested* size to the source, it works out what the resize would actually produce and compares that. If they match, serve the original untouched. The upscale check stays in front, since `crop` would otherwise upscale a source smaller than the request.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
