### PR TITLE
fix(api): clamp /messages pagination at the `to` position

### DIFF
--- a/.github/workflows/auto-mindroom-release.yml
+++ b/.github/workflows/auto-mindroom-release.yml
@@ -1,0 +1,92 @@
+name: Auto MindRoom Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: auto-mindroom-release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Compute and create MindRoom release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Refresh remote tags
+        run: git fetch --force --tags origin
+
+      - name: Compute MindRoom release tag
+        id: version
+        env:
+          RELEASE_TAG_PREFIX: v
+          RELEASE_TAG_SUFFIX: mindroom
+        run: python3 scripts/fork_release_tag.py
+
+      - name: Create release (or skip if it already exists)
+        id: create_release
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          BASE_VERSION: ${{ steps.version.outputs.base_version }}
+          RELEASE_ITERATION: ${{ steps.version.outputs.release_iteration }}
+          REUSED_TAG_AT_HEAD: ${{ steps.version.outputs.reused_tag_at_head }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; skipping."
+            echo "release_created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$REUSED_TAG_AT_HEAD" = "true" ]; then
+            echo "HEAD already tagged as $RELEASE_TAG; creating release for existing tag."
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$RELEASE_TAG" \
+            --generate-notes \
+            --notes "Automated release based on Tuwunel ${BASE_VERSION} (MindRoom iteration ${RELEASE_ITERATION})."
+          echo "release_created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger binary build workflow
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          asset_count="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets | length')"
+
+          if [ "$asset_count" -gt 0 ]; then
+            echo "Release $RELEASE_TAG already has $asset_count assets; skipping binary workflow trigger."
+            exit 0
+          fi
+
+          echo "Dispatching MindRoom Release Binaries for tag $RELEASE_TAG"
+          gh workflow run mindroom-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag="$RELEASE_TAG"
+
+      - name: Trigger container publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          echo "Dispatching MindRoom Release Containers for tag $RELEASE_TAG"
+          gh workflow run mindroom-container-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag="$RELEASE_TAG" \
+            -f publish_latest=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,6 @@
 name: Main
 
 on:
-  push:
-    branches:
-      - "**"
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       pipeline:

--- a/.github/workflows/mindroom-ci.yml
+++ b/.github/workflows/mindroom-ci.yml
@@ -1,0 +1,61 @@
+name: MindRoom CI
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mindroom-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            clang \
+            libclang-dev \
+            libssl-dev \
+            liburing-dev \
+            pkg-config
+
+      - name: Set up Rust
+        run: rustup toolchain install
+
+      - name: Set up nightly rustfmt
+        run: rustup toolchain install nightly --profile minimal --component rustfmt
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo +nightly fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --locked --workspace --all-targets --all-features
+
+      - name: Build release binary
+        run: cargo build --locked --release -p tuwunel

--- a/.github/workflows/mindroom-container-release.yml
+++ b/.github/workflows/mindroom-container-release.yml
@@ -1,0 +1,222 @@
+name: MindRoom Release Containers
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish containers for
+        required: true
+        type: string
+      publish_latest:
+        description: Also move the latest container tags
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mindroom-release-containers-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  DOCKERHUB_ENABLED: ${{ vars.DOCKER_ACCT != '' && vars.DOCKER_REPO != '' && secrets.DOCKERHUB_TOKEN != '' }}
+
+jobs:
+  build:
+    name: Build and push ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: x86_64
+            platform: linux/amd64
+            sys_target: x86_64-v1-linux-gnu
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+            platform: linux/arm64
+            sys_target: aarch64-v8-linux-gnu
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Capture container metadata
+        id: meta
+        run: |
+          echo "created=$(git log -1 --format=%cI)" >> "$GITHUB_OUTPUT"
+          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Download release artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSET_NAME: tuwunel-${{ env.RELEASE_TAG }}-linux-${{ matrix.arch }}.tar.gz
+        run: |
+          mkdir -p "dist/${{ matrix.arch }}"
+
+          # The download succeeds as soon as ANY pattern matches, and the
+          # binaries workflow uploads the .sha256 before the tarball — so a
+          # partial download must keep polling until both files are present.
+          for attempt in $(seq 1 90); do
+            if gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber \
+              -D "dist/${{ matrix.arch }}" \
+              -p "$ASSET_NAME" \
+              -p "$ASSET_NAME.sha256" \
+              && [ -f "dist/${{ matrix.arch }}/$ASSET_NAME" ] \
+              && [ -f "dist/${{ matrix.arch }}/$ASSET_NAME.sha256" ]
+            then
+              break
+            fi
+
+            if [ "$attempt" -eq 90 ]; then
+              echo "Timed out waiting for $ASSET_NAME"
+              exit 1
+            fi
+
+            sleep 20
+          done
+
+          (
+            cd "dist/${{ matrix.arch }}"
+            sha256sum -c "$ASSET_NAME.sha256"
+            tar -xzf "$ASSET_NAME"
+            test -f tuwunel
+            chmod +x tuwunel
+          )
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: mindroom-release-${{ matrix.arch }}
+          driver: docker-container
+          install: true
+          use: true
+          buildkitd-flags: --allow-insecure-entitlement network.host
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKER_ACCT }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push release image
+        env:
+          IMAGE_TAG: ${{ env.RELEASE_TAG }}-release-all-${{ matrix.sys_target }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}
+          DOCKERHUB_IMAGE: docker.io/${{ vars.DOCKER_REPO }}
+        run: |
+          tags=("--tag" "${GHCR_IMAGE}:${IMAGE_TAG}")
+
+          if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
+            tags+=("--tag" "${DOCKERHUB_IMAGE}:${IMAGE_TAG}")
+          fi
+
+          docker buildx build \
+            --builder "mindroom-release-${{ matrix.arch }}" \
+            --file docker/Dockerfile.release-binary \
+            --platform "${{ matrix.platform }}" \
+            --build-arg "PACKAGE_VERSION=${RELEASE_TAG}" \
+            --build-arg "PACKAGE_REVISION=${{ steps.meta.outputs.revision }}" \
+            --build-arg "PACKAGE_CREATED=${{ steps.meta.outputs.created }}" \
+            --push \
+            "${tags[@]}" \
+            "dist/${{ matrix.arch }}"
+
+  manifest:
+    name: Publish multi-arch tags
+    needs: build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: mindroom-release-manifest
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKER_ACCT }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish GHCR release tag
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          AMD64_TAG: ${{ env.RELEASE_TAG }}-release-all-x86_64-v1-linux-gnu
+          ARM64_TAG: ${{ env.RELEASE_TAG }}-release-all-aarch64-v8-linux-gnu
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${RELEASE_TAG}" \
+            "${IMAGE}:${AMD64_TAG}" \
+            "${IMAGE}:${ARM64_TAG}"
+
+      - name: Publish GHCR latest tag
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest) }}
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          AMD64_TAG: ${{ env.RELEASE_TAG }}-release-all-x86_64-v1-linux-gnu
+          ARM64_TAG: ${{ env.RELEASE_TAG }}-release-all-aarch64-v8-linux-gnu
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${AMD64_TAG}" \
+            "${IMAGE}:${ARM64_TAG}"
+
+      - name: Publish Docker Hub release tag
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
+        env:
+          IMAGE: docker.io/${{ vars.DOCKER_REPO }}
+          AMD64_TAG: ${{ env.RELEASE_TAG }}-release-all-x86_64-v1-linux-gnu
+          ARM64_TAG: ${{ env.RELEASE_TAG }}-release-all-aarch64-v8-linux-gnu
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${RELEASE_TAG}" \
+            "${IMAGE}:${AMD64_TAG}" \
+            "${IMAGE}:${ARM64_TAG}"
+
+      - name: Publish Docker Hub latest tag
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest)) }}
+        env:
+          IMAGE: docker.io/${{ vars.DOCKER_REPO }}
+          AMD64_TAG: ${{ env.RELEASE_TAG }}-release-all-x86_64-v1-linux-gnu
+          ARM64_TAG: ${{ env.RELEASE_TAG }}-release-all-aarch64-v8-linux-gnu
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${AMD64_TAG}" \
+            "${IMAGE}:${ARM64_TAG}"
+
+      - name: Inspect GHCR manifest
+        run: docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${RELEASE_TAG}"

--- a/.github/workflows/mindroom-release.yml
+++ b/.github/workflows/mindroom-release.yml
@@ -1,0 +1,112 @@
+name: MindRoom Release Binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and upload assets for
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            clang \
+            libclang-dev \
+            libssl-dev \
+            liburing-dev \
+            pkg-config
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build tuwunel
+        env:
+          CARGO_TERM_COLOR: always
+        run: |
+          cargo build --locked --release -p tuwunel --target "${{ matrix.target }}"
+
+      - name: Package release artifact
+        env:
+          TAG: ${{ env.RELEASE_TAG }}
+          TARGET: ${{ matrix.target }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p dist
+          cp "target/${TARGET}/release/tuwunel" dist/tuwunel
+          strip dist/tuwunel || true
+
+          tarball="tuwunel-${TAG}-linux-${ARCH}.tar.gz"
+          tar -C dist -czf "${tarball}" tuwunel
+          sha256sum "${tarball}" > "${tarball}.sha256"
+
+      - name: Upload intermediate artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.arch }}
+          path: |
+            tuwunel-${{ env.RELEASE_TAG }}-linux-${{ matrix.arch }}.tar.gz
+            tuwunel-${{ env.RELEASE_TAG }}-linux-${{ matrix.arch }}.tar.gz.sha256
+
+  release:
+    name: Publish GitHub Release Assets
+    needs: build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: dist/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          make_latest: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mindroom_rebase_tests"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tuwunel",
+ "tuwunel_api",
+ "tuwunel_core",
+ "tuwunel_service",
+ "url",
+]
+
+[[package]]
 name = "minicbor"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -1,0 +1,222 @@
+# MindRoom Tuwunel Fork - Changes vs Upstream
+
+This document describes the current MindRoom fork behavior on top of upstream
+`tuwunel`. The fork is rebased directly onto upstream commits; see
+`docs/rebase-*.md` for the per-rebase log. As of the 2026-07-21 rebase the base
+is upstream `v1.8.2`. Four features this fork originally carried were merged
+upstream and dropped from the fork: the room-creation default power-level
+override and the SSO grant-cookie path hardening (2026-07-07 rebase), and the
+drained/zero one-time-key counts fix and public MatrixRTC transport discovery
+(2026-07-21 rebase, upstream `164b8da61`/`007033cd5` and `a1776c368`).
+
+## How To Inspect
+- Fork commits: `git log --reverse --oneline <upstream-base>..HEAD`
+- Files changed in the fork: `git diff --stat <upstream-base>..HEAD`
+- Per-commit patch: `git show <sha>`
+
+## Runtime Changes
+
+### 1) `mindroom/edits: compact /sync, purge superseded edits, bundle the survivor`
+Files:
+- `src/api/client/sync/mod.rs`, `src/api/client/sync/mindroom_edits.rs`
+- `src/core/config/mod.rs`, `src/core/config/check/mindroom.rs`, `src/core/config/check.rs`
+- `src/core/matrix/event.rs`, `src/core/matrix/event/relation.rs`
+- `src/database/map/remove.rs`
+- `src/service/edit_purge/mod.rs`, `src/service/mod.rs`, `src/service/services.rs`
+- `src/mindroom-tests/tests/edit_purge_bundle_compose.rs`
+- `tuwunel-example.toml`
+
+Behavior:
+- Adds `/sync` timeline compaction for superseded `m.replace` events.
+- Adds a background purge worker that deletes old superseded edit events from
+  storage and indexes, keeping exactly one edit per (target, sender).
+- Adds the MindRoom edit-lifecycle configuration surface and purge validation.
+- **Turns on upstream's edit bundling by default** (`bundle_edit_relations`,
+  MSC3925; upstream ships it off). The purge deletes superseded edits, so
+  without the bundle a history endpoint (`/messages`, `/context`, `/event`, ...)
+  would serve an original with its stale pre-edit body and no way for the client
+  to find the surviving edit. Upstream bundles the newest surviving edit onto
+  the original at `unsigned.m.relations.m.replace` via its `relatesto_typed`
+  typed index; the purge composes with that index (it tolerates the dangling
+  rows the purge leaves behind and always selects the surviving edit), and
+  upstream's startup `rebuild_relatesto_typed` migration indexes pre-existing
+  edits. `edit_purge::purge_cycle` is `pub` so operators/tests can trigger a
+  cycle; a composition test drives a real purge and asserts the survivor is
+  still bundled and that a dangling newest index row is skipped.
+
+### 2) `auth/sso: SSO-origin UIAA hardening and self-reactivation`
+Files:
+- `src/api/router/auth/uiaa.rs`, `src/api/client/session/sso.rs`
+- `src/api/client/account/deactivate.rs`, `src/api/client/admin/mas/delete_user.rs`
+- `src/api/client/admin/users/deactivate_account.rs`, `src/api/client/admin/users/create_or_modify.rs`
+- `src/api/client/membership/mod.rs`, `src/api/oidc/account/account_deactivate.rs`
+- `src/admin/user/mod.rs`, `src/database/maps.rs`
+- `src/service/deactivate/mod.rs`, `src/service/emergency/mod.rs`
+- `src/service/users/mod.rs`, `src/service/users/sso.rs`
+
+Behavior:
+- Upstream already ships the strict-CSP-safe SSO UIAA fallback itself (MSC2454:
+  server-redirect flow, `m.login.sso/fallback/web` completion, bound-IdP
+  routing). This fork hardens how UIAA flows are advertised for SSO-origin
+  users: no `m.login.password` for passwordless SSO accounts (even with LDAP
+  enabled), `m.login.sso` only for SSO-origin accounts and only when the exact
+  IdP is unambiguous (the device's own IdP or the single configured provider),
+  JWT UIAA rejected for SSO-origin users and no longer advertised (its
+  fallback/web page is not implemented), and legacy SSO-origin account
+  metadata repaired on the fly.
+- Reactivates a deactivated local SSO account on re-login, but only when the
+  account was self-deactivated (a persisted deactivation reason distinguishes
+  self-service from administrative deactivation).
+- Upstream's Synapse admin deactivation endpoints (the v1 deactivate route and
+  the v2 create-or-modify `deactivated` flag, new in v1.8.1) record
+  `DeactivationReason::Admin`, so accounts they deactivate stay deactivated on
+  SSO re-login.
+
+Design note — why deactivation takes a reason (vs Synapse/upstream):
+- Synapse models deactivation as a bare `users.deactivated` flag (plus the
+  separate, admin-imposed MSC3823 `suspended` flag); it stores no reason,
+  hard-blocks SSO login for deactivated accounts (the
+  `sso_account_deactivated_template` 403 page in `auth.py`), and its
+  admin-only `activate_account` expects a password hash to be set afterwards,
+  which passwordless SSO accounts don't have.
+- Upstream Tuwunel likewise stores no reason; since v1.8.1 an admin can
+  reactivate a passwordless user via the password sentinel, but neither
+  server has a self-service path.
+- The fork persists the initiator (`self`/`admin`) so *self*-deactivated SSO
+  accounts can safely self-reactivate when the same IdP identity returns,
+  while admin deactivations stay final. The reason is a required parameter of
+  `deactivate_account`, so each new upstream call site must classify itself
+  at compile time — this is the recurring (and intentional) rebase seam; the
+  v1.8.1 rebase adapted two new Synapse-admin endpoints exactly this way,
+  and the v1.8.2 window added no new callers.
+- Deliberately not upstreamed: reversible deactivation diverges from
+  Synapse-established semantics and would effectively need an MSC, so we
+  carry it as a fork feature. The full comparison lives in
+  `src/service/users/sso.rs` above `DeactivationReason`.
+
+Note: the SSO grant-cookie path hardening this fork originally carried (matching
+set and removal cookie paths) was merged upstream, so it is no longer a fork
+delta.
+
+### 3) `auth/apple: native iOS Apple login exchange`
+Files:
+- `src/api/client/session/mod.rs`, `src/api/client/session/sso.rs`
+- `src/api/client/session/sso/native_apple.rs`
+- `src/api/router.rs`, `src/core/config/mod.rs`, `tuwunel-example.toml`
+
+Behavior:
+- Adds `POST /_matrix/client/unstable/org.mindroom.login/apple`.
+- Verifies native Sign in with Apple identity tokens against Apple's JWKS,
+  issuer, audience, expiration, and nonce (with a brief in-memory JWKS cache
+  that refreshes on an unknown key ID).
+- Accepts configured native app bundle IDs via
+  `global.identity_provider.native_client_ids` while keeping the web Services ID
+  valid; reuses the normal SSO mapping/registration/reactivation/loginToken
+  path.
+
+Note: the Apple `id_token` userinfo fallback that this fork originally carried
+was merged upstream, so it is no longer a fork delta.
+
+### 4) `Notify once when MindRoom streams finish (#9)`
+Files:
+- `src/service/pusher/mod.rs`, `src/service/pusher/send.rs`
+- `src/service/pusher/tests.rs`
+
+Behavior:
+- Recognizes MindRoom streamed events by the `io.mindroom.stream_status`
+  content key (an event-level protocol signal: senders opt their own streamed
+  events in; no account privilege involved).
+- Suppresses push notifications for stream updates in non-terminal states, so
+  a streaming agent reply does not notify once per chunk. Unknown stream
+  statuses fail closed (suppressed) so a new producer state cannot
+  reintroduce push spam.
+- When the stream reaches a terminal status (`completed`, `cancelled`,
+  `interrupted`, `error`) via an `m.replace` edit, evaluates the surviving
+  message as the final content it represents: for `m.room.message` the
+  `m.new_content` body, for `m.room.encrypted` the payload without
+  `m.relates_to`. Ordinary room/DM/mention/mute push rules then decide the
+  single notification instead of the generic edit-suppression rule swallowing
+  the terminal update.
+- The `push_everything` debug mode honors the same suppression.
+
+### 5) `fix(e2ee): reject replacement of existing device identity keys (#10)`
+Files:
+- `src/api/client/keys/upload_keys.rs`, `src/service/users/device.rs`
+
+Behavior:
+- Treats identity keys for an existing device as immutable in `/keys/upload`:
+  the first upload is accepted, an exact-copy re-upload is ignored (upstream's
+  nheko workaround, preserving cross-signing signatures), and differing key
+  material is rejected with 403 `M_FORBIDDEN` so a client that lost its crypto
+  store fails loudly and re-logins instead of becoming a zombie session
+  (root cause of the 2026-07-14 mindroom.chat silent-call incident; unpatched
+  upstream accepts the rotated upload).
+- A stored value that fails to deserialize propagates a Database error rather
+  than being treated as absent (absence would bypass the immutability check).
+- `remove_device` also purges the device's uploaded identity keys and one-time
+  keys (resolving upstream's standing TODO); leftover keys would otherwise
+  collide with the immutability check when a later login re-uses the device
+  id.
+- Submitted upstream (`fix/reject-device-key-replacement` and follow-ups);
+  drop this section when it merges, as happened with the one-time-key and
+  MatrixRTC fixes at v1.8.2.
+
+## Operational Changes
+
+### 6) `ci: fork release automation, container publishing, and GitHub checks`
+Files:
+- `.github/workflows/mindroom-release.yml`, `.github/workflows/auto-mindroom-release.yml`
+- `.github/workflows/mindroom-container-release.yml`, `.github/workflows/mindroom-ci.yml`
+- `scripts/fork_release_tag.py`, `docker/bake.sh`
+
+Behavior:
+- Computes `v<base_version>-mindroom.<n>` tags on `main`, creates/reuses the
+  matching GitHub Release, publishes Linux `x86_64`/`aarch64` binaries, and
+  dispatches container publication. Runs the fork's own GitHub-hosted checks.
+
+## Tests
+
+Fork integration tests live in the `mindroom-tests` crate
+(`src/mindroom-tests/`), plus `default_test` database-path isolation in
+`src/main/args.rs`. They pin the rebase-sensitive behaviors (SSO/UIAA, native
+Apple, deactivation/erase, Synapse-admin deactivation reason, edit-purge ↔
+bundling composition) so future rebases catch regressions. The stream-push
+classification (#9) is pinned by unit tests in `src/service/pusher/tests.rs`.
+
+## Runtime Configuration
+
+### Edit compaction, purge, and bundling
+```toml
+[global]
+mindroom_compact_edits_enabled = true
+mindroom_edit_purge_enabled = true
+mindroom_edit_purge_min_age_secs = 86400
+mindroom_edit_purge_interval_secs = 3600
+mindroom_edit_purge_batch_size = 1000
+mindroom_edit_purge_scan_limit = 100000
+mindroom_edit_purge_dry_run = false
+# bundle_edit_relations defaults to true in the fork; set false only to opt out.
+```
+
+### Native Sign in with Apple
+```toml
+[[global.identity_provider]]
+brand = "AppleOIDC"
+client_id = "chat.mindroom.matrix.apple"
+native_client_ids = ["chat.mindroom.app"]
+```
+
+## Compatibility Notes
+- Matrix event formats remain standard. With edit bundling on, served events
+  (including `/sync`) may carry `unsigned.m.relations.m.replace` (the newest
+  surviving edit, as a sync-shaped event without `room_id`); the fork's `/sync`
+  compaction still delivers the surviving edit event itself.
+- Superseded edits can be permanently removed when purge is enabled; the bundle
+  compensates so history endpoints never serve stale pre-edit bodies.
+- Admin-deactivated SSO accounts stay deactivated on future login attempts.
+- Native Apple login requires the app bundle ID in `native_client_ids`.
+- A client that lost its crypto store but kept its access token receives 403
+  `M_FORBIDDEN` on `/keys/upload` until it logs in again (device identity keys
+  are immutable per device id).
+- Events carrying `io.mindroom.stream_status` push at most once, when the
+  stream reaches a terminal status.

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -161,9 +161,31 @@ Behavior:
   drop this section when it merges, as happened with the one-time-key and
   MatrixRTC fixes at v1.8.2.
 
+### 6) `fix(api): clamp /messages pagination at the to position`
+Files:
+- `src/api/client/message.rs`
+- `src/mindroom-tests/tests/messages_to_clamp.rs`
+
+Behavior:
+- `/messages` stopped pagination only when an event's count exactly equalled
+  the `to` token and silently swallowed unparseable `to` values. A sync
+  `next_batch` token is a global stream position that almost never equals an
+  event count in the requested room, so a `to` bound taken from `/sync` —
+  which the spec explicitly permits — was ignored and the walk ran unbounded
+  (live probes: `to=<sync token>` and `to=garbage!!` both returned HTTP 200
+  with unclamped chunks). Pagination now stops once the walk passes the `to`
+  position in either direction, and an unparseable `to` fails the request the
+  same way an unparseable `from` does.
+- Found by mindroom-nio's limited-timeline backfill (mindroom-nio#13), which
+  pages `/messages` with sync tokens to recover events dropped by limited
+  sync timelines. The nio client does not depend on this fix (it treats `to`
+  as best-effort), but with it servers clamp the walk at the sync position,
+  which also closes a federation topological-ordering edge case client code
+  cannot detect. Candidate for upstreaming.
+
 ## Operational Changes
 
-### 6) `ci: fork release automation, container publishing, and GitHub checks`
+### 7) `ci: fork release automation, container publishing, and GitHub checks`
 Files:
 - `.github/workflows/mindroom-release.yml`, `.github/workflows/auto-mindroom-release.yml`
 - `.github/workflows/mindroom-container-release.yml`, `.github/workflows/mindroom-ci.yml`
@@ -180,8 +202,9 @@ Fork integration tests live in the `mindroom-tests` crate
 (`src/mindroom-tests/`), plus `default_test` database-path isolation in
 `src/main/args.rs`. They pin the rebase-sensitive behaviors (SSO/UIAA, native
 Apple, deactivation/erase, Synapse-admin deactivation reason, edit-purge ↔
-bundling composition) so future rebases catch regressions. The stream-push
-classification (#9) is pinned by unit tests in `src/service/pusher/tests.rs`.
+bundling composition, `/messages` `to`-position clamping) so future rebases
+catch regressions. The stream-push classification (#9) is pinned by unit tests
+in `src/service/pusher/tests.rs`.
 
 ## Runtime Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,47 @@
 # Tuwunel<sup>💕</sup>
 
+> This is the MindRoom fork of
+> [`matrix-construct/tuwunel`](https://github.com/matrix-construct/tuwunel).
+> It tracks upstream and carries a focused set of fork-specific changes for
+> high-frequency edit streaming workloads.
+
+## MindRoom Fork Additions
+
+- Compact edit timeline mode in `/sync` to collapse superseded `m.replace`
+  events in response timelines.
+- Background purge service for superseded `m.replace` events with configurable
+  age/interval/batch/scan/dry-run controls.
+- Native Sign in with Apple login endpoint that verifies iOS identity tokens
+  against Apple's JWKS, issuer, audience, expiry, and nonce.
+- Hardened UIAA flow advertising for SSO-origin (passwordless) accounts, on
+  top of upstream's SSO UIAA fallback (MSC2454).
+- Reactivation of self-deactivated SSO accounts when the same identity returns.
+- Tagged-release binary publishing workflow for Linux `x86_64` and `aarch64`.
+- Release container publishing workflow for MindRoom release tags.
+- Automated fork release tagging on `main` in
+  `v<base_version>-mindroom.<n>` format.
+- Fork runbook and commit-by-commit changelog in
+  [`FORK_CHANGES.md`](./FORK_CHANGES.md).
+
+## MindRoom Release Tags
+
+- Every push to `main` computes a release tag in the format
+  `v<base_version>-mindroom.<n>`.
+- The workflow creates (or reuses) the corresponding GitHub Release for that tag.
+- `base_version` is auto-detected from `BASE_VERSION`, then `Cargo.toml`
+  (`workspace.package.version`), then standard semver tags.
+- Reused tags are detected when `HEAD` is already tagged for that base version.
+- Tagged pushes publish Linux release tarballs for `x86_64` and `aarch64` via
+  [`mindroom-release.yml`](./.github/workflows/mindroom-release.yml).
+- Tagging is performed by
+  [`auto-mindroom-release.yml`](./.github/workflows/auto-mindroom-release.yml)
+  using [`scripts/fork_release_tag.py`](./scripts/fork_release_tag.py).
+- Local preview of the next tag:
+
+```bash
+python3 scripts/fork_release_tag.py
+```
+
 ![GitHub License](https://img.shields.io/github/license/matrix-construct/tuwunel?style=flat%2Dsquare&color=%238A2BE2)
 ![GitHub Created At](https://img.shields.io/github/created-at/matrix-construct/tuwunel?style=flat%2Dsquare&color=%238A2BE2)
 ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/matrix-construct/tuwunel?style=flat%2Dsquare&link=https%3A%2F%2Fgithub.com%2Fmatrix-construct%2Ftuwunel%2Fpulse%2Fmonthly&color=%238A2BE2)

--- a/docker/Dockerfile.release-binary
+++ b/docker/Dockerfile.release-binary
@@ -1,0 +1,43 @@
+# syntax = docker/dockerfile:1.11-labs
+
+FROM debian:testing-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PACKAGE_VERSION=""
+ARG PACKAGE_REVISION=""
+ARG PACKAGE_CREATED=""
+
+LABEL org.opencontainers.image.title="tuwunel" \
+      org.opencontainers.image.description="MindRoom release container for tuwunel" \
+      org.opencontainers.image.version="${PACKAGE_VERSION}" \
+      org.opencontainers.image.revision="${PACKAGE_REVISION}" \
+      org.opencontainers.image.created="${PACKAGE_CREATED}" \
+      org.opencontainers.image.source="https://github.com/mindroom-ai/mindroom-tuwunel" \
+      org.opencontainers.image.documentation="https://github.com/mindroom-ai/mindroom-tuwunel/tree/main/docs/" \
+      org.opencontainers.image.url="https://github.com/mindroom-ai/mindroom-tuwunel" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="mindroom-ai"
+
+RUN <<EOF
+    set -eux
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        adduser \
+        ca-certificates \
+        libstdc++6 \
+        liburing2
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+COPY --chmod=755 tuwunel /usr/bin/tuwunel
+
+RUN <<EOF
+    set -eux
+    ldd /usr/bin/tuwunel
+    sha256sum /usr/bin/tuwunel
+    du -h /usr/bin/tuwunel
+EOF
+
+EXPOSE 8008 8448
+
+ENTRYPOINT ["tuwunel"]

--- a/docker/bake.sh
+++ b/docker/bake.sh
@@ -60,7 +60,7 @@ sys_targets="${env_sys_targets:-$default_sys_targets}"
 sys_versions="${env_sys_versions:-$default_sys_versions}"
 
 docker_dir="$PWD/$BASEDIR"
-builder_name="${GITHUB_ACTOR:-owo}"
+builder_name="${builder_name:-${BUILDX_BUILDER:-}}"
 
 # Translates 'nightly' in `rust_toolchains` to some other value. Needed for
 # github actions to pass some specific nightly. Local users can add the specific
@@ -99,7 +99,9 @@ fi
 
 args=""
 args="$args --provenance=false"
-args="$args --builder ${builder_name}"
+if test -n "$builder_name"; then
+    args="$args --builder ${builder_name}"
+fi
 #args="$args --set *.platform=${sys_platform}"
 
 if test "$CI" = "true"; then

--- a/docs/rebase-upstream-main-2026-07-05.md
+++ b/docs/rebase-upstream-main-2026-07-05.md
@@ -1,0 +1,169 @@
+# Rebase onto upstream `main` (post-`v1.8.0`) - 2026-07-05
+
+## Goal
+
+Rebase the MindRoom fork off `v1.8.0` and onto the unreleased upstream `main`
+tip so the fork can **drop its own `m.replace` edit-bundling delta** and adopt
+upstream's native implementation (MSC3925, config `bundle_edit_relations`),
+which landed upstream after `v1.8.0`. Keep the fork edit-purge; verify the purge
+composes with upstream's new `relatesto_typed` typed index. Reshape the fork
+history into a small set of logical commits (history rewrite is explicitly
+allowed for this fork).
+
+## Baseline
+
+- Fork tip of record: `origin/main` = `f233bfd9`
+  (`mindroom/edits: serve bundled m.replace aggregations on originals (#6)`),
+  tagged `v1.8.0-mindroom.2`. `origin/main` = `v1.8.0` + 22 fork commits.
+- Fork base before this rebase: upstream `v1.8.0` = `c17c1d9c` (2026-06-27, the
+  latest *tagged* upstream release).
+- Upstream target: `upstream/main` tip `59f13052`
+  (`oauth: Borrow the claims in the Apple id_token test helper.`), **unreleased**
+  — the latest tagged release is still `v1.8.0`. Chosen deliberately (user
+  decision) because the edit-bundling feature that supersedes the fork delta is
+  only on `main`, not in any release yet.
+- Upstream delta: `v1.8.0..upstream/main` = 35 commits.
+
+Notable upstream commits in that delta:
+- `c01d1dbf` pdu_metadata: Bundle the latest m.replace edit as a full event (MSC3925).
+- `b8d384dd` rooms/pdu_metadata: Add a typed relation index for the edit bundle (`relatesto_typed`).
+- `ed91e081` pdu_metadata: Bundle m.reference children as an event-id chunk (MSC3267).
+- `db430617` api/client/search: Bundle aggregations on search context events (MSC3666).
+- `a791d7ed` client: Forbid /messages on a room the user cannot see.
+- `127c5228` oauth: fall back to Apple id_token claims when userinfo fails — **this is the fork's own commit `d7c8c138`, merged upstream** (+ merge `58f806b0` + test tweak `59f13052`).
+- `1f14bbf7` Bump Rust 1.95.0 (post-rebase the toolchain is 1.95.0; the fork's 1.94 dev pin no longer builds the workspace — `rust-version` now requires 1.95).
+- `db1c68c6` oidc: Serve native account registration and login (#479) — profile/users restructure.
+- `fb5a4ea9` Profile refactor — moved `Propagation`/`propagation_default` to `crate::profile`; moved `userid_displayname` out of the `users` Data struct.
+
+## Dropped fork commits
+
+`git cherry -v upstream/main f233bfd9 v1.8.0` flagged exactly one fork commit as
+already upstream. Two commits were dropped in the rebase:
+
+- `d7c8c138` `oauth: fall back to Apple id_token claims when userinfo fails` —
+  patch-id match with upstream `127c5228`; dropped (already upstream).
+- `f233bfd9` `mindroom/edits: serve bundled m.replace aggregations on originals
+  (#6)` — the fork's own read-time `m.replace` bundling, **superseded by
+  upstream's `bundle_edit_relations`**; dropped. Its search-context fix is
+  covered by upstream `db430617`; its /messages path by upstream `a791d7ed` +
+  the uniform `bundle_aggregations`.
+
+## Safety refs
+
+- `backup/origin-main-before-rebase-upstreammain-20260705` = `f233bfd9`.
+- `backup/feature-bundled-edit-aggregations-20260705` = `bce9c710`.
+- `backup/upstream-main-target-20260705` = `59f13052`.
+
+Local `main` was reset to `origin/main` (`f233bfd9`) after `--update-refs`
+dragged it onto the rebased tip; the rebase lives on branch
+`mindroom/rebase-upstream-main-20260705`.
+
+## Test command
+
+Post-rebase the workspace requires Rust **1.95.0** (upstream bump). The 1.94 pin
+from prior sessions no longer builds it. A unified 1.95 toolchain was assembled
+from nixpkgs store paths (cargo 1.95.0 + rustc 1.95.0 + a `nix-store --realise`d
+clippy 1.95.0), plus the usual sanitized env (see prior rebase docs and the
+`tuwunel-rebase-test-command` memory): unset the Nix musl/static cross vars,
+`RUSTC_WRAPPER=`, `LIBCLANG_PATH`, liburing pkg-config/include/runtime paths,
+`RUST_TEST_THREADS=1`, `-u TUWUNEL_DATABASE_PATH`, separate `CARGO_TARGET_DIR`.
+
+## Conflict log
+
+Base (`53e41bd1` tests-db-path, `23c6b575` compact/purge) applied clean —
+notably the edit-purge onto upstream's new relation-index code merged with no
+conflict.
+
+- Stop 1 — `a18e17ca` (auth/uiaa strict-CSP SSO fallback), `src/api/router/auth/uiaa.rs`.
+  - Cause: upstream now defaults `UiaaInfo.params` to `to_raw_value(&json!({})).ok()`;
+    the fork commit's context predated that line.
+  - Resolution: keep upstream's `params` default. It is only the no-IdP fallback;
+    the fork's `bind_sso_identity_provider` still overrides `params` with the
+    `m.login.sso` binding when an IdP is bound (unconflicted logic).
+- Stop 2 — `19892e2a` (users/sso self-reactivation), `src/service/deactivate/mod.rs` + `src/service/users/mod.rs`.
+  - Cause: upstream's profile refactor moved `Propagation` to `crate::profile`
+    and removed `userid_displayname` from the `users` Data struct.
+  - Resolution: import `Propagation` from `crate::profile` and `DeactivationReason`
+    from the fork's `users::sso`; keep only the genuinely fork-new
+    `userid_deactivation_reason` map field/handle; drop the fork's re-add of
+    `userid_displayname` (now owned by the profile service; the map still exists
+    in `maps.rs`).
+- Stop 3 — `fb493b23` (native Apple login #2), `src/api/client/session/sso.rs`.
+  - Cause: import-line divergence (upstream's futures import set vs the fork's).
+  - Resolution: take the fork's superset (`StreamExt` + `http::StatusCode`),
+    which `native_apple_login_route` uses at this commit (`StatusCode::OK`).
+
+Remaining fork commits (native review #3, grant-cookie #4, regression tests, CI
+checks, risk-area tests, SSO/power pins) applied clean.
+
+## Adopting upstream edit bundling
+
+- Fork default flipped: `bundle_edit_relations` now defaults **true** in the
+  fork (`#[serde(default = "true_fn")]`, `src/core/config/mod.rs`) with a doc
+  note. Upstream ships it off (opt-in); the fork's purge deletes superseded
+  edits, so without the bundle a history endpoint would serve an original with
+  its stale pre-edit body. `bundle_reference_relations` is left at upstream's
+  default (off) — references are client plumbing MindRoom does not render.
+- Purge ↔ typed-index composition: verified. Upstream's bundler reads
+  `relatesto_typed` newest-first and tolerates dangling rows (`get_pdu_from_id
+  ().ok()` → skip → fall through). The purge deletes edit PDUs (from `pduid_pdu`
+  et al.) but not `relatesto_typed`/`tofrom_relation`, so it leaves dangling
+  rows for deleted edits — which the bundler skips. It keeps the newest edit,
+  which the bundler wants, so the surviving edit is still bundled. Upstream also
+  ships a startup migration (`rebuild_relatesto_typed`) + admin command that
+  rebuild the index from every stored PDU, so existing (pre-upgrade) edits get
+  indexed and bundle correctly. The purge does **not** need to maintain
+  `relatesto_typed`.
+- New test: `src/mindroom-tests/tests/edit_purge_bundle_compose.rs` drives a
+  real `edit_purge.purge_cycle()` then asserts the surviving edit is still
+  bundled, and that a dangling *newest* typed-index row is skipped so the
+  bundler falls through to the surviving edit. `edit_purge::purge_cycle` was made
+  `pub` so integration tests (and operators) can trigger a cycle.
+- Serialization difference to watch: upstream serializes the bundled child as
+  `AnySyncMessageLikeEvent` (omits `room_id`); the dropped fork code used
+  `AnyTimelineEvent` (included `room_id`). Both include `origin_server_ts` (the
+  field the fork noted MindRoom Cinny requires). Client rendering of edits from
+  the bundle should be re-verified against Cinny after deploy.
+
+## Result
+
+- Rebase completed: branch `mindroom/rebase-upstream-main-20260705` =
+  `upstream/main` + 20 fork commits (22 − 2 dropped), later reshaped into logical
+  commits (see below). No conflict markers; `git diff --check` clean.
+
+## Reshape
+
+History was rewritten (allowed for this fork) into 7 logical, self-contained
+commits on branch `mindroom/rebase-clean-20260705` (built by cherry-picking the
+20 replayed commits into feature groups, in a dependency-preserving order so the
+shared files — `sso.rs`, `config/mod.rs`, `tuwunel-example.toml` — kept their
+per-commit hunks). The reshaped tree is byte-identical to the validated
+pre-reshape stack except `FORK_CHANGES.md` (rewritten). Commits:
+
+1. `mindroom/edits: compact /sync, purge superseded edits, bundle the survivor`
+2. `config/rooms: default room power-level override`
+3. `auth/sso: strict-CSP UIAA fallback and self-reactivation`
+4. `auth/apple: native iOS Apple login exchange and SSO cookie hardening`
+5. `ci: fork release automation, container publishing, and GitHub checks`
+6. `tests: integration coverage pinning fork behaviors`
+7. `docs: fork runtime and release overview`
+
+Validation: all 7 commits build (`cargo check --workspace --all-targets`, Rust
+1.95); the tip passes the full test suite and `cargo clippy -D warnings`
+(1.95). Two resurfaced/1.95 lints were fixed in-place: `#[allow(too_many_lines)]`
+on `edit_purge::purge_cycle`, and `Duration::from_mins` in `native_apple.rs`.
+
+Backup refs: `backup/origin-main-before-rebase-upstreammain-20260705`
+(`f233bfd9`, pre-rebase origin/main), `backup/rebase-clean-tip-20260705`
+(reshaped tip), `backup/feature-bundled-edit-aggregations-20260705`,
+`backup/upstream-main-target-20260705`. Local `main` still points at
+`f233bfd9`; publishing is a manual force-push.
+
+## Follow-ups
+
+- Deploy note: `bundle_edit_relations` now defaults on in the fork, so the Nix
+  config need not set it; the startup `rebuild_relatesto_typed` migration runs
+  once on first boot of the rebased build.
+- Re-verify edit rendering in MindRoom Cinny against upstream's bundle shape
+  (no `room_id` in the bundled child).
+- Publish: force-push the branch / update `origin/main` when ready (left manual).

--- a/docs/rebase-upstream-main-2026-07-07.md
+++ b/docs/rebase-upstream-main-2026-07-07.md
@@ -1,0 +1,128 @@
+# Rebase onto upstream `main` - 2026-07-07
+
+## Goal
+
+Rebase the MindRoom fork onto the latest upstream `main` tip and **drop or
+reconcile the fork deltas that upstream has since merged**. Two fork PRs landed
+upstream after the 2026-07-05 rebase:
+
+- **#496** — the room-creation default power-level override
+  (upstream `c4837cfc` + `730fbcbc`, merged via `5166c531` from the fork branch
+  `mindroom/upstream-pr-power-level-defaults`).
+- **#497** — the grant-session cookie removal with a matching path attribute
+  (upstream `ec740593`, merged via `38911216` from the fork branch
+  `mindroom/upstream-pr-grant-cookie-removal-path`).
+
+So the power-level commit is dropped wholesale, and the Apple commit is updated
+to drop its grant-cookie hardening hunk (adopting upstream's exact-path
+implementation) while keeping the native Apple login. History rewrite is
+explicitly allowed for this fork; the story stays a small set of logical
+commits.
+
+## Baseline
+
+- Fork tip of record: `origin/main` = `c0146fcf`
+  (`docs: fork runtime and release overview`).
+- Fork base before this rebase: upstream `main` `59f13052`
+  (the 2026-07-05 rebase target).
+- Upstream target: `upstream/main` tip `2323a8ec`.
+- Upstream delta: `59f13052..2323a8ec` = 63 commits.
+
+Notable upstream commits in that delta:
+- `c4837cfc` client/room: Apply a configurable default power-level override —
+  **this is the fork's own PR #496**; supersedes fork commit `09cf1668`.
+- `730fbcbc` client/room: Inline the power-level override merge helper.
+- `ec740593` oauth: Remove the grant-session cookie with a matching path
+  attribute — **this is the fork's own PR #497**; supersedes the fork's
+  grant-cookie hardening.
+- `824fcded` oidc: Promote the login-token and SSO-redirect helpers to the
+  module root (SSO callback restructure).
+- `34ac2a7f` service/users: Add the MSC4025 erasure marker with admin surfacing
+  — adds `userid_erased` to the `users` Data struct (source of the sole
+  `service/users/mod.rs` conflict).
+- MSC3856 threaded-read and MSC3440 threading series.
+- Rust toolchain stays `1.95.0` (`rust-version = "1.95.0"`).
+
+## Dropped / reconciled fork commits
+
+The fork carried 7 commits (`59f13052..c0146fcf`). Result: 6 commits.
+
+- **DROPPED** `09cf1668` `config/rooms: default room power-level override` —
+  merged upstream as #496 (`c4837cfc`). Dropping it cleanly leaves the edit
+  commit's purge validations in `src/core/config/check.rs` (the power-level
+  commit had moved them into `check/mindroom.rs`; that move is gone with it).
+- **UPDATED** `3d7a9e43` → `0af10c1a` `auth/apple: native iOS Apple login
+  exchange` — the grant-cookie path hardening was merged upstream as #497
+  (`ec740593`), so the fork's broaden variant (`GRANT_SESSION_COOKIE_PATH`
+  const + the `/_matrix/client/`-widening function + its two unit tests) is
+  dropped and upstream's exact-path `grant_session_cookie_path` is kept as-is.
+  The native Apple login endpoint, JWKS validation, `native_client_ids`, and the
+  `complete_sso_session` extraction are all kept. Commit subject/body updated to
+  drop the "SSO cookie hardening" claim.
+- **UPDATED** `e6516960` → `2ef63bf1` `tests: integration coverage pinning fork
+  behaviors` — dropped `src/mindroom-tests/tests/power_level_override.rs`
+  (146 lines): power-level is no longer a fork behavior, so it no longer belongs
+  in the fork's behavior-pinning suite. Commit message's power-level mention
+  removed.
+- KEPT (replayed) `c4e57cc7` → `5ad18572` edits, `9545283c` → `64f89adb` sso,
+  `b8eed4f2` → `5758e864` ci, `c0146fcf` → docs (FORK_CHANGES/README updated).
+
+## Conflicts resolved
+
+- `src/service/users/mod.rs` — additive: upstream added `userid_erased`
+  (MSC4025) at the same spot the fork adds `userid_deactivation_reason`.
+  Resolved as a union (both maps, in struct + `build`).
+- `src/api/client/session/sso.rs` — the grant-cookie reconciliation. The
+  auto-merge was a garbled function-boundary interleave, so the file was reset
+  to upstream's clean version (`:2`, which already carries #497's exact
+  `grant_session_cookie_path` and, from #495, the local
+  `decode_apple_userinfo_from_id_token`) and the native-Apple deltas were
+  re-applied surgically:
+  - add `mod native_apple;` and `native_apple_login_route` re-export;
+  - move the id_token decode into `native_apple::decode_userinfo_from_id_token`
+    (remove the local copy + its `serde_json::Value` import + its four unit
+    tests, all now living in `native_apple.rs`);
+  - extract `complete_sso_session` from the callback so the native endpoint can
+    reuse it — **rebuilt from upstream's *current* callback**, preserving the
+    new upstream `origin`/`ldap_user_exists` registration logic that postdates
+    the fork's original extraction.
+  Upstream's exact grant-cookie handling and its `grant_session_cookie_path`
+  tests are kept unchanged.
+
+## Safety refs
+
+- `backup/origin-main-before-rebase-20260707` = `c0146fcf` (published fork tip).
+- `backup/upstream-main-target-20260707` = `2323a8ec`.
+- `backup/rebased-upstream-main-20260707` = the first rebased tip before the
+  test-removal / message-reword cleanups.
+
+Local `main` was reset back to `origin/main` (`c0146fcf`) after `--update-refs`
+dragged it onto the rebased tip; the rebase lives on branch
+`mindroom/rebase-upstream-main-20260707` and is fast-forwarded onto `main` only
+after validation.
+
+## Validation
+
+- Toolchain: sanitized Rust `1.95.0` wrapper (nix-store cargo/rustc/clippy 1.95,
+  nightly rustfmt), `RUSTC_WRAPPER=` unset, separate
+  `CARGO_TARGET_DIR=target-ci195`. (liburing re-pinned 2.12→2.14 and clang
+  21.1.2→21.1.8 after a nix GC.)
+- `cargo check --workspace --all-targets` — clean.
+- `cargo clippy --workspace --all-targets` and `cargo test` — see session log.
+
+## Post-rebase amendments (same session)
+
+Intermediate commit shas above drifted with these rewrites; the commit
+*subjects* are the stable identifiers.
+
+- Added `src/mindroom-tests/tests/sso_callback_completion.rs`, pinning the
+  `complete_sso_session` branches the new-user happy path does not reach
+  (identity reuse + previous-session deletion, admin-deactivated rejection,
+  self-deactivated reactivation); folded into the tests commit.
+- Reworded the sso commit to `auth/sso: SSO-origin UIAA hardening and
+  self-reactivation`: upstream ships the strict-CSP SSO UIAA fallback itself
+  (MSC2454 — `11309062`, `a87b8bad`, `3127eca6`, `78e6af7b`, `bdad6af8`), so
+  the fork commit now claims only its real deltas — UIAA flow-advertising
+  hardening for SSO-origin users plus self-reactivation with a persisted
+  deactivation reason. FORK_CHANGES and README were updated to match (tree
+  unchanged; message/docs only).

--- a/docs/rebase-v1.6.1-2026-05-04.md
+++ b/docs/rebase-v1.6.1-2026-05-04.md
@@ -1,0 +1,220 @@
+# Rebase on upstream v1.6.1 - 2026-05-04
+
+## Goal
+
+Rebase the MindRoom fork onto upstream `v1.6.1` with explicit overlap review, conflict-by-conflict notes, and full test runs after each conflict resolution before continuing the rebase.
+
+## Baseline
+
+- Local branch at start: `main` = `3cf5462fe760683d7d0d2ce82c2ed0ea69b534fa`
+- Fetched fork tip: `origin/main` = `f562d1c38423e01ef8dd2b3ef63c3c67720c13a1`
+- Upstream target: `v1.6.1` = `dda5123436d55c58aacd8ba6ebd0d2bae0c87260`
+- Merge base of `origin/main` and `v1.6.1`: `44a85e25956f3e5664279d5f1fd41a70a3f2a00f`
+- Initial state: local `main` was clean and one commit behind `origin/main`.
+
+## Safety Refs
+
+- `backup/main-before-rebase-v1.6.1-20260504` preserves the local branch start.
+- `backup/origin-main-before-rebase-v1.6.1-20260504` preserves the fetched fork tip.
+
+## Test Command
+
+Current full local test command for conflict gates:
+
+```bash
+env -u TUWUNEL_DATABASE_PATH \
+  -u LD_PRELOAD \
+  -u NIX_CFLAGS_LINK -u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS -u NIX_CC -u NIX_BINTOOLS \
+  -u CC -u CXX -u LD -u AR -u AS -u RANLIB \
+  -u CARGO_BUILD_TARGET -u CARGO_BUILD_RUSTFLAGS -u CARGO_PROFILE \
+  -u JEMALLOC_OVERRIDE -u ROCKSDB_LIB_DIR -u cmakeFlags \
+  PKG_CONFIG_PATH=/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/lib/pkgconfig \
+  CFLAGS=-I/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/include \
+  CXXFLAGS=-I/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/include \
+  LD_LIBRARY_PATH=/nix/store/hczbpz0rrrn86nvphr2zv9fx4qm8isb2-liburing-2.12/lib:$LD_LIBRARY_PATH \
+  RUST_TEST_THREADS=1 \
+  cargo test --workspace --all-targets
+```
+
+Reason: the inherited shell has Nix cross/static-link variables (`CC=x86_64-unknown-linux-musl-gcc`, `LD=x86_64-unknown-linux-musl-ld`, `NIX_CFLAGS_LINK=-static`, `CARGO_BUILD_TARGET=x86_64-unknown-linux-musl`, `JEMALLOC_OVERRIDE=<musl static jemalloc>`, etc.) that make even a simple Rust binary segfault at startup or force/link against musl-specific artifacts. The sanitized environment produced a runnable simple Rust binary. `rust-librocksdb-sys` also needs explicit `liburing` pkg-config/include/runtime paths in this shell. `RUST_TEST_THREADS=1` avoids parallel RocksDB lock contention, and `TUWUNEL_DATABASE_PATH` must be unset because Figment environment overrides beat test-local TOML database paths.
+
+## Running Notes
+
+- Need to inspect the full fork diff from merge base to `origin/main`.
+- Need to inspect the full upstream diff from merge base to `v1.6.1`.
+- Need to identify same-file and same-feature overlaps before starting the rebase.
+- Need to include the missing `origin/main` merge commit in the fork tip before rebasing local `main`.
+
+## Overlap Review
+
+Completed first pass before starting the rebase.
+
+Commands used:
+
+```bash
+git diff --stat --find-renames 44a85e25956f3e5664279d5f1fd41a70a3f2a00f..origin/main
+git diff --stat --find-renames 44a85e25956f3e5664279d5f1fd41a70a3f2a00f..v1.6.1
+git diff --name-only 44a85e25956f3e5664279d5f1fd41a70a3f2a00f..origin/main
+git diff --name-only 44a85e25956f3e5664279d5f1fd41a70a3f2a00f..v1.6.1
+git cherry -v v1.6.1 origin/main
+```
+
+Patch-id check:
+
+- `git cherry -v v1.6.1 origin/main` shows all fork commits as `+`; no fork commit appears to have been directly included upstream.
+
+Fork diff summary:
+
+- 32 files changed, 4128 insertions, 53 deletions.
+- Main runtime areas: edit compaction and purge, Apple SSO userinfo fallback, strict-CSP SSO UIAA fallback, SSO self-reactivation, default room power-level override.
+- Main operational areas: fork release automation, binary/container release workflows, fork documentation.
+
+Upstream diff summary:
+
+- 239 files changed, 10881 insertions, 4017 deletions.
+- Main runtime areas: OIDC/account-management and UIAA improvements, configurable client IP extraction, storage/S3 multipart behavior, spaces cache/timeline refactors, migration controls, device key/sync fixes, docs and packaging updates.
+
+Same-file overlap:
+
+- `README.md`
+- `docker/bake.sh`
+- `src/admin/user/commands.rs`
+- `src/api/client/account.rs`
+- `src/api/client/session/sso.rs`
+- `src/api/router/auth/uiaa.rs`
+- `src/core/config/check.rs`
+- `src/core/config/mod.rs`
+- `src/core/matrix/event.rs`
+- `src/database/maps.rs`
+- `src/service/media/mod.rs`
+- `src/service/mod.rs`
+- `src/service/users/mod.rs`
+- `tuwunel-example.toml`
+
+Functional overlap and expected resolution:
+
+- SSO/UIAA is the highest-risk overlap. Upstream binds an exact IdP into UIAA session params and routes the fallback page through that IdP; the fork restricts SSO-origin users away from password/JWT UIAA paths and repairs legacy SSO-origin metadata. Resolution should preserve upstream IdP binding and fallback routing while retaining the fork's SSO-origin policy and repair behavior.
+- `src/api/client/session/sso.rs` must preserve upstream `ClientIp` extractor and redirect diagnostics, plus fork Apple `id_token` fallback and SSO self-reactivation.
+- `src/service/users/mod.rs` must preserve upstream `peek_login_token` and OIDC device IdP helpers, plus fork deactivation reason tracking and SSO self-reactivation.
+- Timeline/storage has a semantic overlap even where file conflicts may not occur: upstream added `roomid_ts_pducount` as a timestamp index for PDUs, while the fork's edit purge deletes old PDUs directly. Resolution must delete the corresponding timestamp-index row when purging a superseded edit, otherwise timestamp lookups can reference removed PDUs.
+- `src/service/media/mod.rs` should keep upstream storage provider upload changes and fork `mxc_is_owned_by_user` / `delete_owned_by` helpers used by edit purge sidecar cleanup.
+- `docker/bake.sh` should keep upstream repository-root resolution and OCI package metadata, plus fork optional `BUILDX_BUILDER` handling.
+- Config/examples need additive merge: upstream `ip_source`, size parsing, S3, migration, spaces cache, etc.; fork `default_power_level_content_override` and `mindroom_*` options.
+- Default room power-level override appears fork-only. Upstream still only applies request-level `power_level_content_override`.
+- Edit compaction/purge appears fork-only. Upstream mentions "replacement" in unrelated room upgrade/key replacement contexts, not superseded `m.replace` compaction.
+
+## Conflict Log
+
+- Stop 1: commit `b2e5f5ad` (`mindroom/edits: compact /sync and purge superseded edits`)
+  - Conflict: `src/core/config/mod.rs`.
+  - Cause: upstream added S3 multipart/redacted-format helper defaults at the end of the config helper section; fork added MindRoom edit-purge default helper functions at the same location.
+  - Resolution: kept both upstream helper functions (`default_multipart_threshold`, `default_multipart_part_size`, `fmt_redacted_opt`) and fork helper functions (`default_mindroom_edit_purge_*`).
+  - Semantic overlap handled: upstream `v1.6.1` adds `roomid_ts_pducount` for timestamp timeline lookups. The fork edit purge now removes `roomid_ts_pducount` when the index still points to the purged PDU, and the edit-purge tests assert timestamp-index cleanup.
+  - Test gate attempt 1: failed to compile `tuwunel_service`; `OwnedRoomId::as_ref()` was ambiguous for timestamp-index key serialization.
+  - Follow-up: made the timestamp-index key type explicit as `&RoomId`, matching upstream timeline writes.
+  - Test gate attempt 2: compiled, then nine edit-purge tests failed because the test harness used fake 9-byte PDU keys and the timestamp-index adaptation parses real `RawPduId` keys.
+  - Follow-up: changed the edit-purge test helper to generate real `RawPduId` bytes from `PduId`.
+  - Test gate attempt 3: passed.
+  - Summary: workspace/all-targets passed, including 157 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+- Stop 2: commit `5a573fa3` (`auth/uiaa: add strict-CSP-safe SSO fallback flow`)
+  - Conflict: `src/api/router/auth/uiaa.rs`.
+  - Cause: upstream `v1.6.1` binds an exact IdP into `UiaaInfo.params` for SSO fallback routing and can expose JWT UIAA when configured; the fork hides password/JWT UIAA for SSO-origin users and repairs legacy SSO origins before choosing flows.
+  - Resolution: kept legacy SSO-origin repair, kept fork `sender_uses_sso` policy for password/JWT, kept upstream exact IdP binding, and only advertises `m.login.sso` when a concrete IdP can be bound to the UIAA session.
+  - Test gate: passed.
+  - Summary: workspace/all-targets passed, including 157 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+- Stop 3: commit `f562d1c3` (`Merge pull request #1 from mindroom-ai/mindroom-sidecar-purge-cleanup`)
+  - Conflict: `src/service/edit_purge/mod.rs`.
+  - Cause: the sidecar cleanup commit added per-candidate sender/MXC metadata and sidecar media deletion; the earlier v1.6.1 resolution had added per-candidate room/timestamp metadata to remove upstream's `roomid_ts_pducount` index.
+  - Resolution: merged both candidate metadata sets, kept sidecar cleanup logic, kept timestamp-index deletion, and updated sidecar-content test fixtures to populate `roomid_ts_pducount`.
+  - Test gate attempt 1: failed by hang.
+  - Failure details: full workspace/all-targets built successfully and entered tests, but `src/main/tests/smoke.rs` stayed asleep for several minutes as `target/debug/deps/smoke-*`; the run was interrupted and the orphaned smoke process was killed before continuing investigation.
+  - Follow-up: isolated `cargo test -p tuwunel --test smoke` with the same sanitized environment passed in 1.35s. Rerunning the full gate with output redirected to a file to avoid blocking on the large captured log stream.
+  - Test gate attempt 2: passed.
+  - Summary: workspace/all-targets passed with output redirected to `/tmp/rebase-stop3-test.log`, including 168 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+
+## Test Log
+
+- Baseline fork-tip test, unsanitized:
+  - Command: `cargo test --workspace --all-targets`
+  - Result: failed before project compilation.
+  - Error: multiple dependency build scripts exited with `signal: 11, SIGSEGV`, including `typenum`, `generic-array`, `serde`, `libc`, `quote`, `proc-macro2`, and `portable-atomic`.
+- Reproduction:
+  - Command: `cargo test -j1 --workspace --all-targets`
+  - Result: same `proc-macro2` build-script `SIGSEGV`.
+  - A minimal Rust hello-world binary compiled under the inherited environment also segfaulted.
+- Environment isolation:
+  - A minimal Rust hello-world binary compiled with `LD_PRELOAD`, `NIX_CFLAGS_LINK`, `NIX_CFLAGS_COMPILE`, `NIX_LDFLAGS`, `NIX_CC`, `NIX_BINTOOLS`, `CC`, and `LD` unset ran successfully.
+- First sanitized Cargo run:
+  - Command: `env -u LD_PRELOAD -u NIX_CFLAGS_LINK -u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS -u NIX_CC -u NIX_BINTOOLS -u CC -u LD cargo test --workspace --all-targets`
+  - Result: got past dependency build-script segfaults, then failed in `ring` because `CARGO_BUILD_TARGET=x86_64-unknown-linux-musl` was still inherited and `x86_64-linux-musl-gcc` was not found.
+- Second sanitized Cargo run:
+  - Command also removed `CARGO_BUILD_TARGET`, `CARGO_BUILD_RUSTFLAGS`, and `CARGO_PROFILE`.
+  - Result: got to `tuwunel_core` link, then failed because inherited `JEMALLOC_OVERRIDE` pointed at a musl static jemalloc and produced undefined `sdallocx`, `nallocx`, `mallocx`, `sallocx`, and `rallocx` symbols.
+- Third sanitized Cargo run:
+  - Command also removed `JEMALLOC_OVERRIDE`, `ROCKSDB_LIB_DIR`, musl compiler variables, and added the local `liburing` pkg-config/include path.
+  - Result: built and ran tests, then failed at runtime because `liburing.so.2` was not on the dynamic loader path.
+- Fourth sanitized Cargo run:
+  - Command added the local `liburing` runtime directory to `LD_LIBRARY_PATH`.
+  - Result: built and ran tests, then failed with multiple RocksDB lock collisions under parallel test execution.
+- Serial sanitized Cargo run:
+  - Command added `RUST_TEST_THREADS=1`.
+  - Result: reduced failures to `users::tests::self_deactivated_sso_account_reactivates`.
+  - Root cause: `TUWUNEL_DATABASE_PATH` from the test/build environment overrides the users tests' generated TOML path via Figment environment providers, so both SSO service tests opened the same default `/var/tmp/tuwunel.db` database and the first `Services` instance kept its RocksDB lock in-process.
+  - Confirmation: `cargo test -p tuwunel_service users::tests:: -- --nocapture` failed without `-u TUWUNEL_DATABASE_PATH`; the same command passed with `-u TUWUNEL_DATABASE_PATH`.
+- Baseline fork-tip test with current command:
+  - Command: the full command in [Test Command](#test-command).
+  - Result: passed.
+  - Summary: workspace/all-targets passed, including 161 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+
+## Rebase Result
+
+- Rebase completed successfully: `main` now points at `b8ece3bd` on top of upstream `v1.6.1`.
+- Backup refs restored after `--update-refs` moved them during rebase:
+  - `backup/main-before-rebase-v1.6.1-20260504` -> `3cf5462f`.
+  - `backup/origin-main-before-rebase-v1.6.1-20260504` -> `f562d1c3`.
+- Final verification passed from the completed branch tip with the full command in [Test Command](#test-command), redirected to `/tmp/rebase-final-test.log`.
+- Final summary: workspace/all-targets passed, including 168 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+- Final cleanliness checks passed: no conflict markers outside this note, and `git diff --check` is clean.
+- Remaining working tree item: this rebase note is present as an untracked file at `docs/rebase-v1.6.1-2026-05-04.md`.
+
+## Autosquash Pass
+
+- Stop A1: folding `e6254e43` (`fixup! mindroom/edits: compact /sync and purge superseded edits`) into `890538e6`.
+  - Conflict: `src/service/edit_purge/mod.rs`.
+  - Cause: the timestamp-index fixup was created after the later sidecar-media commit existed, so its patch context tried to carry sidecar test helper functions backward into the earlier edit-purge commit.
+  - Resolution: kept only the timestamp-index assertion helper and same-timestamp regression test in the earlier edit-purge commit; left media helper functions for the later sidecar cleanup commit.
+  - Format gate before continue: `cargo fmt --check` failed in `src/main/args.rs`, which belongs to already-replayed commit `a7a9570` rather than this edit-purge conflict. Defer the formatting fix to the per-commit validation pass so it can be amended into the introducing commit.
+  - Test gate before continue: passed with the full command in [Test Command](#test-command), redirected to `/tmp/autosquash-conflict-A1-test.log`.
+- Stop A2: applying `d33186d4` (`mindroom/edits: clean up superseded sidecar media`) after autosquashing the earlier edit-purge timestamp test.
+  - Conflict: `src/service/edit_purge/mod.rs`.
+  - Cause: sidecar cleanup added media test helpers at the same helper-boundary where the earlier autosquashed timestamp test added `assert_event_payload_indexes_absent`.
+  - Resolution: kept both helper sets: timestamp payload-index absence assertions and sidecar media ownership/presence helpers.
+  - Format gate before continue: `cargo fmt --check` failed in already-replayed commits: `src/main/args.rs` from `a7a9570` and `src/core/config/mod.rs` from the default power-level override line. Defer both to the per-commit validation pass.
+  - Test gate before continue: passed with the full command in [Test Command](#test-command), redirected to `/tmp/autosquash-conflict-A2-test.log`.
+
+## Per-Commit Validation Pass
+
+- Stop V1: commit `a7a9570` (`tests: isolate default_test database path`).
+  - Gate failure: `cargo fmt --check` failed in `src/main/args.rs`.
+  - Resolution: applied rustfmt's line wrapping to the new `database_path` option construction and amended the commit.
+- Stop V2: commit `a83c88f1` (`auth/uiaa: add strict-CSP-safe SSO fallback flow`).
+  - Gate failure: `cargo fmt --check` failed in `src/service/users/mod.rs`.
+  - Resolution: applied rustfmt's multiline wrapping to `maybe_repair_legacy_sso_origin` and amended the commit.
+- Stop V3: commit `21bf4daa` (`Add default room power level override`).
+  - Gate failure: `cargo fmt --check` failed in `src/core/config/mod.rs`.
+  - Follow-up: after amending the rustfmt change, the rescheduled exec passed but regenerated `tuwunel-example.toml` with the same wrapped comment, leaving the worktree dirty and preventing the rebase from advancing.
+  - Resolution: amended both the source doc-comment wrap and the matching generated example-config wrap into the commit.
+
+## Autosquash + Per-Commit Validation Result
+
+- Autosquash completed with no remaining `fixup!` commits in `v1.6.1..HEAD`.
+- Per-commit validation completed successfully across the rewritten fork commits using `git rebase --reschedule-failed-exec --exec` with:
+  - `cargo fmt --check`.
+  - The full command in [Test Command](#test-command), redirected per commit to `/tmp/rebase-exec-<shortsha>.log`.
+- Rewritten `main` tip: `bbb48ce3` (`mindroom/edits: clean up superseded sidecar media`).
+- Final tip verification:
+  - `cargo fmt --check`: passed.
+  - `git log --oneline --grep='fixup!' v1.6.1..HEAD`: empty.
+  - Full workspace/all-targets test command: passed, redirected to `/tmp/rebase-final-after-autosquash-test.log`.
+  - Final test summary included 171 passed / 2 ignored in `tuwunel_service` and 6 passed in `tuwunel_service` state-res integration tests.
+- Remaining working tree item: this rebase note is still untracked at `docs/rebase-v1.6.1-2026-05-04.md`.

--- a/docs/rebase-v1.7.1-2026-06-12.md
+++ b/docs/rebase-v1.7.1-2026-06-12.md
@@ -1,0 +1,226 @@
+# Rebase on upstream v1.7.1 - 2026-06-12
+
+## Goal
+
+Rebase the MindRoom fork onto upstream `v1.7.1` with explicit overlap review, conflict-by-conflict notes, and full test runs after each conflict resolution before continuing the rebase.
+
+## Baseline
+
+- Fork tip of record: `origin/main` = `d64264da` (`ci: add GitHub-hosted MindRoom checks (#5)`).
+- Fork base before this rebase: `v1.7.0` (commit `01f56a9d`, `Bump 1.7.0.`); `origin/main` = `v1.7.0` + 19 fork commits, linear history.
+- Upstream target: `v1.7.1` = `ba56af22` (tagged 2026-06-05, latest published GitHub release as of 2026-06-12).
+- Upstream delta: `v1.7.0..v1.7.1` = 147 commits.
+- Local `main` at session start was `bbb48ce3`, a stale leftover of the v1.6.1 rebase session (2026-05-04) that was superseded by later force-pushes to `origin/main`; it was reset to `origin/main` after backing it up.
+- `git cherry` patch-id check: pending (see Overlap Review).
+
+## Safety Refs
+
+- `backup/main-stale-v1.6.1-rebase-20260612` = `bbb48ce3` preserves the stale local branch found at session start.
+- `backup/origin-main-before-rebase-v1.7.1-20260612` = `d64264da` preserves the fork tip this rebase starts from.
+
+## Test Command
+
+Current full local test command for conflict gates:
+
+```bash
+env -u TUWUNEL_DATABASE_PATH \
+  -u LD_PRELOAD \
+  -u NIX_CFLAGS_LINK -u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS -u NIX_CC -u NIX_BINTOOLS \
+  -u CC -u CXX -u LD -u AR -u AS -u RANLIB \
+  -u CARGO_BUILD_TARGET -u CARGO_BUILD_RUSTFLAGS -u CARGO_PROFILE \
+  -u JEMALLOC_OVERRIDE -u ROCKSDB_LIB_DIR -u cmakeFlags \
+  RUSTC_WRAPPER= \
+  PKG_CONFIG_PATH=/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/lib/pkgconfig \
+  CFLAGS=-I/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/include \
+  CXXFLAGS=-I/nix/store/kic9mkwsq7xgrlxzzarrd7k0k83qnhik-liburing-2.12-dev/include \
+  LD_LIBRARY_PATH=/nix/store/hczbpz0rrrn86nvphr2zv9fx4qm8isb2-liburing-2.12/lib:$LD_LIBRARY_PATH \
+  RUST_TEST_THREADS=1 \
+  cargo test --workspace --all-targets
+```
+
+This is the v1.6.1-session command (same rationale: the inherited shell exports Nix musl/static cross-compile variables that segfault build scripts; `rust-librocksdb-sys` needs explicit liburing paths; `RUST_TEST_THREADS=1` avoids RocksDB lock contention; `TUWUNEL_DATABASE_PATH` must be unset because Figment env overrides beat test-local TOML database paths) with one new addition:
+
+- `RUSTC_WRAPPER=` (empty) — new this session. The repo's `.cargo/config.toml` sets `build.rustc-wrapper = "rustc-wrapper"`, which resolves to sccache. sccache 0.12.0 in the current dev shell crashes with `GLIBC_ABI_DT_X86_64_PLT not found` (it was built against glibc 2.42 while `LD_LIBRARY_PATH` carries the nix-ld glibc 2.40 directory), failing every crate compile. An empty `RUSTC_WRAPPER` env var overrides the config and disables the wrapper.
+
+The liburing Nix store paths from the v1.6.1 notes still exist and were reused verbatim.
+
+## Running Notes
+
+- 2026-06-12: session start. Confirmed `v1.7.1` is the latest upstream release (`gh release list`). Confirmed linear fork history on top of `v1.7.0`. Created safety refs. Reset local `main` to `origin/main`.
+
+## Overlap Review
+
+Completed before starting the rebase.
+
+Commands used:
+
+```bash
+git diff --stat --find-renames 01f56a9d..origin/main      # fork side
+git diff --stat --find-renames 01f56a9d..v1.7.1           # upstream side
+git diff --name-only 01f56a9d..origin/main | sort > /tmp/fork-files.txt
+git diff --name-only 01f56a9d..v1.7.1 | sort > /tmp/upstream-files.txt
+comm -12 /tmp/fork-files.txt /tmp/upstream-files.txt
+git cherry -v v1.7.1 origin/main
+```
+
+Patch-id check:
+
+- `git cherry -v v1.7.1 origin/main` shows all 19 fork commits as `+`; no fork commit was directly included upstream.
+
+Fork diff summary (`v1.7.0..origin/main`):
+
+- 47 files changed, 5797 insertions, 149 deletions.
+- Runtime areas: edit compaction/purge, default room power-level override, SSO self-reactivation with deactivation-reason tracking, Apple `id_token` userinfo fallback, native Apple login exchange (`/_matrix/client/unstable/org.mindroom.login/apple`), SSO grant-cookie path hardening, strict-CSP SSO UIAA fallback.
+- Test areas: `src/mindroom-tests` rebase regression crate, isolated `default_test` database paths.
+- Operational areas: fork release/CI workflows (`mindroom-*.yml`, disabled upstream push/PR triggers in `main.yml`), fork docs.
+- Compared to the v1.6.1-era fork, much more code now lives in fork-only modules (`mindroom_power_levels.rs`, `native_apple.rs`, `mindroom_edits.rs`, `src/service/edit_purge/`, `src/service/users/sso.rs`, `src/core/config/check/mindroom.rs`, `src/mindroom-tests/`), which shrinks the conflict surface.
+
+Upstream diff summary (`v1.7.0..v1.7.1`, 147 commits):
+
+- 540 files changed, 23950 insertions, 12394 deletions.
+- Dominant theme: large file-splitting refactors — admin command files split into per-handler modules, `api/client` multi-endpoint files split, `sso_callback_route` split into helpers (`validate_session_cookie`, `apply_token_response`, `existing_identity_session`, `chain_next_idp_url`, `finalize_login_redirect`), `create_room_route` split into helpers (`apply_power_levels_pdu`, `build_power_levels_users`, ...).
+- Other areas: new `service/fetcher` (10 commits), OIDC token-endpoint hardening and refresh-token lifecycle (6), multiple access tokens per device, sync v5, MSC4380 invite suppression, membership/event_handler/federation changes, CI and Complement work.
+
+Same-file overlap (18 files):
+
+- `Cargo.lock` (regenerate, do not hand-merge)
+- `.github/workflows/main.yml`
+- `src/admin/user/commands.rs`
+- `src/api/client/account.rs`
+- `src/api/client/room/create.rs`
+- `src/api/client/session/mod.rs`
+- `src/api/client/session/sso.rs`
+- `src/api/router.rs`
+- `src/core/config/check.rs`
+- `src/core/config/mod.rs`
+- `src/core/matrix/event.rs`
+- `src/database/maps.rs`
+- `src/main/args.rs`
+- `src/service/media/mod.rs`
+- `src/service/mod.rs`
+- `src/service/services.rs`
+- `src/service/users/mod.rs`
+- `tuwunel-example.toml`
+
+Functional overlap and expected resolution:
+
+- `src/api/client/session/sso.rs` is the highest-risk overlap. Upstream split `sso_callback_route` into helpers covering the same region the fork refactored into its own `complete_sso_session` helper (identity-session dedup, registration, activation check). Resolution: adopt upstream's helper structure and weave fork behavior in — Apple userinfo `id_token` fallback around `request_userinfo`, `id_token` persisted on the session, `grant_session_cookie_path` hardening on both set and removal cookies, legacy SSO-origin repair, SSO self-reactivation, and the `native_apple` module hookup/re-export.
+- `src/admin/user/commands.rs`: upstream split every admin command file into per-handler modules (-933 lines). The fork's `DeactivationReason::Admin` arguments must be re-applied in whichever new per-handler module now holds `deactivate_user`/`deactivate_all`.
+- `src/api/client/account.rs`: upstream split multi-endpoint units (-162 lines); the fork's `DeactivationReason::SelfService` argument and doc tweak must follow `deactivate_route` to its new home.
+- `src/api/client/room/create.rs`: upstream split `create_room_route` into helpers; `default_power_levels_content` is now called from `apply_power_levels_pdu`. The fork's `mindroom_power_levels` submodule and the default-override merge parameter must be re-threaded through the new helper chain.
+- `src/service/users/mod.rs`: keep upstream OIDC refresh-token/multi-access-token changes plus fork `sso` submodule, `userid_deactivation_reason` map, `deactivate_account(reason)`, `set_origin`, and sentinel-password origin-preservation logic in `set_password`.
+- `src/main/args.rs`: keep upstream's new args plus the fork's per-test unique `database_path` in `default_test`.
+- Config/example: additive merge — upstream added ~474 lines of options; fork adds `default_power_level_content_override` and `mindroom_*` options plus the `check/mindroom.rs` hook in `check.rs`.
+- `src/database/maps.rs`: keep upstream's new maps plus fork `userid_deactivation_reason` descriptor.
+- `src/service/{mod,services}.rs`: additive — register fork `edit_purge` service alongside upstream's new services.
+- `src/service/media/mod.rs`: keep upstream changes plus fork `mxc_is_owned_by_user`/`delete_owned_by` helpers.
+- `src/core/matrix/event.rs`: one-line re-export union (fork adds `ExtractRelatesToInfo`, `RelatesToInfo`).
+- `.github/workflows/main.yml`: keep fork's removal of push/PR triggers (fork runs its own `mindroom-ci.yml`); take upstream's other changes.
+- `Cargo.lock`: take upstream's, then regenerate so fork-only deps (e.g. for `mindroom-tests`/native Apple JWT) are re-added by cargo.
+- Edit purge vs upstream timeline changes: upstream touched `service/rooms/timeline` (2 commits); verify the fork's purge still deletes every index it expects (including `roomid_ts_pducount` handling added during the v1.6.1 rebase) — the `mindroom-tests` regression crate plus edit-purge unit tests gate this.
+
+## Conflict Log
+
+- Stop 1: commit `87e98323` (`mindroom/edits: compact /sync and purge superseded edits`)
+  - Conflict: `src/service/services.rs` (import list only).
+  - Cause: upstream added the new `fetcher` service to the same `use crate::{...}` list where the fork adds `edit_purge`.
+  - Resolution: union of both imports. The `Services` struct field, `build()` entry, and `cast!` list for both `edit_purge` and `fetcher` had already auto-merged cleanly.
+  - Test gate: passed (433 passed / 0 failed, log `/tmp/rebase-stop1-test.log`).
+- Stop 2: commit `afa49ef3` (`oauth: fall back to Apple id_token claims when userinfo fails`)
+  - Conflict: `src/api/client/session/sso.rs`.
+  - Cause: upstream's `0d051f74` split `sso_callback_route` into helpers; the token-response-to-session block the fork had patched (to persist `id_token`) became upstream's `apply_token_response` helper. The fork's `.or_else` Apple-fallback around `request_userinfo` auto-merged cleanly against the new structure.
+  - Resolution: dropped the fork's now-superseded inline token-response block and instead added `id_token: token.id_token` to upstream's `apply_token_response`, preserving the fork behavior (the fallback decodes claims from `session.id_token`, so it must be persisted before `request_userinfo`). `src/service/oauth/sessions.rs` (`Session.id_token` field) auto-merged.
+  - Test gate: passed (437 passed / 0 failed, log `/tmp/rebase-stop2-test.log`).
+- Stop 3: commit `a06a5792` (`users/sso: reactivate self-deactivated accounts on login`)
+  - Conflicts: modify/delete on `src/admin/user/commands.rs` and `src/api/client/account.rs` (both deleted upstream by the per-handler module splits `1f7b15dc` and `d8d7d401`).
+  - Resolution: accepted upstream deletions (`git rm` both files) and re-applied the fork's edits at the handlers' new homes:
+    - `src/admin/user/mod.rs`: `deactivate_user` helper now passes `DeactivationReason::Admin` to `full_deactivate`/`deactivate_account`, plus the `DeactivationReason` import.
+    - `src/api/client/account/deactivate.rs`: `deactivate_route` passes `DeactivationReason::SelfService`, plus the SSO self-reactivation doc note.
+  - New upstream call site adapted: `src/api/oidc/account/account_deactivate.rs` (OIDC account-management page, new in v1.7.1) calls `deactivate_account`; gave it `DeactivationReason::SelfService` since it is a user-initiated deactivation, matching the fork's treatment of the Matrix self-deactivation endpoint.
+  - Auto-merged cleanly: `src/service/users/mod.rs` (deactivation-reason map + sentinel-password origin preservation alongside upstream's OIDC token work), `src/database/maps.rs`, `src/api/client/session/sso.rs`, fork-only `src/service/users/sso.rs`, `deactivate`/`emergency`/`membership` call-site updates.
+  - Test gate: passed (446 passed / 0 failed, log `/tmp/rebase-stop3-test.log`).
+- Stop 4: commit `e750cbca` (`Add default room power level override`)
+  - Conflicts: `src/api/client/room/create.rs`, `src/core/config/check.rs`.
+  - Cause (create.rs): upstream `20615234` replaced the inline power-levels block in `create_room_route` with an `apply_power_levels_pdu` helper; the fork had patched that inline block to pass the configured default override into `default_power_levels_content`.
+  - Resolution (create.rs): kept upstream's `apply_power_levels_pdu(...)` call in `create_room_route`; the fork's signature change and `merge_power_level_content_override` calls inside `default_power_levels_content` auto-merged, so the only manual change was passing `services.config.default_power_level_content_override.as_ref()` from `apply_power_levels_pdu`. The fork's `mindroom_power_levels` submodule landed untouched.
+  - Cause (check.rs): upstream added `fs::read_to_string` to the same `use std::{...}` line where the fork inserts `mod mindroom;`.
+  - Resolution (check.rs): kept both; the fork's `mindroom::check(config)?` call auto-merged.
+  - Test gate: passed (449 passed / 0 failed, log `/tmp/rebase-stop4-test.log`).
+- Stop 5: commit `31adcdb0` (`auth: add native Apple login exchange (#2)`)
+  - Conflict: `src/api/client/session/sso.rs` (two hunks).
+  - Cause: this fork commit extracted the post-userinfo logic of `sso_callback_route` into `complete_sso_session` (shared with the new native Apple route) and removed the `ensure_sso_account_active` helper from the earlier reactivation commit; upstream had restructured the same region into its own helpers.
+  - Resolution:
+    - Import hunk: union (`Json`/`IntoResponse` for the native route + upstream's `CookieJar`).
+    - Body hunk: took the fork's `complete_sso_session(...)` call, replacing the inline block (whose `ensure_sso_account_active` definition the commit had already auto-removed).
+    - Divergence reduction: inside the auto-merged `complete_sso_session`, replaced the fork's inlined `get_by_unique_id` match with upstream's semantically identical `existing_identity_session` helper, which would otherwise have become dead code.
+  - Test gate: passed (463 passed / 0 failed, log `/tmp/rebase-stop5-test.log`).
+- Commit `9948d441` (`auth/apple: address native login review (#3)`) applied cleanly, creating `src/api/client/session/sso/native_apple.rs`.
+- Stop 6: commit `e9c25c7c` (`Harden SSO grant cookie path (#4)`)
+  - Conflict: `src/api/client/session/sso.rs` (import lines only).
+  - Cause: commit #3 had moved the native Apple route (and its `Json`/`IntoResponse` imports) out to `native_apple.rs`, so this commit's import context disagreed with the post-Stop-5 merged imports; upstream's `CookieJar` (used by `validate_session_cookie`) sat on the same line.
+  - Resolution: fork-side imports plus `CookieJar`. Verified `Json`/`IntoResponse` are no longer referenced in `sso.rs` and that `grant_session_cookie_path` is applied to both the set and removal cookie sites.
+  - Test gate: passed (474 passed / 0 failed, log `/tmp/rebase-stop6-test.log`).
+- Remaining commits (`Add rebase regression tests`, `ci: add GitHub-hosted MindRoom checks (#5)`) applied cleanly; the rebase finished without further stops.
+
+## Test Log
+
+- Baseline fork-tip test (first attempt, v1.6.1-era command without `RUSTC_WRAPPER=`):
+  - Result: failed before project compilation; every dependency crate failed with sccache `GLIBC_ABI_DT_X86_64_PLT not found` errors via the repo's `.cargo/config.toml` `rustc-wrapper`.
+- Baseline fork-tip test at `origin/main` (= `d64264da`) with the current command (sccache disabled):
+  - Result: passed; log at `/tmp/rebase-v171-baseline-test.log`.
+  - Summary: workspace/all-targets, 395 passed / 0 failed / 4 ignored total, including 200 passed / 2 ignored in `tuwunel_service` and the two `mindroom_rebase_tests` integration tests.
+
+## Rebase Result
+
+- Rebase completed successfully: `main` = `141c295c` (`ci: add GitHub-hosted MindRoom checks (#5)`) = upstream `v1.7.1` + the 19 fork commits, linear, no fixups needed.
+- `--update-refs` (from git config) moved `backup/origin-main-before-rebase-v1.7.1-20260612` during the rebase, same as in the v1.6.1 session; it was restored to `d64264da` immediately afterwards.
+- `git rerere` recorded preimages/resolutions for the conflicted files during the rebase.
+- Not pushed: `origin/main` still points at `d64264da`; publishing the rebase requires a force-push, which was deliberately left as a separate step.
+
+### Post-Rebase Verification
+
+- Final tip test run: passed — 476 passed / 0 failed / 4 ignored across workspace/all-targets, log `/tmp/rebase-v171-final-test.log`. Includes the `mindroom_rebase_tests` integration tests and all edit-purge/SSO unit tests.
+- `cargo fmt --check`: clean at the final tip (no autosquash or per-commit fixups were required this time).
+- `git diff --check`: clean; no conflict markers anywhere in `src/`.
+- Fork-delta cross-check (interdiff style):
+  - Fork-only files: byte-identical between `origin/main` and rebased `main`.
+  - Changed-file set `v1.7.1..main` vs `v1.7.0..origin/main` differs only by the three intentional adaptations: `src/admin/user/commands.rs` → `src/admin/user/mod.rs`, `src/api/client/account.rs` → `src/api/client/account/deactivate.rs`, plus new coverage of `src/api/oidc/account/account_deactivate.rs`.
+  - Per-file fork deltas in all other overlap files are line-for-line identical (`src/service/services.rs` differs only by upstream `fetcher` context lines).
+  - `Cargo.lock` fork delta is exactly the `mindroom_rebase_tests` package entry.
+  - Spot-checked at the final tip: `id_token` persisted in `apply_token_response`, Apple `id_token` userinfo fallback, `grant_session_cookie_path` on both cookie sites, `maybe_repair_legacy_sso_origin`, `maybe_reactivate_deactivated_sso`, `native_apple_login_route` export and `org.mindroom.login/apple` route, `mindroom::check` config hook, `default_power_level_content_override` threading via `apply_power_levels_pdu`.
+- Remaining working tree items: this note and the previous session's note are untracked at `docs/rebase-v1.7.1-2026-06-12.md` and `docs/rebase-v1.6.1-2026-05-04.md`.
+
+## Per-Commit Validation Pass
+
+Run after the initial rebase, prompted by review: the conflict-stop gates had only covered 6 of the 19 commits plus the tip, and clippy had not been run at all.
+
+- Clippy at the rebased tip with the fork CI's exact flags (`cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`) found one violation: fork-only `edit_purge::purge_cycle` (179 lines) trips `clippy::too_many_lines` because upstream lowered `too-many-lines-threshold` in `clippy.toml` from 200 to 150 in `v1.7.1`. The function itself is unchanged from `origin/main`.
+  - Fix: `#[allow(clippy::too_many_lines)]` on `purge_cycle` (behavior-preserving; splitting the function is a possible follow-up), committed as `fixup!` into the introducing edit-purge commit.
+- Per-commit validation: `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash --reschedule-failed-exec --exec 'bash /tmp/percommit-gate.sh' v1.7.1`, where the gate runs `cargo fmt --check` plus the full sanitized workspace test command, logs per commit at `/tmp/rebase-exec-<shortsha>.log`.
+  - Result: all 19 gates passed on the first pass; no fmt or test fixups were needed at any commit.
+- Rewritten `main` tip: `4183a609` (`ci: add GitHub-hosted MindRoom checks (#5)`); diff vs the pre-validation tip is exactly the one `#[allow]` line; `git log --grep='fixup!' v1.7.1..main` is empty; backup refs unmoved.
+- Final tip CI-parity checks, all passed:
+  - `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` (log `/tmp/rebase-v171-clippy2.log`).
+  - `cargo test --locked --workspace --all-targets --all-features`: 476 passed / 0 failed / 4 ignored (log `/tmp/rebase-v171-allfeatures-test.log`).
+- Not run locally: the CI `cargo build --locked --release -p tuwunel` step (long LTO build); it is covered by the fork's GitHub-hosted CI and release workflows on push.
+
+## Post-Rebase Test Hardening
+
+Added after the per-commit validation pass, as commit `97ad1e54` (`tests: pin rebase-sensitive SSO and power-level behaviors`) on top of the rebased stack. Rationale: the riskiest rebase resolutions were semantic — code that compiles either way but only behaves correctly one way — and three of them had no test coverage:
+
+- `apply_token_response` id_token persistence (the Stop-2 resolution). New unit test in `src/api/client/session/sso.rs` (`apply_token_response_persists_id_token_for_userinfo_fallback`). Previously, dropping the `id_token: token.id_token` line compiled cleanly and broke Apple fallback only when Apple's userinfo endpoint failed in production.
+- Config-to-room-state threading of `default_power_level_content_override` (the Stop-4 resolution). New end-to-end test `src/mindroom-tests/tests/power_level_override.rs` creates real rooms through the router and asserts the override lands in `m.room.power_levels` state, request override still winning. The existing `mindroom_power_levels.rs` unit tests call `default_power_levels_content` directly and would not catch a future call site passing `None`.
+- The `appleoidc` userinfo fallback wiring in `sso_callback_route` (Stop 2/5 region). New end-to-end test `src/mindroom-tests/tests/apple_userinfo_fallback.rs` drives the full redirect → callback flow against a mock IdP (discovery + token endpoint serving an unsigned id_token, userinfo returning 500) and asserts login completes, the user registers with `sso` origin, and the session retains the id_token.
+- Harness change: generic `mock_server(Router)` helper in `tests/support/mod.rs`; `base64` added as a `mindroom-tests` dev-dependency.
+
+Already covered before this pass (no new tests needed): power-level merge semantics (`mindroom_power_levels.rs` unit tests), all three deactivation-reason reactivation policies (`src/service/users/sso.rs` service tests), edit-purge index cleanup (service tests), grant-cookie path and id_token claim decoding (sso.rs unit tests).
+
+Accepted residual risk (documented, not tested): the per-call-site `DeactivationReason` choices (admin → `Admin`, client + OIDC account page → `SelfService`) are one-line policy decisions; testing the OIDC page end-to-end requires the account-management login-token dance and was judged not worth the harness complexity. The service-level semantics of each reason are fully tested.
+
+Gates for this commit: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and the full workspace test suite — all passed; suite is now 479 passed / 0 failed / 4 ignored (log `/tmp/newtests-full.log`).
+
+## Follow-Ups
+
+- Force-push `main` to `origin` when ready (`git push --force-with-lease origin main`), then let the fork release automation tag `v1.7.1-mindroom.1`.
+- After pushing, update the Nix pin on `hetzner-matrix` (`tuwunelVersion` + hash) per the host runbook when a release exists.
+- The dev-shell sccache breakage (`GLIBC_ABI_DT_X86_64_PLT`) predates this rebase and still exists; builds need `RUSTC_WRAPPER=` until the shell is rebuilt with a consistent glibc.

--- a/docs/rebase-v1.8.1-2026-07-10.md
+++ b/docs/rebase-v1.8.1-2026-07-10.md
@@ -1,0 +1,174 @@
+# Rebase on upstream v1.8.1 - 2026-07-10
+
+## Goal
+
+Rebase the MindRoom fork onto upstream `v1.8.1` (the latest published GitHub
+release) with the usual explicit overlap review, per-commit build gates, and a
+sweep for semantic conflicts that a textually clean rebase would hide.
+
+## Baseline
+
+- Fork tip of record: `origin/main` = `213dde5e`
+  (`docs: fork runtime and release overview`).
+- Fork base before this rebase: upstream `main` `2323a8ec`
+  (the 2026-07-07 rebase target, past `v1.8.0`).
+- Upstream target: `v1.8.1` = `af3b4ad4` (`Bump 1.8.1.`, tagged 2026-07-09,
+  published 2026-07-10; identical to the `upstream/main` tip at session time).
+- Upstream delta: `2323a8ec..v1.8.1` = 25 commits.
+- Fork delta: 6 linear commits, no merges.
+- `git cherry -v v1.8.1 main`: all 6 fork commits `+` — nothing was absorbed
+  upstream in this window, so nothing is dropped.
+
+Notable upstream commits in the delta:
+
+- The Synapse admin API surface (#38/#494): `/_synapse/admin` user, device,
+  token, room, media, federation, and misc endpoints, a new `service/tasks`
+  background-task tracker, and new room purge/delete machinery
+  (`rooms/timeline/purge.rs`, `pdu_metadata::purge_event_relations`).
+- Migration hardening for conduit imports (#41) and a longer systemd start
+  timeout during long migrations.
+- Private read receipts now carry a timestamp (`read_receipt` schema change,
+  threaded through `timeline/append.rs`).
+- `synapse-admin-api` dependency rev bump; version bump to 1.8.1;
+  SECURITY.md, issue templates, PR template.
+
+## Safety Refs
+
+- `backup/origin-main-before-rebase-v1.8.1-20260710` = `213dde5e` preserves
+  the fork tip this rebase starts from.
+- Work branch: `mindroom/rebase-v1.8.1-20260710`; local `main` untouched until
+  validation completed. `--no-update-refs` passed to every rebase because the
+  global `rebase.updateRefs=true` dragged `main` along during the 2026-07-07
+  session.
+
+## Overlap Review
+
+Same-file overlap (`comm -12` of both `--name-only` diffs) — 6 files, down
+from 18 in the v1.7.1 rebase:
+
+- `Cargo.lock` — fork adds the `mindroom_rebase_tests` package entry;
+  upstream bumps every workspace crate to 1.8.1 and the `synapse-admin-api`
+  rev. Disjoint hunks.
+- `README.md` — fork adds the fork banner at the top; upstream reworded the
+  support section (~line 144) for SECURITY.md.
+- `src/api/router.rs` — fork inserts the native-Apple route after
+  `login_token_route`; upstream registers the Synapse admin routers and moves
+  the shared-secret register routes behind a `mas_active` gate ~25 lines away
+  in the same function. The fork route
+  (`/_matrix/client/unstable/org.mindroom.login/apple`) does not collide with
+  upstream's new unstable admin whois aliases.
+- `src/service/media/mod.rs` — fork's `mxc_is_owned_by_user`/`delete_owned_by`
+  at ~line 242 sit between upstream's struct-field hunk (~45) and its new
+  admin-media helpers (~474).
+- `src/service/mod.rs`, `src/service/services.rs` — fork registers
+  `edit_purge`, upstream registers `tasks`, at different alphabetical
+  positions.
+
+All six auto-merged; the rebase completed with **zero textual conflicts** and
+`git range-diff` showed all 6 commits replayed patch-identical.
+
+## Semantic Reconciliation
+
+A textually clean rebase still broke the build, exactly where predicted during
+the overlap review:
+
+- Upstream's **new** Synapse admin endpoints call the pre-fork one-argument
+  `users.deactivate_account`, while the fork's signature (from the sso commit)
+  is `deactivate_account(user_id, reason: DeactivationReason)`:
+  - `src/api/client/admin/users/deactivate_account.rs`
+    (`POST /_synapse/admin/v1/deactivate/{user_id}`)
+  - `src/api/client/admin/users/create_or_modify.rs`
+    (`PUT /_synapse/admin/v2/users/{user_id}` with `deactivated: true`)
+- Both are admin-initiated, so both now pass `DeactivationReason::Admin`,
+  mirroring the existing `mas/delete_user.rs` adaptation. Folded into the sso
+  commit (`auth/sso: SSO-origin UIAA hardening and self-reactivation`) so the
+  stack stays per-commit buildable; its message body notes the adaptation.
+
+The rest of the new admin surface was swept for fork-API interactions and
+needed no changes:
+
+- `reset_password.rs` and `create_or_modify.rs` call the two-argument
+  `set_password`, whose signature the fork does not change; the fork's
+  sentinel/origin-preservation logic composes (a real admin-set password
+  clears SSO origin by design, the `PASSWORD_SENTINEL` reactivation path
+  preserves it).
+- `mas/reactivate_user.rs` (sentinel path) and the new suspend/lock endpoints
+  touch nothing the fork modifies.
+
+### Edit-purge index audit
+
+Upstream's new `timeline::purge_history` is the authoritative checklist of
+per-event indexes: `pduid_pdu`, `eventid_pduid`, `eventid_outlierpdu`,
+`roomid_tscount_pducount` (via `bias_count`), search deindex,
+`purge_event_relations` (`tofrom_relation`, `relatesto_typed`,
+`referencedevents`, `softfailedeventids`), and `retention.purge_original`.
+`timeline/append.rs` gained **no new per-PDU index** in this window (only the
+receipt-timestamp parameter), so the fork's edit-purge deletion set
+(`pduid_pdu`, `eventid_pduid`, `roomid_tscount_pducount`, sidecar media)
+remains complete relative to its reviewed baseline. Relation rows for purged
+superseded edits are still intentionally left dangling — the same
+"harmless: relation reads discard ids that no longer resolve" rationale
+upstream now documents on `purge_event_relations`. The
+`edit_purge_bundle_compose` test continues to pin the dangling-row tolerance.
+
+## Kept / updated fork commits
+
+Result: the same 6 logical commits on the new base.
+
+- KEPT (replayed) `5ad18572` → edits, `b9d4c8c1` → apple, `8d903677` → ci,
+  `85b01a36` → tests.
+- **UPDATED** `8c8b8e41` → sso: adds the two `DeactivationReason::Admin`
+  call-site adaptations for upstream's new Synapse admin deactivation
+  endpoints (see above).
+- **UPDATED** `213dde5e` → docs: this file; FORK_CHANGES.md re-based to
+  v1.8.1 and its sso section extended with the new endpoint files.
+
+`Cargo.lock` merged coherently (fork test-crate entry intact, all workspace
+crates at 1.8.1, no stale 1.8.0 entries); every build below ran `--locked`,
+which proves lock/manifest coherence the same way the fork CI does.
+
+## Validation
+
+First rebase session on macOS (aarch64-apple-darwin, rustup toolchain 1.95.0
+per `rust-toolchain.toml`) instead of the Nix Linux dev shell — none of the
+liburing/sccache environment surgery from the v1.6.1/v1.7.1 notes applies
+here; the repo `.cargo/config.toml` only sets `RUMA_UNSTABLE_EXHAUSTIVE_TYPES`.
+
+- Per-commit gates: `cargo check --locked --workspace --all-targets` at the
+  three compile-relevant seam commits (edits, sso, apple) and at the tip —
+  all clean, so the stack bisects.
+- `cargo clippy --locked --workspace --all-targets -- -D warnings` — clean.
+- `RUST_TEST_THREADS=1 cargo test --locked --workspace --all-targets` — all
+  suites green, including all six `mindroom_rebase_tests` binaries
+  (admin_deactivate_erase, apple_userinfo_fallback, deactivate_erase,
+  edit_purge_bundle_compose, sso_callback_completion, sso_redirect) and the
+  `tuwunel_service` unit suite (270 passed — edit_purge, users::sso
+  reactivation, and upstream's new tasks tests). The `--all-features`
+  clippy/test axis is covered by `mindroom-ci.yml` on push (Linux runners).
+- `rustfmt` (nightly) over the two adapted files — no reformatting.
+
+## Post-rebase amendments (same session)
+
+- Boot smoke on the rebased tip (fresh DB, port 28998): CS API 200, the fork
+  Apple route rejects with the camelCase `identityToken` field error the
+  Cinny client's contract expects, the new `/_synapse/admin` whois route
+  answers 401 beside it, and the fresh database contains the fork's
+  `userid_deactivation_reason` column family.
+- Documented the deactivation-reason design divergence (vs Synapse and
+  upstream) in `src/service/users/sso.rs` above `DeactivationReason`, with a
+  matching design note in FORK_CHANGES.md — including the decision **not** to
+  upstream it (reversible deactivation would effectively need an MSC). Synapse
+  facts verified against the `mindroom-synapse` checkout: bare
+  `users.deactivated` flag, no reason concept, SSO login of deactivated
+  accounts hard-blocked (`sso_account_deactivated_template`), admin
+  `activate_account` expects a password hash afterwards. Folded into the sso
+  and docs commits so future rebases don't re-derive this.
+
+## Post-rebase notes
+
+- Pushing `main` triggers `auto-mindroom-release.yml`, which should compute
+  `v1.8.1-mindroom.1` (base version auto-detected from `Cargo.toml`, now
+  1.8.1) and publish binaries/containers via the release workflows.
+- The production host pin (`tuwunelVersion` in
+  `dotfiles/configs/nixos/hosts/hetzner-matrix`) can move to the new tag once
+  the release assets exist.

--- a/docs/rebase-v1.8.2-2026-07-21.md
+++ b/docs/rebase-v1.8.2-2026-07-21.md
@@ -1,0 +1,245 @@
+# Rebase on upstream v1.8.2 - 2026-07-21
+
+## Goal
+
+Rebase the MindRoom fork onto upstream `v1.8.2` (the latest published GitHub
+release) with the usual explicit overlap review, per-commit build gates, and a
+sweep for semantic conflicts that a textually clean rebase would hide. First
+rebase in which fork features were absorbed upstream via our own submitted
+branches, so this session also prunes the fork delta.
+
+## Baseline
+
+- Fork tip of record: `origin/main` = `efc8b615e`
+  (`fix(e2ee): reject replacement of existing device identity keys (#10)`).
+- Fork base before this rebase: upstream `v1.8.1` = `af3b4ad4`.
+- Upstream target: `v1.8.2` = `9099defe5` (`Bump 1.8.2.`, tagged/published
+  2026-07-17; `upstream/main` was already 39 commits past it — we track
+  releases, not main).
+- Upstream delta: `v1.8.1..v1.8.2` = 119 commits.
+- Fork delta: 12 linear commits, no merges — the six logical commits from the
+  v1.8.1 session plus two follow-up fixes (ci container-asset wait, Synapse
+  admin deactivation test) and four merged PRs (#7, #8, #9, #10).
+
+Notable upstream commits in the delta:
+
+- Two of our own upstream submissions merged (see Dropped below): the
+  zero/drained one-time-key counts fix (`164b8da61` + upstream's own follow-up
+  `007033cd5` matching Synapse's OTK count shape) and public MatrixRTC
+  transport discovery (`a1776c368`).
+- Forward-extremity work: scored prune engine, receive-path cap, admin
+  prune/list commands, band preservation on soft-failed events
+  (`timeline/append.rs`).
+- Media rework: URL previews stored as CBOR, relay-media caching, new
+  `mediaid_lazy`/`mediaid_lazycontent`/`url_preview` maps (`url_previews`
+  dropped), og:video/og:audio support, admin media hardening.
+- Admin output overhaul (size-capped buffer, reply/thread splitting, file
+  attachment) with new `admin_output_max_events`/`admin_output_threads`
+  options; more Synapse admin endpoints (server notices, user redaction,
+  login-as, federation destinations, media info/purge/statistics).
+- MSC3202/MSC4203 appservice E2EE transaction extensions; database backup
+  restore/verify commands; `--health-check` and `--restore-backup` CLI args;
+  packaging (RPM/COPR, apt repo) and CI storage tuning.
+- A new `documented_defaults_match_the_code` test
+  (`src/core/config/tests.rs`) parsing `config/mod.rs` doc comments against
+  the one-line integer default fns — this now also covers the fork's
+  `mindroom_edit_purge_*` options.
+- Dependency bumps including ruma (always emits the room ephemeral section in
+  `/sync`).
+
+## Dropped: fork commits absorbed upstream
+
+`git cherry -v v1.8.2 main` marked `c2729b76c` equivalent (`-`); manual review
+of the two `mindroom-ai/caveman/*` merge branches in the upstream log
+confirmed both submissions landed:
+
+- **DROPPED** `c2729b76c` `fix(e2ee): report drained one-time-key pools (#7)`
+  — byte-identical upstream as `164b8da61` (`users: Preserve zero
+  one-time-key counts.`); upstream then reshaped the same function in
+  `007033cd5` (`users: Match Synapse one-time-key count shape.`), which the
+  fork now inherits instead of carrying its own copy.
+- **DROPPED** `806ef6b9c` `fix(matrixrtc): allow public transport discovery
+  (#8)` — byte-identical upstream as `a1776c368` (only hunk offsets/context
+  differ; `git cherry` missed it because `d16303553` added Matrix v1.18/v1.19
+  to the surrounding version list).
+
+Not absorbed, kept: `efc8b615e` (#10) — upstream's `upload_keys.rs` was
+untouched in this window (the `store_device_keys` helper both sides share
+predates v1.8.1) and upstream `remove_device` still carries the
+`TODO: Remove onetimekeys` the fork resolved. The upstream submission branch
+(`origin/fix/reject-device-key-replacement`) had not merged as of v1.8.2.
+
+## Safety Refs
+
+- `backup/origin-main-before-rebase-v1.8.2-20260721` = `efc8b615e` preserves
+  the fork tip this rebase starts from (including the original, pre-fold
+  commits).
+- Work branch: `mindroom/rebase-v1.8.2-20260721`; local `main` untouched until
+  validation completed. `--no-update-refs` passed to every rebase (global
+  `rebase.updateRefs=true`).
+
+## Restacking (fold pass)
+
+Before leaving the v1.8.1 base, the accumulated follow-ups were folded into
+their logical parents and the docs commit moved back to the stack tip, so the
+stack replays as clean per-feature units:
+
+- `aa59033c6` (`ci: wait for both container release assets before building`)
+  squashed into the ci commit; its rationale preserved in the combined body.
+- `a42a76b67` (`tests: pin Synapse-admin deactivation to the admin reason`)
+  squashed into the tests commit; ditto.
+- `e1ba208f9` (docs) moved from mid-stack to last. All moved pairs touch
+  disjoint files.
+
+Verification: the folded stack's tree is **identical** to `origin/main`
+(`git diff main` empty), so the fold changed only history shape, not content.
+
+## Overlap Review
+
+Same-file overlap (`comm -12` of both `--name-only` diffs): 17 files, of
+which 3 (`versions.rs`, `auth/dispatch.rs`, `users/keys.rs`) belong only to
+the dropped commits, leaving 14 real overlaps:
+
+- `Cargo.lock` — fork adds the `mindroom_rebase_tests` entry; upstream bumps
+  workspace crates to 1.8.2, ruma, and friends. Disjoint hunks.
+- `README.md` — fork banner at top; upstream support/SECURITY edits ~40 lines
+  below. Disjoint.
+- `.github/workflows/main.yml` — fork removes the push/PR/tag triggers
+  (workflow_dispatch only); upstream tunes builder storage parameters and
+  threads a new `apt_ssh_key` secret. Disjoint. Upstream's new tag-triggered
+  `copr.yml` excludes `v*-*` tags, so the fork's `v<base>-mindroom.<n>`
+  release tags cannot trigger COPR submission; the apt publish path only runs
+  from `main.yml`, which the fork already gates to workflow_dispatch.
+- `src/api/router.rs` — fork's native-Apple route vs upstream's new Synapse
+  admin routes ~60 lines away. Disjoint.
+- `src/core/config/mod.rs`, `tuwunel-example.toml`, `check.rs` — fork's
+  mindroom options/defaults vs upstream's new options (dns_servers,
+  url_preview agents, admin_output_*) in different regions. Disjoint.
+- `src/database/maps.rs` — fork's `userid_deactivation_reason` (~554) vs
+  upstream's new media/url-preview maps (~149, ~507). Disjoint.
+- `src/main/args.rs` — fork's `default_test` database-path isolation vs
+  upstream's new `--health-check`/`--restore-backup` args; `default_test`
+  mutates a parsed default rather than constructing `Args` literally, so the
+  new fields compose without adaptation.
+- `src/service/deactivate/mod.rs` — upstream only dropped a `.boxed()` in
+  `full_deactivate`; fork's reason threading untouched.
+- `src/service/media/mod.rs`, `data.rs` — fork's
+  `mxc_is_owned_by_user`/`delete_owned_by` sit inside upstream's reworked
+  media module; `mediaid_user` (the map the helper reads) survives the CBOR
+  preview/relay-media rework with the same key schema and write sites, and
+  `delete_owned_by` composes with upstream's new lazy-content-aware
+  `delete`.
+- `src/service/pusher/send.rs` — both sides touch `send_push_notice` and
+  `send_notice`: fork adds the stream-suppression early return and terminal
+  push-content mapping, upstream adds a `user_id` parameter and deletes
+  pushers the gateway rejects. Hunks disjoint; composition reviewed by hand
+  post-rebase.
+- `src/service/users/device.rs` — fork's identity-key/OTK purge in
+  `remove_device` vs upstream changes elsewhere in the file (create_device,
+  refresh tokens, MSC3202 fanout helpers). Disjoint;
+  `onetimekeyid4225_otk` still exists with the same access pattern.
+
+The rebase completed with **zero textual conflicts** and `git range-diff`
+showed all 8 kept commits replayed patch-identical.
+
+## Semantic Reconciliation
+
+Sweeps for interactions a clean merge would hide:
+
+- **Deactivation seam quiet this window**: `deactivate_account` and
+  `set_password` call-site counts are identical between v1.8.1 and v1.8.2
+  (7 and 11), and no new caller files appeared — the first rebase since the
+  sso commit that needed no `DeactivationReason` adaptation.
+- **Edit-purge index audit**: upstream's `timeline/append.rs` changes are
+  forward-extremity band preservation only (`nonempty_band`); no new per-PDU
+  index was added, so the fork's edit-purge deletion set (`pduid_pdu`,
+  `eventid_pduid`, `roomid_tscount_pducount`, sidecar media) remains complete
+  relative to its reviewed v1.8.1 baseline. `purge_history` remains the
+  authoritative checklist.
+- **Pusher composition**: upstream's rejected-pushkey deletion runs after the
+  fork's suppression logic by construction (suppressed events never reach the
+  gateway); the fork's `send_notice` content mapping feeds upstream's new
+  `Request::new(notify)` path unchanged.
+- **Documented-defaults test**: the new upstream test parses the fork's
+  `mindroom_edit_purge_*` doc comments too; they already satisfy the
+  `/// default: N` ↔ one-line-fn contract (verified by the test run below).
+  `bundle_edit_relations` (bool) is outside the test's integer scope.
+- **Dropped-#7 follow-on**: upstream `007033cd5` changed the OTK count shape
+  after absorbing the fork fix; nothing in the fork pins the old shape (the
+  mindroom-tests suite does not exercise OTK counts), so inheriting the
+  upstream behavior is the intended outcome.
+- **Newly enabled clippy lints**: upstream turned on `option_if_let_else`
+  (and `significant_drop_in_scrutinee`, `cognitive_complexity`,
+  `unused_braces`) workspace-wide in this window. Three fork sites needed the
+  `map_or_else` conversion — the resume-key stream selection in
+  `src/service/edit_purge/mod.rs` and the `replace_target` test-content
+  helpers in `edit_purge/mod.rs` and
+  `src/api/client/sync/mindroom_edits.rs`. Folded into the edits commit.
+
+## Kept / updated fork commits
+
+Result: 8 logical commits on the new base (12 before folding/drops).
+
+- KEPT (replayed patch-identical) `5112447c2` → sso, `dbf94d222` → apple,
+  `34baf29bc` → #9 stream push, `efc8b615e` → #10 device-key immutability.
+- **UPDATED** `73411e48c` → edits: replayed patch-identical, then extended
+  with the three `option_if_let_else` conversions above.
+- **UPDATED (fold only)** ci: absorbs `aa59033c6`; tests: absorbs
+  `a42a76b67`. Content byte-identical to the sum of their parts.
+- **UPDATED** docs: this file; FORK_CHANGES.md re-based to v1.8.2, its
+  dropped-features note extended (#7/#8), and new sections documenting the
+  stream-push (#9) and device-key immutability (#10) features that landed
+  after the last docs pass.
+
+## Validation
+
+macOS aarch64-apple-darwin, rustup toolchain 1.95.0 per `rust-toolchain.toml`;
+plain cargo, no Nix dev-shell surgery (see v1.8.1 notes).
+
+- Per-commit gates: `cargo check --locked --workspace --all-targets` at every
+  code commit of the stack (edits, sso, apple, tests, #9, #10 = tip-1) — all
+  clean, so the stack bisects. After the clippy conversions were folded into
+  the edits commit, that commit was re-gated the same way (the two touched
+  files are never modified by later commits, so the downstream gates hold).
+- `cargo clippy --locked --workspace --all-targets -- -D warnings` at the
+  tip — clean after the three conversions; the failures it caught first were
+  exactly the new-lint sites listed above.
+- `RUST_TEST_THREADS=1 cargo test --locked --workspace --all-targets` at the
+  tip — 686 passed, 0 failed across 39 suites, including the 334-test
+  `tuwunel_service` unit suite (edit_purge, users::sso reactivation, the #9
+  stream-push classification, upstream's tasks/backup suites), the 165-test
+  `tuwunel_core` suite with upstream's new
+  `documented_defaults_match_the_code` (which now also parses the fork's
+  `mindroom_edit_purge_*` options — they satisfy the `/// default: N` ↔
+  one-line-fn contract), and the seven `mindroom_rebase_tests` binaries
+  (admin_deactivate_erase, apple_userinfo_fallback, deactivate_erase,
+  edit_purge_bundle_compose, sso_callback_completion, sso_redirect,
+  synapse_admin_deactivate). The `--all-features` axis is covered by
+  `mindroom-ci.yml` on push (Linux runners). Note for future sessions: don't
+  pipe the test run through `head` — the pipeline exit code becomes `head`'s
+  and truncation can masquerade as a pass; this session re-ran the suite
+  unfiltered after noticing exactly that.
+- `cargo +nightly fmt --all -- --check` — no reformatting.
+- Boot smoke on the rebased tip (fresh DB, port 28998): CS API versions 200
+  (declares v1.19 and `org.matrix.msc4143`), the
+  `org.matrix.msc4143/rtc/transports` route answers **without a token** —
+  end-to-end proof the dropped #8 behavior survives via upstream's code — the
+  fork Apple route rejects with the camelCase `identityToken` contract error,
+  `/_synapse/admin/v1/whois` answers 401, and the fresh database opens the
+  fork's `userid_deactivation_reason` column family alongside upstream's new
+  `mediaid_lazy`/`url_preview` families.
+
+## Post-rebase notes
+
+- Pushing `main` triggers `auto-mindroom-release.yml`, which computes
+  `v1.8.2-mindroom.1` (base auto-detected from `Cargo.toml`, now 1.8.2) and
+  publishes binaries/containers. Upstream's new `copr.yml` ignores the
+  hyphenated fork tags.
+- Deploy pins (`tuwunelVersion`/`tuwunelArchiveHash` in
+  `dotfiles/configs/nixos/hosts/{hetzner-matrix,mindroom}/constants.nix`;
+  aarch64 vs x86_64 hashes differ) can move to the new tag once release
+  assets exist.
+- The #10 upstream submission (`fix/reject-device-key-replacement` plus its
+  undeserializable-keys and device-removal-purge follow-ups) was still
+  unmerged at v1.8.2; if it lands upstream, drop #10 at the next rebase the
+  same way #7/#8 were dropped here.

--- a/scripts/fork_release_tag.py
+++ b/scripts/fork_release_tag.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
+
+SEMVER_PREFIX_RE = re.compile(r"^(\d+\.\d+\.\d+)(?:[-+].*)?$")
+
+
+@dataclass
+class ReleaseTag:
+    base_version: str
+    release_iteration: int
+    release_tag: str
+    reused_tag_at_head: bool
+
+
+def run_git_tag(*args: str) -> list[str]:
+    output = subprocess.check_output(["git", "tag", *args], text=True)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def parse_base_version(raw_version: str) -> str:
+    match = SEMVER_PREFIX_RE.match(raw_version.strip())
+    if not match:
+        raise ValueError(
+            f'Unsupported version "{raw_version}". Expected something like "1.5.0".'
+        )
+    return match.group(1)
+
+
+def semver_key(version: str) -> tuple[int, int, int]:
+    major, minor, patch = version.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def compatible_prefixes(prefix: str) -> list[str]:
+    variants = [prefix]
+    if len(prefix) == 1 and prefix.isalpha():
+        swapped = prefix.swapcase()
+        if swapped != prefix:
+            variants.append(swapped)
+    return variants
+
+
+def build_prefix_pattern(prefix: str) -> str:
+    options = "|".join(re.escape(value) for value in compatible_prefixes(prefix))
+    return f"(?:{options})"
+
+
+def get_base_version_from_tags(all_tags: list[str], base_prefix: str) -> str | None:
+    prefix_pattern = build_prefix_pattern(base_prefix)
+    base_re = re.compile(rf"^{prefix_pattern}(\d+\.\d+\.\d+)$")
+    versions = [match.group(1) for tag in all_tags if (match := base_re.fullmatch(tag))]
+    if not versions:
+        return None
+    return sorted(versions, key=semver_key)[-1]
+
+
+def get_release_iteration(
+    tag: str, base_version: str, release_prefix: str, release_suffix: str
+) -> int | None:
+    prefix_pattern = build_prefix_pattern(release_prefix)
+    suffix_pattern = re.escape(release_suffix)
+    release_re = re.compile(
+        rf"^{prefix_pattern}{re.escape(base_version)}-{suffix_pattern}\.(\d+)$"
+    )
+    match = release_re.fullmatch(tag)
+    return int(match.group(1)) if match else None
+
+
+def compute_release_tag(
+    base_version: str,
+    all_tags: list[str],
+    head_tags: list[str],
+    release_prefix: str,
+    release_suffix: str,
+) -> ReleaseTag:
+    all_iterations = [
+        value
+        for value in (
+            get_release_iteration(tag, base_version, release_prefix, release_suffix)
+            for tag in all_tags
+        )
+        if value is not None
+    ]
+    max_iteration = max(all_iterations) if all_iterations else 0
+
+    head_iterations = [
+        (tag, value)
+        for tag in head_tags
+        for value in [
+            get_release_iteration(tag, base_version, release_prefix, release_suffix)
+        ]
+        if value is not None
+    ]
+    if head_iterations:
+        reused_tag, reused_iteration = sorted(
+            head_iterations, key=lambda item: item[1], reverse=True
+        )[0]
+        return ReleaseTag(
+            base_version=base_version,
+            release_iteration=reused_iteration,
+            release_tag=reused_tag,
+            reused_tag_at_head=True,
+        )
+
+    next_iteration = max_iteration + 1
+    return ReleaseTag(
+        base_version=base_version,
+        release_iteration=next_iteration,
+        release_tag=f"{release_prefix}{base_version}-{release_suffix}.{next_iteration}",
+        reused_tag_at_head=False,
+    )
+
+
+def write_github_output(result: ReleaseTag) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    with open(output_path, "a", encoding="utf-8") as output_file:
+        output_file.write(f"base_version={result.base_version}\n")
+        output_file.write(f"release_iteration={result.release_iteration}\n")
+        output_file.write(f"release_tag={result.release_tag}\n")
+        output_file.write(f"reused_tag_at_head={str(result.reused_tag_at_head).lower()}\n")
+
+
+def read_package_version(repo_root: Path) -> str | None:
+    package_path = repo_root / "package.json"
+    if not package_path.exists():
+        return None
+    package_json = json.loads(package_path.read_text(encoding="utf-8"))
+    version = package_json.get("version")
+    if not isinstance(version, str):
+        raise ValueError("package.json version must be a string")
+    return version.strip()
+
+
+def read_cargo_workspace_version(repo_root: Path) -> str | None:
+    cargo_path = repo_root / "Cargo.toml"
+    if not cargo_path.exists():
+        return None
+    if tomllib is None:
+        return None
+
+    cargo = tomllib.loads(cargo_path.read_text(encoding="utf-8"))
+    workspace = cargo.get("workspace")
+    if isinstance(workspace, dict):
+        workspace_package = workspace.get("package")
+        if isinstance(workspace_package, dict):
+            version = workspace_package.get("version")
+            if isinstance(version, str):
+                return version.strip()
+
+    package = cargo.get("package")
+    if isinstance(package, dict):
+        version = package.get("version")
+        if isinstance(version, str):
+            return version.strip()
+
+    return None
+
+
+def main() -> int:
+    release_prefix = (os.getenv("RELEASE_TAG_PREFIX") or "v").strip()
+    base_prefix = (os.getenv("BASE_TAG_PREFIX") or release_prefix).strip()
+    release_suffix = (os.getenv("RELEASE_TAG_SUFFIX") or "mindroom").strip()
+
+    if not release_prefix:
+        raise ValueError("RELEASE_TAG_PREFIX must not be empty")
+    if not release_suffix:
+        raise ValueError("RELEASE_TAG_SUFFIX must not be empty")
+
+    repo_root = Path(__file__).resolve().parent.parent
+    all_tags = run_git_tag("--list")
+    head_tags = run_git_tag("--points-at", "HEAD")
+    raw_version = os.getenv("BASE_VERSION")
+    if raw_version:
+        base_version = parse_base_version(raw_version)
+    else:
+        package_version = read_package_version(repo_root)
+        if package_version:
+            base_version = parse_base_version(package_version)
+        else:
+            cargo_version = read_cargo_workspace_version(repo_root)
+            if cargo_version:
+                base_version = parse_base_version(cargo_version)
+            else:
+                base_version = get_base_version_from_tags(all_tags, base_prefix)
+                if not base_version:
+                    raise ValueError(
+                        "Could not auto-detect base version. Set BASE_VERSION or provide package.json/Cargo.toml version."
+                    )
+
+    result = compute_release_tag(
+        base_version,
+        all_tags,
+        head_tags,
+        release_prefix,
+        release_suffix,
+    )
+    write_github_output(result)
+
+    print(f"base_version={result.base_version}")
+    print(f"release_iteration={result.release_iteration}")
+    print(f"release_tag={result.release_tag}")
+    print(f"reused_tag_at_head={str(result.reused_tag_at_head).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/src/admin/user/mod.rs
+++ b/src/admin/user/mod.rs
@@ -27,7 +27,7 @@ use clap::Subcommand;
 use futures::FutureExt;
 use ruma::{OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedRoomOrAliasId, OwnedUserId, UserId};
 use tuwunel_core::Result;
-use tuwunel_service::Services;
+use tuwunel_service::{Services, users::DeactivationReason};
 
 use crate::admin_command_dispatch;
 
@@ -237,11 +237,14 @@ async fn deactivate_user(services: &Services, user_id: &UserId, no_leave_rooms: 
 	if !no_leave_rooms {
 		services
 			.deactivate
-			.full_deactivate(user_id, false)
+			.full_deactivate(user_id, false, DeactivationReason::Admin)
 			.boxed()
 			.await?;
 	} else {
-		services.users.deactivate_account(user_id).await?;
+		services
+			.users
+			.deactivate_account(user_id, DeactivationReason::Admin)
+			.await?;
 	}
 
 	Ok(())

--- a/src/api/client/account/deactivate.rs
+++ b/src/api/client/account/deactivate.rs
@@ -2,6 +2,7 @@ use axum::extract::State;
 use futures::FutureExt;
 use ruma::api::client::account::{ThirdPartyIdRemovalStatus, deactivate};
 use tuwunel_core::{Result, info};
+use tuwunel_service::users::DeactivationReason;
 
 use crate::{ClientIp, Ruma, router::auth_uiaa};
 
@@ -15,7 +16,8 @@ use crate::{ClientIp, Ruma, router::auth_uiaa};
 ///   last seen ts)
 /// - Forgets all to-device events
 /// - Triggers device list updates
-/// - Removes ability to log in again
+/// - Removes ability to log in again, unless local policy permits SSO
+///   self-reactivation
 #[tracing::instrument(skip_all, fields(%client), name = "deactivate")]
 pub(crate) async fn deactivate_route(
 	State(services): State<crate::State>,
@@ -26,7 +28,7 @@ pub(crate) async fn deactivate_route(
 
 	services
 		.deactivate
-		.full_deactivate(sender_user, body.erase)
+		.full_deactivate(sender_user, body.erase, DeactivationReason::SelfService)
 		.boxed()
 		.await?;
 

--- a/src/api/client/admin/mas/delete_user.rs
+++ b/src/api/client/admin/mas/delete_user.rs
@@ -1,6 +1,7 @@
 use axum::extract::State;
 use synapse_admin_api::mas::delete_user::{Request, Response};
 use tuwunel_core::Result;
+use tuwunel_service::users::DeactivationReason;
 
 use super::{Mas, existing_user};
 use crate::Ruma;
@@ -15,7 +16,7 @@ pub(crate) async fn delete_user_route(
 
 	services
 		.deactivate
-		.full_deactivate(&user_id, body.erase)
+		.full_deactivate(&user_id, body.erase, DeactivationReason::Admin)
 		.await?;
 
 	Ok(Response::new())

--- a/src/api/client/admin/users/create_or_modify.rs
+++ b/src/api/client/admin/users/create_or_modify.rs
@@ -8,7 +8,10 @@ use tuwunel_core::{
 	Err, Result,
 	utils::{IterStream, ReadyExt, stream::automatic_width},
 };
-use tuwunel_service::{threepid::canonicalize_email, users::PASSWORD_SENTINEL};
+use tuwunel_service::{
+	threepid::canonicalize_email,
+	users::{DeactivationReason, PASSWORD_SENTINEL},
+};
 
 use super::user_details;
 use crate::{Ruma, client::admin::require_admin};
@@ -92,7 +95,11 @@ pub(crate) async fn admin_create_or_modify_route(
 	}
 
 	match body.deactivated {
-		| Some(true) => services.users.deactivate_account(user_id).await?,
+		| Some(true) =>
+			services
+				.users
+				.deactivate_account(user_id, DeactivationReason::Admin)
+				.await?,
 		| Some(false)
 			if services
 				.users

--- a/src/api/client/admin/users/deactivate_account.rs
+++ b/src/api/client/admin/users/deactivate_account.rs
@@ -1,6 +1,7 @@
 use axum::extract::State;
 use synapse_admin_api::users::deactivate_account::v1 as deactivate_account;
 use tuwunel_core::{Err, Result};
+use tuwunel_service::users::DeactivationReason;
 
 use crate::{Ruma, client::admin::require_admin};
 
@@ -21,7 +22,7 @@ pub(crate) async fn admin_deactivate_account_route(
 
 	services
 		.users
-		.deactivate_account(&body.user_id)
+		.deactivate_account(&body.user_id, DeactivationReason::Admin)
 		.await?;
 
 	if body.erase {

--- a/src/api/client/keys/upload_keys.rs
+++ b/src/api/client/keys/upload_keys.rs
@@ -78,25 +78,48 @@ async fn store_device_keys(
 		)));
 	}
 
-	// Workaround for a nheko bug which omits cross-signing signatures when
-	// re-uploading the same DeviceKeys: ignore an exact-copy re-upload so the
-	// existing signatures are preserved.
-	let unchanged = services
+	// No existing device keys means this is the device's first upload. A
+	// stored value that fails to deserialize must not be mistaken for that:
+	// it would bypass the immutability check below, so propagate it instead.
+	if let Ok(existing_keys) = services
 		.users
 		.get_device_keys(sender_user, sender_device)
 		.await
-		.and_then(|keys| keys.deserialize().map_err(Into::into))
-		.is_ok_and(|existing| existing.keys == new_keys.keys);
+	{
+		let existing = existing_keys.deserialize().map_err(|e| {
+			err!(Database(debug_warn!(
+				?sender_user,
+				?sender_device,
+				"Failed to deserialize existing device keys: {e}"
+			)))
+		})?;
 
-	if unchanged {
-		debug!(
+		// Workaround for a nheko bug which omits cross-signing signatures when
+		// re-uploading the same DeviceKeys: ignore an exact-copy re-upload so
+		// the existing signatures are preserved.
+		if existing.keys == new_keys.keys {
+			debug!(
+				?sender_user,
+				?sender_device,
+				?device_keys,
+				"Ignoring user uploaded keys as they are an exact copy already in the database"
+			);
+
+			return Ok(());
+		}
+
+		// Identity keys for an existing device are immutable. Different key
+		// material for the same device id means the client lost its crypto
+		// store while keeping its access token; accepting the replacement
+		// would silently break olm sessions and permanently poison the device
+		// caches of every peer that saw the old identity. Force a fresh login
+		// instead.
+		return Err!(Request(Forbidden(debug_warn!(
 			?sender_user,
 			?sender_device,
-			?device_keys,
-			"Ignoring user uploaded keys as they are an exact copy already in the database"
-		);
-
-		return Ok(());
+			"Rejecting upload of different identity keys for an existing device; device keys \
+			 are immutable. Log out and log in again to register a new encryption identity."
+		))));
 	}
 
 	services

--- a/src/api/client/membership/mod.rs
+++ b/src/api/client/membership/mod.rs
@@ -14,7 +14,7 @@ use axum::extract::State;
 use futures::{FutureExt, StreamExt};
 use ruma::{RoomId, RoomOrAliasId, UserId, api::client::membership::joined_rooms};
 use tuwunel_core::{Err, Result, result::LogErr, warn};
-use tuwunel_service::Services;
+use tuwunel_service::{Services, users::DeactivationReason};
 
 pub(crate) use self::{
 	ban::ban_user_route,
@@ -112,7 +112,7 @@ async fn maybe_deactivate(services: &Services, user_id: &UserId, client_ip: IpAd
 
 		services
 			.deactivate
-			.full_deactivate(user_id, false)
+			.full_deactivate(user_id, false, DeactivationReason::Admin)
 			.boxed()
 			.await?;
 	}

--- a/src/api/client/message.rs
+++ b/src/api/client/message.rs
@@ -22,7 +22,7 @@ use tuwunel_core::{
 	smallvec::SmallVec,
 	utils::{
 		BoolExt, IterStream, ReadyExt,
-		result::{FlatOk, LogErr},
+		result::LogErr,
 		stream::{BroadbandExt, TryIgnore, WidebandExt},
 	},
 };
@@ -147,7 +147,7 @@ pub(crate) async fn get_messages(
 			| Direction::Backward => PduCount::max(),
 		});
 
-	let to: Option<PduCount> = to.map(str::parse).flat_ok();
+	let to: Option<PduCount> = to.map(str::parse).transpose()?;
 
 	let limit: usize = limit
 		.and_then(|limit| limit.try_into().ok())
@@ -185,8 +185,17 @@ pub(crate) async fn get_messages(
 
 	let shortroomid = services.short.get_shortroomid(room_id).await?;
 
+	// `to` is a position, not necessarily the count of an event in this room
+	// (sync tokens are global stream positions), so the walk must stop once
+	// the bound is passed rather than only on an exact count match.
 	let events: Vec<_> = it
-		.ready_take_while(|(count, _)| Some(*count) != to)
+		.ready_take_while(|(count, _)| match to {
+			| Some(to) => match dir {
+				| Direction::Forward => *count < to,
+				| Direction::Backward => *count > to,
+			},
+			| None => true,
+		})
 		.ready_filter_map(|item| event_filter(item, filter))
 		.wide_filter_map(|item| related_by_filter(services, shortroomid, filter, item))
 		.wide_filter_map(|item| event_filters(services, sender_user, item, bypass_visibility))

--- a/src/api/client/session/mod.rs
+++ b/src/api/client/session/mod.rs
@@ -29,7 +29,8 @@ pub(crate) use self::{
 	logout::{logout_all_route, logout_route},
 	refresh::refresh_token_route,
 	sso::{
-		sso_callback_route, sso_fallback_route, sso_login_route, sso_login_with_provider_route,
+		native_apple_login_route, sso_callback_route, sso_fallback_route, sso_login_route,
+		sso_login_with_provider_route,
 	},
 	token::login_token_route,
 };

--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -952,4 +952,48 @@ mod tests {
 			"unexpected removal cookie: {removal}"
 		);
 	}
+
+	/// The Apple id_token userinfo fallback decodes claims from
+	/// `Session::id_token`, so the token response's id_token must be persisted
+	/// on the session before `request_userinfo` runs.
+	#[test]
+	fn apply_token_response_persists_id_token_for_userinfo_fallback() {
+		let token = TokenResponse {
+			token_type: Some("Bearer".to_owned()),
+			access_token: Some("access-token".to_owned()),
+			expires_in: Some(3600),
+			refresh_token: Some("refresh-token".to_owned()),
+			refresh_token_expires_in: Some(86400),
+			scope: Some("openid email".to_owned()),
+			id_token: Some("header.payload.signature".to_owned()),
+		};
+
+		let session =
+			apply_token_response(Session::default(), token).expect("token response applies");
+
+		assert_eq!(
+			session.id_token.as_deref(),
+			Some("header.payload.signature"),
+			"id_token must be persisted for the Apple userinfo fallback",
+		);
+		assert_eq!(session.access_token.as_deref(), Some("access-token"));
+		assert_eq!(session.refresh_token.as_deref(), Some("refresh-token"));
+		assert!(session.expires_at.is_some());
+		assert!(session.refresh_token_expires_at.is_some());
+	}
+
+	/// A token response without an id_token (plain OAuth2 provider) must not
+	/// invent one.
+	#[test]
+	fn apply_token_response_leaves_id_token_empty_when_absent() {
+		let token: TokenResponse = serde_json::from_value(serde_json::json!({
+			"access_token": "access-123",
+		}))
+		.expect("valid token response");
+
+		let session =
+			apply_token_response(Session::default(), token).expect("session updates apply");
+
+		assert_eq!(session.id_token, None);
+	}
 }

--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -461,6 +461,13 @@ pub(crate) async fn sso_callback_route(
 	}
 
 	services.oauth.sessions.put(&session).await;
+	if services
+		.users
+		.maybe_repair_legacy_sso_origin(&user_id)
+		.await
+	{
+		info!("Repaired legacy SSO-origin metadata for {user_id}");
+	}
 
 	if let Some(old_sess_id) = old_sess_id
 		.as_deref()
@@ -469,9 +476,7 @@ pub(crate) async fn sso_callback_route(
 		services.oauth.sessions.delete(old_sess_id).await;
 	}
 
-	if !services.users.is_active_local(&user_id).await {
-		return Err!(Request(UserDeactivated("This user has been deactivated.")));
-	}
+	ensure_sso_account_active(&services, &user_id).await?;
 
 	let cookie = Cookie::build((GRANT_SESSION_COOKIE, EMPTY))
 		.path(grant_session_cookie_path(provider.callback_url.as_ref()))
@@ -616,6 +621,22 @@ fn finalize_login_redirect(
 		.to_string();
 
 	Ok(location)
+}
+
+async fn ensure_sso_account_active(services: &Services, user_id: &UserId) -> Result {
+	if services
+		.users
+		.maybe_reactivate_deactivated_sso(user_id)
+		.await?
+	{
+		info!("Reactivated deactivated SSO account {user_id}");
+	}
+
+	if !services.users.is_active_local(user_id).await {
+		return Err!(Request(UserDeactivated("This user has been deactivated.")));
+	}
+
+	Ok(())
 }
 
 async fn handle_uiaa(

--- a/src/api/client/session/sso.rs
+++ b/src/api/client/session/sso.rs
@@ -1,3 +1,4 @@
+mod native_apple;
 mod uiaa;
 
 use std::{borrow::Cow, collections::BTreeMap, net::IpAddr, time::Duration};
@@ -15,7 +16,6 @@ use ruma::{
 	},
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 use tuwunel_core::{
 	Err, Result, at,
 	config::IdentityProvider,
@@ -45,7 +45,7 @@ use tuwunel_service::{
 };
 use url::Url;
 
-pub(crate) use self::uiaa::sso_fallback_route;
+pub(crate) use self::{native_apple::native_apple_login_route, uiaa::sso_fallback_route};
 use super::TOKEN_LENGTH;
 use crate::{ClientIp, Ruma};
 
@@ -81,64 +81,6 @@ static GRANT_SESSION_COOKIE: &str = "tuwunel_grant_session";
 /// without an explicit path defaults to the request-URI's directory.
 fn grant_session_cookie_path(callback_url: Option<&Url>) -> &str {
 	callback_url.map(Url::path).unwrap_or("/")
-}
-
-fn decode_apple_userinfo_from_id_token(session: &Session) -> Result<UserInfo> {
-	let id_token = session.id_token.as_deref().ok_or_else(|| {
-		err!(Request(Unauthorized("Missing Apple id_token in token response.")))
-	})?;
-
-	let payload_b64 = id_token
-		.split('.')
-		.nth(1)
-		.ok_or_else(|| err!(Request(Unauthorized("Apple id_token is malformed."))))?;
-
-	let payload = b64
-		.decode(payload_b64)
-		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is invalid base64."))))?;
-
-	let payload: JsonValue = serde_json::from_slice(&payload)
-		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is not valid JSON."))))?;
-
-	let sub = payload
-		.get("sub")
-		.and_then(JsonValue::as_str)
-		.ok_or_else(|| {
-			err!(Request(Unauthorized("Apple id_token missing required sub claim.")))
-		})?;
-
-	let email = payload
-		.get("email")
-		.and_then(JsonValue::as_str)
-		.map(ToOwned::to_owned);
-
-	let preferred_username = email
-		.as_deref()
-		.and_then(|value| value.split_once('@'))
-		.map(at!(0))
-		.map(ToOwned::to_owned);
-
-	Ok(UserInfo {
-		sub: sub.to_owned(),
-		preferred_username: preferred_username.clone(),
-		username: preferred_username,
-		nickname: None,
-		name: payload
-			.get("name")
-			.and_then(JsonValue::as_str)
-			.map(ToOwned::to_owned),
-		given_name: payload
-			.get("given_name")
-			.and_then(JsonValue::as_str)
-			.map(ToOwned::to_owned),
-		family_name: payload
-			.get("family_name")
-			.and_then(JsonValue::as_str)
-			.map(ToOwned::to_owned),
-		email,
-		avatar_url: None,
-		picture: None,
-	})
 }
 
 /// # `GET /_matrix/client/v3/login/sso/redirect`
@@ -419,7 +361,7 @@ pub(crate) async fn sso_callback_route(
 				"Failed to fetch Apple userinfo endpoint; falling back to id_token claims.",
 			);
 
-			decode_apple_userinfo_from_id_token(&session).map_err(|decode_error| {
+			native_apple::decode_userinfo_from_id_token(&session).map_err(|decode_error| {
 				debug_warn!(
 					?decode_error,
 					idp_id = provider.id(),
@@ -429,54 +371,8 @@ pub(crate) async fn sso_callback_route(
 			})
 		})?;
 
-	let unique_id = unique_id_sub((&provider, &userinfo.sub))?;
-
-	let (old_user_id, old_sess_id) = existing_identity_session(&services, &unique_id).await?;
-
-	let session = Session {
-		user_info: Some(userinfo.clone()),
-		..session
-	};
-
-	let user_id = match (session.user_id, old_user_id) {
-		| (Some(user_id), ..) | (None, Some(user_id)) => user_id,
-		| (None, None) => decide_user_id(&services, &provider, &userinfo, &unique_id).await?,
-	};
-
-	let session = Session {
-		user_id: Some(user_id.clone()),
-		..session
-	};
-
-	if !services.users.exists(&user_id).await {
-		let origin = match provider.registration {
-			| true => "sso",
-			// Present in LDAP is an existing user to provision, not a new registration.
-			| false if ldap_user_exists(&services, &user_id).await => "ldap",
-			| false =>
-				return Err!(Request(Forbidden("Registration from this provider is disabled"))),
-		};
-
-		register_user(&services, &provider, &session, &userinfo, &user_id, origin).await?;
-	}
-
-	services.oauth.sessions.put(&session).await;
-	if services
-		.users
-		.maybe_repair_legacy_sso_origin(&user_id)
-		.await
-	{
-		info!("Repaired legacy SSO-origin metadata for {user_id}");
-	}
-
-	if let Some(old_sess_id) = old_sess_id
-		.as_deref()
-		.filter(is_not_equal_to!(&sess_id))
-	{
-		services.oauth.sessions.delete(old_sess_id).await;
-	}
-
-	ensure_sso_account_active(&services, &user_id).await?;
+	let (user_id, session) =
+		complete_sso_session(&services, &provider, session, userinfo).await?;
 
 	let cookie = Cookie::build((GRANT_SESSION_COOKIE, EMPTY))
 		.path(grant_session_cookie_path(provider.callback_url.as_ref()))
@@ -623,20 +519,74 @@ fn finalize_login_redirect(
 	Ok(location)
 }
 
-async fn ensure_sso_account_active(services: &Services, user_id: &UserId) -> Result {
+/// Map an authenticated SSO/OIDC identity onto a local account and return the
+/// resulting user together with the committed session. Shared by the browser
+/// SSO callback and the native Apple login endpoint.
+async fn complete_sso_session(
+	services: &Services,
+	provider: &Provider,
+	mut session: Session,
+	userinfo: UserInfo,
+) -> Result<(OwnedUserId, Session)> {
+	let sess_id = session
+		.sess_id
+		.clone()
+		.ok_or_else(|| err!(Request(InvalidParam("Missing SSO session id."))))?;
+
+	let unique_id = unique_id_sub((provider, &userinfo.sub))?;
+
+	let (old_user_id, old_sess_id) = existing_identity_session(services, &unique_id).await?;
+
+	session.user_info = Some(userinfo.clone());
+
+	let user_id = match (session.user_id.take(), old_user_id) {
+		| (Some(user_id), ..) | (None, Some(user_id)) => user_id,
+		| (None, None) => decide_user_id(services, provider, &userinfo, &unique_id).await?,
+	};
+
+	session.user_id = Some(user_id.clone());
+
+	if !services.users.exists(&user_id).await {
+		let origin = match provider.registration {
+			| true => "sso",
+			// Present in LDAP is an existing user to provision, not a new registration.
+			| false if ldap_user_exists(services, &user_id).await => "ldap",
+			| false =>
+				return Err!(Request(Forbidden("Registration from this provider is disabled"))),
+		};
+
+		register_user(services, provider, &session, &userinfo, &user_id, origin).await?;
+	}
+
+	services.oauth.sessions.put(&session).await;
 	if services
 		.users
-		.maybe_reactivate_deactivated_sso(user_id)
+		.maybe_repair_legacy_sso_origin(&user_id)
+		.await
+	{
+		info!("Repaired legacy SSO-origin metadata for {user_id}");
+	}
+
+	if let Some(old_sess_id) = old_sess_id
+		.as_deref()
+		.filter(is_not_equal_to!(&sess_id))
+	{
+		services.oauth.sessions.delete(old_sess_id).await;
+	}
+
+	if services
+		.users
+		.maybe_reactivate_deactivated_sso(&user_id)
 		.await?
 	{
 		info!("Reactivated deactivated SSO account {user_id}");
 	}
 
-	if !services.users.is_active_local(user_id).await {
+	if !services.users.is_active_local(&user_id).await {
 		return Err!(Request(UserDeactivated("This user has been deactivated.")));
 	}
 
-	Ok(())
+	Ok((user_id, session))
 }
 
 async fn handle_uiaa(
@@ -962,78 +912,7 @@ fn parse_user_id(server_name: &ServerName, username: &str) -> Result<OwnedUserId
 
 #[cfg(test)]
 mod tests {
-	use serde_json::json;
-
 	use super::*;
-
-	fn apple_session_with_claims(claims: &serde_json::Value) -> Session {
-		let payload = b64.encode(serde_json::to_vec(claims).expect("serialize claims"));
-
-		Session {
-			id_token: Some(format!("header.{payload}.signature")),
-			..Default::default()
-		}
-	}
-
-	#[test]
-	fn decode_apple_userinfo_from_id_token_extracts_expected_claims() {
-		let session = apple_session_with_claims(&json!({
-			"sub": "apple-user-123",
-			"email": "alice@example.com",
-			"name": "Alice Example",
-			"given_name": "Alice",
-			"family_name": "Example"
-		}));
-
-		let userinfo =
-			decode_apple_userinfo_from_id_token(&session).expect("decode Apple id_token claims");
-
-		assert_eq!(userinfo.sub, "apple-user-123");
-		assert_eq!(userinfo.email.as_deref(), Some("alice@example.com"));
-		assert_eq!(userinfo.preferred_username.as_deref(), Some("alice"));
-		assert_eq!(userinfo.username.as_deref(), Some("alice"));
-		assert_eq!(userinfo.name.as_deref(), Some("Alice Example"));
-		assert_eq!(userinfo.given_name.as_deref(), Some("Alice"));
-		assert_eq!(userinfo.family_name.as_deref(), Some("Example"));
-	}
-
-	#[test]
-	fn decode_apple_userinfo_from_id_token_requires_sub_claim() {
-		let session = apple_session_with_claims(&json!({
-			"email": "alice@example.com"
-		}));
-
-		let error = decode_apple_userinfo_from_id_token(&session)
-			.expect_err("missing sub claim should fail");
-
-		let message = format!("{error}");
-		assert!(message.contains("sub claim"), "unexpected error: {message}");
-	}
-
-	#[test]
-	fn decode_apple_userinfo_from_id_token_requires_id_token() {
-		let session = Session::default();
-
-		let error = decode_apple_userinfo_from_id_token(&session)
-			.expect_err("missing id_token should fail");
-
-		let message = format!("{error}");
-		assert!(message.contains("Missing Apple id_token"), "unexpected error: {message}");
-	}
-
-	#[test]
-	fn decode_apple_userinfo_from_id_token_rejects_invalid_payload() {
-		let session = Session {
-			id_token: Some("header.!.signature".to_owned()),
-			..Default::default()
-		};
-
-		let error = decode_apple_userinfo_from_id_token(&session)
-			.expect_err("invalid id_token payload should fail");
-
-		let message = format!("{error}");
-		assert!(message.contains("invalid base64"), "unexpected error: {message}");
-	}
 
 	#[test]
 	fn grant_session_cookie_path_uses_the_callback_path() {

--- a/src/api/client/session/sso/native_apple.rs
+++ b/src/api/client/session/sso/native_apple.rs
@@ -1,0 +1,804 @@
+use std::{
+	collections::{BTreeMap, BTreeSet},
+	fmt::Write as _,
+	future::Future,
+	sync::OnceLock,
+	time::{Duration, Instant},
+};
+
+use axum::{Json, extract::State, response::IntoResponse};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as b64};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tokio::sync::RwLock;
+use tuwunel_core::{
+	Err, Result, at,
+	config::IdentityProvider,
+	debug_info, err,
+	jwt::{Algorithm, DecodingKey, Header, Validation, decode, decode_header},
+	utils,
+	utils::hash::sha256,
+};
+use tuwunel_service::{
+	Services,
+	oauth::{Provider, SESSION_ID_LENGTH, Session, UserInfo},
+};
+
+use super::{super::TOKEN_LENGTH, complete_sso_session};
+
+static APPLE_ISSUER: &str = "https://appleid.apple.com";
+static APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
+static APPLE_JWKS_CACHE: OnceLock<RwLock<Option<CachedAppleJwks>>> = OnceLock::new();
+
+const APPLE_JWKS_CACHE_TTL: Duration = Duration::from_mins(10);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NativeAppleLoginRequest {
+	identity_token: String,
+	// Kept for auditability and future code-exchange/revocation checks; the
+	// current exchange validates the identity token directly.
+	authorization_code: Option<String>,
+	nonce: Option<String>,
+	provider_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeAppleLoginResponse {
+	login_token: String,
+	expires_in_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct AppleJwks {
+	keys: Vec<AppleJwk>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct AppleJwk {
+	alg: Option<String>,
+	e: String,
+	kid: String,
+	kty: String,
+	n: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppleIdTokenClaims {
+	iss: String,
+	aud: String,
+	#[expect(
+		dead_code,
+		reason = "jsonwebtoken validates this registered claim"
+	)]
+	exp: u64,
+	sub: String,
+	email: Option<String>,
+	name: Option<String>,
+	given_name: Option<String>,
+	family_name: Option<String>,
+	nonce: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct CachedAppleJwks {
+	jwks: AppleJwks,
+	fetched_at: Instant,
+}
+
+fn apple_native_audiences(provider: &Provider) -> BTreeSet<String> {
+	let mut audiences = provider.native_client_ids.clone();
+	audiences.insert(provider.client_id.clone());
+	audiences
+}
+
+fn sha256_hex(value: &str) -> String {
+	let digest = sha256::hash(value.as_bytes());
+	let mut output = String::new();
+
+	for byte in digest {
+		write!(&mut output, "{byte:02x}").expect("write to string");
+	}
+
+	output
+}
+
+fn apple_userinfo_from_validated_claims(
+	provider: &Provider,
+	claims: AppleIdTokenClaims,
+	raw_nonce: Option<&str>,
+) -> Result<UserInfo> {
+	if claims.iss != APPLE_ISSUER {
+		return Err!(Request(Unauthorized("Apple id_token issuer is not trusted.")));
+	}
+
+	if !apple_native_audiences(provider).contains(&claims.aud) {
+		return Err!(Request(Unauthorized(
+			"Apple id_token audience is not configured for this provider."
+		)));
+	}
+
+	match (claims.nonce.as_deref(), raw_nonce) {
+		| (Some(token_nonce), Some(raw_nonce)) => {
+			let expected_nonce = sha256_hex(raw_nonce);
+			if token_nonce != expected_nonce.as_str() {
+				return Err!(Request(Unauthorized("Apple id_token nonce does not match.")));
+			}
+		},
+		| (Some(_), None) => {
+			return Err!(Request(Unauthorized(
+				"Apple id_token nonce is present but no request nonce was supplied."
+			)));
+		},
+		| (None, Some(_)) => {
+			return Err!(Request(Unauthorized("Apple id_token nonce is missing.")));
+		},
+		| (None, None) => {},
+	}
+
+	Ok(apple_userinfo_from_claim_values(
+		claims.sub,
+		claims.email,
+		claims.name,
+		claims.given_name,
+		claims.family_name,
+	))
+}
+
+fn apple_userinfo_from_claim_values(
+	sub: String,
+	email: Option<String>,
+	name: Option<String>,
+	given_name: Option<String>,
+	family_name: Option<String>,
+) -> UserInfo {
+	let preferred_username = email
+		.as_deref()
+		.and_then(|value| value.split_once('@'))
+		.map(at!(0))
+		.map(ToOwned::to_owned);
+
+	UserInfo {
+		sub,
+		preferred_username: preferred_username.clone(),
+		username: preferred_username,
+		nickname: None,
+		name,
+		given_name,
+		family_name,
+		email,
+		avatar_url: None,
+		picture: None,
+	}
+}
+
+pub(super) fn decode_userinfo_from_id_token(session: &Session) -> Result<UserInfo> {
+	let id_token = session.id_token.as_deref().ok_or_else(|| {
+		err!(Request(Unauthorized("Missing Apple id_token in token response.")))
+	})?;
+
+	let payload_b64 = id_token
+		.split('.')
+		.nth(1)
+		.ok_or_else(|| err!(Request(Unauthorized("Apple id_token is malformed."))))?;
+
+	let payload = b64
+		.decode(payload_b64)
+		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is invalid base64."))))?;
+
+	let payload: JsonValue = serde_json::from_slice(&payload)
+		.map_err(|_| err!(Request(Unauthorized("Apple id_token payload is not valid JSON."))))?;
+
+	let sub = payload
+		.get("sub")
+		.and_then(JsonValue::as_str)
+		.ok_or_else(|| {
+			err!(Request(Unauthorized("Apple id_token missing required sub claim.")))
+		})?;
+
+	let email = payload
+		.get("email")
+		.and_then(JsonValue::as_str)
+		.map(ToOwned::to_owned);
+
+	Ok(apple_userinfo_from_claim_values(
+		sub.to_owned(),
+		email,
+		payload
+			.get("name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+		payload
+			.get("given_name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+		payload
+			.get("family_name")
+			.and_then(JsonValue::as_str)
+			.map(ToOwned::to_owned),
+	))
+}
+
+fn apple_id_token_header(token: &str) -> Result<Header> {
+	let header = decode_header(token)
+		.map_err(|e| err!(Request(Unauthorized("Apple id_token header is invalid: {e}"))))?;
+
+	if header.alg != Algorithm::RS256 {
+		return Err!(Request(Unauthorized("Apple id_token uses unsupported signing algorithm.")));
+	}
+
+	if header.kid.is_none() {
+		return Err!(Request(Unauthorized("Apple id_token missing key id.")));
+	}
+
+	Ok(header)
+}
+
+fn apple_decoding_key_for_kid(kid: &str, jwks: &AppleJwks) -> Result<Option<DecodingKey>> {
+	let Some(jwk) = jwks.keys.iter().find(|key| key.kid == kid) else {
+		return Ok(None);
+	};
+
+	if jwk.kty != "RSA"
+		|| jwk
+			.alg
+			.as_deref()
+			.is_some_and(|alg| alg != "RS256")
+	{
+		return Err!(Request(Unauthorized("Apple id_token key is not an RSA signing key.")));
+	}
+
+	DecodingKey::from_rsa_components(&jwk.n, &jwk.e)
+		.map(Some)
+		.map_err(|e| err!(Request(Unauthorized("Apple id_token signing key is invalid: {e}"))))
+}
+
+fn apple_jwks_contains_kid(jwks: &AppleJwks, kid: &str) -> bool {
+	jwks.keys.iter().any(|key| key.kid == kid)
+}
+
+fn cached_apple_jwks_is_fresh(cached: &CachedAppleJwks) -> bool {
+	cached.fetched_at.elapsed() < APPLE_JWKS_CACHE_TTL
+}
+
+fn apple_id_token_validation(provider: &Provider) -> Validation {
+	let audiences = apple_native_audiences(provider)
+		.into_iter()
+		.collect::<Vec<_>>();
+	let issuers = [APPLE_ISSUER.to_owned()];
+	let required_spec_claims: Vec<_> = ["iss", "aud", "exp", "sub"].into();
+	let mut validation = Validation::new(Algorithm::RS256);
+
+	validation.set_audience(&audiences);
+	validation.set_issuer(&issuers);
+	validation.set_required_spec_claims(&required_spec_claims);
+
+	validation
+}
+
+fn native_apple_provider_id(
+	requested_provider_id: Option<&str>,
+	identity_providers: &BTreeMap<String, IdentityProvider>,
+) -> Result<String> {
+	if let Some(provider_id) = requested_provider_id {
+		return Ok(provider_id.to_owned());
+	}
+
+	let mut apple_providers = identity_providers
+		.values()
+		.filter(|provider| provider.brand == "appleoidc")
+		.map(IdentityProvider::id);
+	let Some(provider_id) = apple_providers.next() else {
+		return Err!(Request(NotFound(
+			"No AppleOIDC identity provider is configured for native Apple login."
+		)));
+	};
+
+	if apple_providers.next().is_some() {
+		return Err!(Request(InvalidParam(
+			"Native Apple login requires provider_id when multiple AppleOIDC identity providers \
+			 are configured."
+		)));
+	}
+
+	Ok(provider_id.to_owned())
+}
+
+async fn fetch_apple_jwks(services: &Services) -> Result<AppleJwks> {
+	services
+		.client
+		.oauth
+		.get(APPLE_JWKS_URL)
+		.send()
+		.await?
+		.error_for_status()?
+		.json()
+		.await
+		.map_err(Into::into)
+}
+
+async fn cached_apple_jwks(services: &Services) -> Result<AppleJwks> {
+	let cache = APPLE_JWKS_CACHE.get_or_init(|| RwLock::new(None));
+
+	{
+		let cached = cache.read().await;
+		if let Some(cached) = cached
+			.as_ref()
+			.filter(|cached| cached_apple_jwks_is_fresh(cached))
+		{
+			return Ok(cached.jwks.clone());
+		}
+	}
+
+	let mut cached = cache.write().await;
+	if let Some(cached) = cached
+		.as_ref()
+		.filter(|cached| cached_apple_jwks_is_fresh(cached))
+	{
+		return Ok(cached.jwks.clone());
+	}
+
+	let jwks = fetch_apple_jwks(services).await?;
+	*cached = Some(CachedAppleJwks {
+		jwks: jwks.clone(),
+		fetched_at: Instant::now(),
+	});
+
+	Ok(jwks)
+}
+
+async fn refresh_apple_jwks_from_cache(
+	cache: &RwLock<Option<CachedAppleJwks>>,
+	kid: &str,
+	fetch: impl Future<Output = Result<AppleJwks>>,
+) -> Result<AppleJwks> {
+	let mut cached = cache.write().await;
+
+	if let Some(cached) = cached
+		.as_ref()
+		.filter(|cached| cached_apple_jwks_is_fresh(cached))
+		.filter(|cached| apple_jwks_contains_kid(&cached.jwks, kid))
+	{
+		return Ok(cached.jwks.clone());
+	}
+
+	let jwks = fetch.await?;
+	*cached = Some(CachedAppleJwks {
+		jwks: jwks.clone(),
+		fetched_at: Instant::now(),
+	});
+
+	Ok(jwks)
+}
+
+async fn refresh_apple_jwks(services: &Services, kid: &str) -> Result<AppleJwks> {
+	let cache = APPLE_JWKS_CACHE.get_or_init(|| RwLock::new(None));
+
+	refresh_apple_jwks_from_cache(cache, kid, fetch_apple_jwks(services)).await
+}
+
+async fn validate_apple_identity_token(
+	services: &Services,
+	provider: &Provider,
+	identity_token: &str,
+) -> Result<AppleIdTokenClaims> {
+	let header = apple_id_token_header(identity_token)?;
+	let kid = header
+		.kid
+		.as_deref()
+		.expect("apple_id_token_header validates kid");
+	let jwks = cached_apple_jwks(services).await?;
+	let decoding_key = if let Some(decoding_key) = apple_decoding_key_for_kid(kid, &jwks)? {
+		decoding_key
+	} else {
+		let jwks = refresh_apple_jwks(services, kid).await?;
+		apple_decoding_key_for_kid(kid, &jwks)?
+			.ok_or_else(|| err!(Request(Unauthorized("Apple id_token key id is not trusted."))))?
+	};
+	let validation = apple_id_token_validation(provider);
+
+	decode::<AppleIdTokenClaims>(identity_token, &decoding_key, &validation)
+		.map(|decoded| decoded.claims)
+		.map_err(|e| err!(Request(Unauthorized("Apple id_token is invalid: {e}"))))
+}
+
+#[tracing::instrument(name = "native_apple_login", level = "info", skip_all)]
+pub(crate) async fn native_apple_login_route(
+	State(services): State<crate::State>,
+	Json(body): Json<NativeAppleLoginRequest>,
+) -> Result<impl IntoResponse> {
+	let provider_id = native_apple_provider_id(
+		body.provider_id.as_deref(),
+		&services.config.identity_provider,
+	)?;
+	let provider = services.oauth.providers.get(&provider_id).await?;
+
+	if provider.brand != "appleoidc" {
+		return Err!(Request(InvalidParam(
+			"Native Apple login requires an AppleOIDC identity provider."
+		)));
+	}
+
+	let claims =
+		validate_apple_identity_token(&services, &provider, &body.identity_token).await?;
+	let userinfo =
+		apple_userinfo_from_validated_claims(&provider, claims, body.nonce.as_deref())?;
+	let sess_id = utils::random_string(SESSION_ID_LENGTH);
+	let session = Session {
+		idp_id: Some(provider.id().to_owned()),
+		sess_id: Some(sess_id),
+		id_token: Some(body.identity_token),
+		..Default::default()
+	};
+
+	if let Some(authorization_code) = body.authorization_code.as_deref() {
+		debug_info!(
+			code_len = authorization_code.len(),
+			provider = provider.id(),
+			"Received native Apple authorization code alongside id_token.",
+		);
+	}
+
+	let (user_id, _) = complete_sso_session(&services, &provider, session, userinfo).await?;
+	let login_token = utils::random_string(TOKEN_LENGTH);
+	let expires_in_ms = services
+		.users
+		.create_login_token(&user_id, &login_token);
+
+	Ok((StatusCode::OK, Json(NativeAppleLoginResponse { login_token, expires_in_ms })))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	use serde_json::json;
+
+	use super::*;
+
+	fn apple_provider_with_native_clients(native_client_ids: &[&str]) -> Provider {
+		Provider {
+			brand: "appleoidc".to_owned(),
+			client_id: "chat.mindroom.matrix.apple".to_owned(),
+			client_secret: None,
+			client_secret_file: None,
+			issuer_url: Some(
+				"https://appleid.apple.com"
+					.parse()
+					.expect("issuer URL"),
+			),
+			callback_url: None,
+			default: false,
+			name: Some("Apple".to_owned()),
+			icon: None,
+			scope: BTreeSet::new(),
+			userid_claims: BTreeSet::new(),
+			trusted: false,
+			unique_id_fallbacks: true,
+			registration: true,
+			base_path: None,
+			discovery_url: None,
+			authorization_url: None,
+			token_url: None,
+			revocation_url: None,
+			introspection_url: None,
+			userinfo_url: None,
+			discovery: true,
+			grant_session_duration: Some(300),
+			check_cookie: true,
+			forward_action_prompt: false,
+			extra_authorization_parameters: BTreeMap::new(),
+			native_client_ids: native_client_ids
+				.iter()
+				.map(ToString::to_string)
+				.collect::<BTreeSet<_>>(),
+		}
+	}
+
+	fn apple_claims(audience: &str) -> AppleIdTokenClaims {
+		AppleIdTokenClaims {
+			iss: "https://appleid.apple.com".to_owned(),
+			aud: audience.to_owned(),
+			exp: 4_102_444_800,
+			sub: "apple-user-123".to_owned(),
+			email: Some("alice@example.com".to_owned()),
+			name: None,
+			given_name: None,
+			family_name: None,
+			nonce: Some(sha256_hex("native-nonce")),
+		}
+	}
+
+	fn apple_session_with_claims(claims: &serde_json::Value) -> Session {
+		let payload = b64.encode(serde_json::to_vec(claims).expect("serialize claims"));
+
+		Session {
+			id_token: Some(format!("header.{payload}.signature")),
+			..Default::default()
+		}
+	}
+
+	fn apple_test_jwk(kid: &str) -> AppleJwk {
+		AppleJwk {
+			alg: Some("RS256".to_owned()),
+			e: "AQAB".to_owned(),
+			kid: kid.to_owned(),
+			kty: "RSA".to_owned(),
+			n: "yRE6rHuNR0QbHO3H3Kt2pOKGVhQqGZXInOduQNxXzuKlvQTLUTv4l4sggh5_CYYi_cvI-SXVT9kPWSKXxJXBXd_4LkvcPuUakBoAkfh-eiFVMh2VrUyWyj3MFl0HTVF9KwRXLAcwkREiS3npThHRyIxuy0ZMeZfxVL5arMhw1SRELB8HoGfG_AtH89BIE9jDBHZ9dLelK9a184zAf8LwoPLxvJb3Il5nncqPcSfKDDodMFBIMc4lQzDKL5gvmiXLXB1AGLm8KBjfE8s3L5xqi-yUod-j8MtvIj812dkS4QMiRVN_by2h3ZY8LYVGrqZXZTcgn2ujn8uKjXLZVD5TdQ".to_owned(),
+		}
+	}
+
+	fn apple_test_jwks(kids: &[&str]) -> AppleJwks {
+		AppleJwks {
+			keys: kids
+				.iter()
+				.map(|kid| apple_test_jwk(kid))
+				.collect(),
+		}
+	}
+
+	#[test]
+	fn apple_decoding_key_lookup_allows_refresh_when_kid_is_unknown() {
+		let cached_jwks = apple_test_jwks(&["cached-key"]);
+		let fresh_jwks = apple_test_jwks(&["rotated-key"]);
+
+		assert!(
+			apple_decoding_key_for_kid("rotated-key", &cached_jwks)
+				.expect("unknown kid should not be a hard failure before refresh")
+				.is_none()
+		);
+		assert!(
+			apple_decoding_key_for_kid("rotated-key", &fresh_jwks)
+				.expect("refreshed JWKS should resolve rotated kid")
+				.is_some()
+		);
+	}
+
+	#[tokio::test]
+	async fn refresh_apple_jwks_reuses_cache_when_waited_refresh_contains_kid() {
+		let cache = RwLock::new(Some(CachedAppleJwks {
+			jwks: apple_test_jwks(&["rotated-key"]),
+			fetched_at: Instant::now(),
+		}));
+		let fetches = AtomicUsize::new(0);
+
+		let jwks = refresh_apple_jwks_from_cache(&cache, "rotated-key", async {
+			fetches.fetch_add(1, Ordering::SeqCst);
+			Ok(apple_test_jwks(&["unused-network-key"]))
+		})
+		.await
+		.expect("cached key should be reused without fetching");
+
+		assert!(apple_jwks_contains_kid(&jwks, "rotated-key"));
+		assert_eq!(fetches.load(Ordering::SeqCst), 0);
+	}
+
+	#[tokio::test]
+	async fn refresh_apple_jwks_fetches_when_locked_cache_still_misses_kid() {
+		let cache = RwLock::new(Some(CachedAppleJwks {
+			jwks: apple_test_jwks(&["cached-key"]),
+			fetched_at: Instant::now(),
+		}));
+		let fetches = AtomicUsize::new(0);
+
+		let jwks = refresh_apple_jwks_from_cache(&cache, "rotated-key", async {
+			fetches.fetch_add(1, Ordering::SeqCst);
+			Ok(apple_test_jwks(&["rotated-key"]))
+		})
+		.await
+		.expect("missing key should trigger one refresh");
+
+		assert!(apple_jwks_contains_kid(&jwks, "rotated-key"));
+		assert_eq!(fetches.load(Ordering::SeqCst), 1);
+
+		let cached = cache.read().await;
+		let cached = cached
+			.as_ref()
+			.expect("refreshed JWKS should be cached");
+		assert!(apple_jwks_contains_kid(&cached.jwks, "rotated-key"));
+	}
+
+	#[test]
+	fn decode_userinfo_from_id_token_extracts_expected_claims() {
+		let session = apple_session_with_claims(&json!({
+			"sub": "apple-user-123",
+			"email": "alice@example.com",
+			"name": "Alice Example",
+			"given_name": "Alice",
+			"family_name": "Example"
+		}));
+
+		let userinfo =
+			decode_userinfo_from_id_token(&session).expect("decode Apple id_token claims");
+
+		assert_eq!(userinfo.sub, "apple-user-123");
+		assert_eq!(userinfo.email.as_deref(), Some("alice@example.com"));
+		assert_eq!(userinfo.preferred_username.as_deref(), Some("alice"));
+		assert_eq!(userinfo.username.as_deref(), Some("alice"));
+		assert_eq!(userinfo.name.as_deref(), Some("Alice Example"));
+		assert_eq!(userinfo.given_name.as_deref(), Some("Alice"));
+		assert_eq!(userinfo.family_name.as_deref(), Some("Example"));
+	}
+
+	#[test]
+	fn decode_userinfo_from_id_token_requires_sub_claim() {
+		let session = apple_session_with_claims(&json!({
+			"email": "alice@example.com"
+		}));
+
+		let error =
+			decode_userinfo_from_id_token(&session).expect_err("missing sub claim should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("sub claim"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn decode_userinfo_from_id_token_requires_id_token() {
+		let session = Session::default();
+
+		let error =
+			decode_userinfo_from_id_token(&session).expect_err("missing id_token should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("Missing Apple id_token"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn decode_userinfo_from_id_token_rejects_invalid_payload() {
+		let session = Session {
+			id_token: Some("header.!.signature".to_owned()),
+			..Default::default()
+		};
+
+		let error = decode_userinfo_from_id_token(&session)
+			.expect_err("invalid id_token payload should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("invalid base64"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_claims_accept_configured_bundle_audience() {
+		let provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		let claims = apple_claims("chat.mindroom.app");
+
+		let userinfo =
+			apple_userinfo_from_validated_claims(&provider, claims, Some("native-nonce"))
+				.expect("configured native bundle audience should be accepted");
+
+		assert_eq!(userinfo.sub, "apple-user-123");
+		assert_eq!(userinfo.email.as_deref(), Some("alice@example.com"));
+		assert_eq!(userinfo.preferred_username.as_deref(), Some("alice"));
+	}
+
+	#[test]
+	fn native_apple_claims_accept_web_services_audience_for_compatibility() {
+		let provider = apple_provider_with_native_clients(&[]);
+		let claims = apple_claims("chat.mindroom.matrix.apple");
+
+		apple_userinfo_from_validated_claims(&provider, claims, Some("native-nonce"))
+			.expect("provider client_id audience should remain accepted");
+	}
+
+	#[test]
+	fn native_apple_claims_reject_unconfigured_audience() {
+		let provider = apple_provider_with_native_clients(&[]);
+		let claims = apple_claims("chat.mindroom.app");
+
+		let error = apple_userinfo_from_validated_claims(&provider, claims, Some("native-nonce"))
+			.expect_err("unconfigured native bundle audience should be rejected");
+
+		let message = format!("{error}");
+		assert!(message.contains("audience"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_claims_reject_wrong_issuer() {
+		let provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		let mut claims = apple_claims("chat.mindroom.app");
+		claims.iss = "https://example.com".to_owned();
+
+		let error = apple_userinfo_from_validated_claims(&provider, claims, Some("native-nonce"))
+			.expect_err("wrong issuer should be rejected");
+
+		let message = format!("{error}");
+		assert!(message.contains("issuer"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_claims_reject_nonce_mismatch() {
+		let provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		let claims = apple_claims("chat.mindroom.app");
+
+		let error =
+			apple_userinfo_from_validated_claims(&provider, claims, Some("different-nonce"))
+				.expect_err("nonce mismatch should be rejected");
+
+		let message = format!("{error}");
+		assert!(message.contains("nonce"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_claims_reject_token_nonce_without_request_nonce() {
+		let provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		let claims = apple_claims("chat.mindroom.app");
+
+		let error = apple_userinfo_from_validated_claims(&provider, claims, None)
+			.expect_err("token nonce without request nonce should be rejected");
+
+		let message = format!("{error}");
+		assert!(message.contains("nonce"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_claims_reject_request_nonce_without_token_nonce() {
+		let provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		let mut claims = apple_claims("chat.mindroom.app");
+		claims.nonce = None;
+
+		let error = apple_userinfo_from_validated_claims(&provider, claims, Some("native-nonce"))
+			.expect_err("request nonce without token nonce should be rejected");
+
+		let message = format!("{error}");
+		assert!(message.contains("nonce"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_provider_id_uses_explicit_provider_id() {
+		let providers =
+			[("apple".to_owned(), apple_provider_with_native_clients(&["chat.mindroom.app"]))]
+				.into();
+
+		assert_eq!(
+			native_apple_provider_id(Some("chat.mindroom.matrix.apple"), &providers)
+				.expect("explicit provider id should pass through"),
+			"chat.mindroom.matrix.apple"
+		);
+	}
+
+	#[test]
+	fn native_apple_provider_id_falls_back_to_single_apple_provider() {
+		let providers =
+			[("apple".to_owned(), apple_provider_with_native_clients(&["chat.mindroom.app"]))]
+				.into();
+
+		assert_eq!(
+			native_apple_provider_id(None, &providers)
+				.expect("single Apple provider should be selected"),
+			"chat.mindroom.matrix.apple"
+		);
+	}
+
+	#[test]
+	fn native_apple_provider_id_rejects_missing_apple_provider() {
+		let mut provider = apple_provider_with_native_clients(&["chat.mindroom.app"]);
+		provider.brand = "google".to_owned();
+		let providers = [("google".to_owned(), provider)].into();
+
+		let error = native_apple_provider_id(None, &providers)
+			.expect_err("missing Apple provider should fail");
+
+		let message = format!("{error}");
+		assert!(message.contains("AppleOIDC"), "unexpected error: {message}");
+	}
+
+	#[test]
+	fn native_apple_provider_id_rejects_ambiguous_apple_providers() {
+		let mut second_provider = apple_provider_with_native_clients(&["chat.mindroom.dev"]);
+		second_provider.client_id = "chat.mindroom.matrix.apple.dev".to_owned();
+		let providers = [
+			("apple".to_owned(), apple_provider_with_native_clients(&["chat.mindroom.app"])),
+			("apple-dev".to_owned(), second_provider),
+		]
+		.into();
+
+		let error = native_apple_provider_id(None, &providers)
+			.expect_err("multiple Apple providers should require provider_id");
+
+		let message = format!("{error}");
+		assert!(message.contains("provider_id"), "unexpected error: {message}");
+	}
+}

--- a/src/api/client/sync/mindroom_edits.rs
+++ b/src/api/client/sync/mindroom_edits.rs
@@ -1,0 +1,325 @@
+use std::collections::{HashMap, HashSet};
+
+use ruma::{OwnedEventId, OwnedUserId};
+use tuwunel_core::{
+	PduCount,
+	matrix::{
+		event::{Event, ExtractRelatesToInfo},
+		pdu::PduEvent,
+	},
+};
+
+/// Collapse multiple m.replace relation events targeting the same event from
+/// the same sender into just the latest one by timeline order (`PduCount`),
+/// with `event_id` as a deterministic tie-break.
+///
+/// Non-replace events are always kept. For each `(target_event_id, sender)`
+/// group with multiple replacements in the batch, only the newest replacement
+/// is retained.
+pub(super) fn collapse_superseded_edits(
+	events: Vec<(PduCount, PduEvent)>,
+) -> Vec<(PduCount, PduEvent)> {
+	let mut replace_events_by_target_sender: HashMap<(OwnedEventId, OwnedUserId), Vec<usize>> =
+		HashMap::new();
+
+	for (idx, (_, pdu)) in events.iter().enumerate() {
+		if let Ok(content) = pdu.get_content::<ExtractRelatesToInfo>()
+			&& content.relates_to.rel_type == "m.replace"
+		{
+			replace_events_by_target_sender
+				.entry((content.relates_to.event_id.clone(), pdu.sender.clone()))
+				.or_default()
+				.push(idx);
+		}
+	}
+
+	if replace_events_by_target_sender
+		.values()
+		.all(|indices| indices.len() <= 1)
+	{
+		return events;
+	}
+
+	let mut remove_indices: HashSet<usize> = HashSet::new();
+	for indices in replace_events_by_target_sender.values() {
+		if indices.len() <= 1 {
+			continue;
+		}
+
+		let best_idx = *indices
+			.iter()
+			.max_by(|&&a, &&b| {
+				let (count_a, pdu_a) = &events[a];
+				let (count_b, pdu_b) = &events[b];
+				count_a
+					.cmp(count_b)
+					.then_with(|| pdu_a.event_id.cmp(&pdu_b.event_id))
+			})
+			.expect("indices is non-empty");
+
+		for &idx in indices {
+			if idx != best_idx {
+				remove_indices.insert(idx);
+			}
+		}
+	}
+
+	events
+		.into_iter()
+		.enumerate()
+		.filter(|(idx, _)| !remove_indices.contains(idx))
+		.map(|(_, item)| item)
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use ruma::{EventId, OwnedRoomId, OwnedUserId, UInt};
+	use serde_json::value::RawValue;
+	use tuwunel_core::matrix::pdu::{EventHash, PduCount, PduEvent};
+
+	use super::collapse_superseded_edits;
+
+	fn make_pdu(event_id: &str, ts: u64, replace_target: Option<&str>) -> (PduCount, PduEvent) {
+		make_pdu_with_sender(event_id, ts, replace_target, "@user:example.com")
+	}
+
+	fn make_pdu_with_sender(
+		event_id: &str,
+		ts: u64,
+		replace_target: Option<&str>,
+		sender: &str,
+	) -> (PduCount, PduEvent) {
+		make_pdu_with_count_and_sender(event_id, ts, ts, replace_target, sender)
+	}
+
+	fn make_pdu_with_count_and_sender(
+		event_id: &str,
+		count: u64,
+		ts: u64,
+		replace_target: Option<&str>,
+		sender: &str,
+	) -> (PduCount, PduEvent) {
+		let content = replace_target.map_or_else(
+			|| r#"{"body":"hello"}"#.to_owned(),
+			|target| {
+				format!(
+					r#"{{"body":"edited","m.relates_to":{{"rel_type":"m.replace","event_id":"{target}"}}}}"#
+				)
+			},
+		);
+
+		let pdu = PduEvent {
+			kind: ruma::events::TimelineEventType::RoomMessage,
+			content: RawValue::from_string(content)
+				.expect("valid JSON")
+				.into(),
+			event_id: EventId::parse(event_id).expect("valid event_id"),
+			room_id: OwnedRoomId::try_from("!test:example.com").expect("valid room_id"),
+			sender: OwnedUserId::try_from(sender).expect("valid user_id"),
+			state_key: None,
+			redacts: None,
+			prev_events: Default::default(),
+			auth_events: Default::default(),
+			origin_server_ts: UInt::try_from(ts).expect("valid ts"),
+			depth: UInt::try_from(1_u64).expect("valid depth"),
+			hashes: EventHash::default(),
+			origin: None,
+			unsigned: None,
+		};
+
+		(PduCount::Normal(count), pdu)
+	}
+
+	#[test]
+	fn collapse_no_edits() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$msg2:example.com", 2000, None),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 2);
+	}
+
+	#[test]
+	fn collapse_single_edit_kept() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$edit1:example.com", 2000, Some("$msg1:example.com")),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 2);
+		assert_eq!(result[1].1.event_id.as_str(), "$edit1:example.com");
+	}
+
+	#[test]
+	fn collapse_multiple_edits_keeps_latest() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$edit1:example.com", 2000, Some("$msg1:example.com")),
+			make_pdu("$edit2:example.com", 3000, Some("$msg1:example.com")),
+			make_pdu("$edit3:example.com", 4000, Some("$msg1:example.com")),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 2);
+		assert_eq!(result[0].1.event_id.as_str(), "$msg1:example.com");
+		assert_eq!(result[1].1.event_id.as_str(), "$edit3:example.com");
+	}
+
+	#[test]
+	fn collapse_multiple_targets_independent() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$edit1a:example.com", 2000, Some("$msg1:example.com")),
+			make_pdu("$edit1b:example.com", 3000, Some("$msg1:example.com")),
+			make_pdu("$msg2:example.com", 4000, None),
+			make_pdu("$edit2a:example.com", 5000, Some("$msg2:example.com")),
+			make_pdu("$edit2b:example.com", 6000, Some("$msg2:example.com")),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 4);
+
+		let event_ids: Vec<&str> = result
+			.iter()
+			.map(|(_, pdu)| pdu.event_id.as_str())
+			.collect();
+		assert!(event_ids.contains(&"$msg1:example.com"));
+		assert!(event_ids.contains(&"$edit1b:example.com"));
+		assert!(event_ids.contains(&"$msg2:example.com"));
+		assert!(event_ids.contains(&"$edit2b:example.com"));
+		assert!(!event_ids.contains(&"$edit1a:example.com"));
+		assert!(!event_ids.contains(&"$edit2a:example.com"));
+	}
+
+	#[test]
+	fn collapse_preserves_order() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$edit1:example.com", 2000, Some("$msg1:example.com")),
+			make_pdu("$msg2:example.com", 3000, None),
+			make_pdu("$edit2:example.com", 4000, Some("$msg1:example.com")),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 3);
+		assert_eq!(result[0].1.event_id.as_str(), "$msg1:example.com");
+		assert_eq!(result[1].1.event_id.as_str(), "$msg2:example.com");
+		assert_eq!(result[2].1.event_id.as_str(), "$edit2:example.com");
+	}
+
+	#[test]
+	fn collapse_same_ts_uses_event_id_tiebreak() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu("$editA:example.com", 2000, Some("$msg1:example.com")),
+			make_pdu("$editB:example.com", 2000, Some("$msg1:example.com")),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 2);
+		assert_eq!(result[1].1.event_id.as_str(), "$editB:example.com");
+	}
+
+	#[test]
+	fn collapse_prefers_timeline_order_over_timestamp() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu_with_count_and_sender(
+				"$edit_old_ts_newer_count:example.com",
+				3000,
+				1000,
+				Some("$msg1:example.com"),
+				"@user:example.com",
+			),
+			make_pdu_with_count_and_sender(
+				"$edit_new_ts_older_count:example.com",
+				2000,
+				4000,
+				Some("$msg1:example.com"),
+				"@user:example.com",
+			),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 2);
+		assert_eq!(result[1].1.event_id.as_str(), "$edit_old_ts_newer_count:example.com");
+	}
+
+	#[test]
+	fn collapse_groups_edits_by_target_and_sender() {
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_pdu_with_sender(
+				"$edit_a1:example.com",
+				2000,
+				Some("$msg1:example.com"),
+				"@alice:example.com",
+			),
+			make_pdu_with_sender(
+				"$edit_a2:example.com",
+				3000,
+				Some("$msg1:example.com"),
+				"@alice:example.com",
+			),
+			make_pdu_with_sender(
+				"$edit_b1:example.com",
+				4000,
+				Some("$msg1:example.com"),
+				"@bob:example.com",
+			),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 3);
+
+		let event_ids: Vec<&str> = result
+			.iter()
+			.map(|(_, pdu)| pdu.event_id.as_str())
+			.collect();
+		assert!(event_ids.contains(&"$msg1:example.com"));
+		assert!(event_ids.contains(&"$edit_a2:example.com"));
+		assert!(event_ids.contains(&"$edit_b1:example.com"));
+		assert!(!event_ids.contains(&"$edit_a1:example.com"));
+	}
+
+	#[test]
+	fn collapse_non_replace_relations_untouched() {
+		let make_reply = |event_id: &str, ts: u64, target: &str| -> (PduCount, PduEvent) {
+			let content = format!(
+				r#"{{"body":"reply","m.relates_to":{{"rel_type":"m.thread","event_id":"{target}"}}}}"#
+			);
+			let pdu = PduEvent {
+				kind: ruma::events::TimelineEventType::RoomMessage,
+				content: RawValue::from_string(content)
+					.expect("valid JSON")
+					.into(),
+				event_id: EventId::parse(event_id).expect("valid event_id"),
+				room_id: OwnedRoomId::try_from("!test:example.com").expect("valid room_id"),
+				sender: OwnedUserId::try_from("@user:example.com").expect("valid user_id"),
+				state_key: None,
+				redacts: None,
+				prev_events: Default::default(),
+				auth_events: Default::default(),
+				origin_server_ts: UInt::try_from(ts).expect("valid ts"),
+				depth: UInt::try_from(1_u64).expect("valid depth"),
+				hashes: EventHash::default(),
+				origin: None,
+				unsigned: None,
+			};
+			(PduCount::Normal(ts), pdu)
+		};
+
+		let events = vec![
+			make_pdu("$msg1:example.com", 1000, None),
+			make_reply("$thread1:example.com", 2000, "$msg1:example.com"),
+			make_reply("$thread2:example.com", 3000, "$msg1:example.com"),
+		];
+
+		let result = collapse_superseded_edits(events);
+		assert_eq!(result.len(), 3);
+	}
+}

--- a/src/api/client/sync/mod.rs
+++ b/src/api/client/sync/mod.rs
@@ -1,3 +1,4 @@
+mod mindroom_edits;
 mod v3;
 mod v5;
 
@@ -13,6 +14,7 @@ use tuwunel_core::{
 };
 use tuwunel_service::Services;
 
+use self::mindroom_edits::collapse_superseded_edits;
 pub(crate) use self::{
 	v3::{calculate_heroes, sync_events_route},
 	v5::sync_events_v5_route,
@@ -57,6 +59,17 @@ async fn load_timeline(
 	// They /sync response doesn't always return all messages, so we say the output
 	// is limited unless there are events in non_timeline_pdus
 	let limited = non_timeline_pdus.next().await.is_some();
+
+	// Collapse superseded m.replace events when enabled
+	let timeline_pdus = if services
+		.server
+		.config
+		.mindroom_compact_edits_enabled
+	{
+		collapse_superseded_edits(timeline_pdus)
+	} else {
+		timeline_pdus
+	};
 
 	Ok((timeline_pdus, limited, last_timeline_count))
 }

--- a/src/api/oidc/account/account_deactivate.rs
+++ b/src/api/oidc/account/account_deactivate.rs
@@ -1,7 +1,7 @@
 use const_str::format as const_format;
 use ruma::UserId;
 use tuwunel_core::{Result, info, utils::html::escape as html_escape};
-use tuwunel_service::Services;
+use tuwunel_service::{Services, users::DeactivationReason};
 
 use super::{ACCOUNT_HEAD, url_encode};
 
@@ -28,7 +28,10 @@ pub(super) async fn account_deactivate_execute_html(
 	services: &Services,
 	user_id: &UserId,
 ) -> Result<String> {
-	services.users.deactivate_account(user_id).await?;
+	services
+		.users
+		.deactivate_account(user_id, DeactivationReason::SelfService)
+		.await?;
 
 	info!(?user_id, "Account deactivated via account management page");
 

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -57,6 +57,10 @@ fn register_client_auth_routes(router: Router<State>) -> Router<State> {
 		.ruma_route(&client::get_login_types_route)
 		.ruma_route(&client::login_route)
 		.ruma_route(&client::login_token_route)
+		.route(
+			"/_matrix/client/unstable/org.mindroom.login/apple",
+			post(client::native_apple_login_route),
+		)
 		.ruma_route(&client::refresh_token_route)
 		.ruma_route(&client::sso_login_route)
 		.ruma_route(&client::sso_login_with_provider_route)

--- a/src/api/router/auth/uiaa.rs
+++ b/src/api/router/auth/uiaa.rs
@@ -7,7 +7,7 @@ use ruma::{
 };
 use serde_json::{json, value::to_raw_value};
 use tuwunel_core::{
-	Err, Error, Result, err, is_equal_to, utils,
+	Err, Error, Result, err, utils,
 	utils::{
 		OptionExt,
 		future::{OptionFutureExt, TryExtExt},
@@ -23,20 +23,34 @@ where
 {
 	let sender_user = body.sender_user.as_deref();
 
+	if let Some(sender_user) = sender_user {
+		services
+			.users
+			.maybe_repair_legacy_sso_origin(sender_user)
+			.await;
+	}
+
+	let sender_uses_sso = if let Some(sender_user) = sender_user {
+		services
+			.users
+			.origin(sender_user)
+			.await
+			.is_ok_and(|origin| origin == "sso")
+	} else {
+		false
+	};
+
 	let password_flow = [AuthType::Password];
-	let user_origin = sender_user
-		.map_async(|sender_user| services.users.origin(sender_user).ok())
-		.unwrap_or(None)
-		.await;
-	let has_password = sender_user
-		.map_async(|sender_user| {
-			services
-				.users
-				.has_password(sender_user)
-				.unwrap_or(false)
-		})
-		.unwrap_or(false)
-		.await || (cfg!(feature = "ldap") && services.config.ldap.enable);
+	let has_password = !sender_uses_sso
+		&& (sender_user
+			.map_async(|sender_user| {
+				services
+					.users
+					.has_password(sender_user)
+					.unwrap_or(false)
+			})
+			.unwrap_or(false)
+			.await || (cfg!(feature = "ldap") && services.config.ldap.enable));
 
 	// Determine the exact IdP to bind to the UIAA session.
 	//
@@ -51,37 +65,38 @@ where
 	//     configured → routing is still unambiguous.
 	//  3. Otherwise: cannot determine provider → do NOT advertise m.login.sso.
 	let sso_flow = [AuthType::Sso];
-	let bound_idp: Option<String> = sender_user
-		.map_async(async |sender_user| {
-			body.sender_device
-				.as_deref()
-				.map_async(async |device_id| {
-					services
-						.users
-						.get_oidc_device_idp(sender_user, device_id)
-						.await
-						.filter(|s| !s.is_empty())
-				})
-				.await
-				.flatten()
-				.or_else(|| {
-					let use_sso = user_origin
-						.as_deref()
-						.is_some_and(is_equal_to!("sso"))
-						&& services.config.identity_provider.len() == 1;
-
-					use_sso
-						.then(|| services.oauth.providers.get_default_id())
-						.flatten()
-				})
-		})
-		.await
-		.flatten();
+	let device_bound_idp: Option<String> = if sender_uses_sso {
+		sender_user
+			.map_async(async |sender_user| {
+				body.sender_device
+					.as_deref()
+					.map_async(async |device_id| {
+						services
+							.users
+							.get_oidc_device_idp(sender_user, device_id)
+							.await
+							.filter(|s| !s.is_empty())
+					})
+					.await
+					.flatten()
+			})
+			.await
+			.flatten()
+	} else {
+		None
+	};
+	let bound_idp = select_bound_sso_idp(
+		sender_uses_sso,
+		device_bound_idp,
+		services.config.identity_provider.len(),
+		services.oauth.providers.get_default_id(),
+	);
 
 	let has_sso = bound_idp.is_some();
 
+	// NOTE: JWT fallback/web is not implemented for UIAA.
+	let has_jwt = false;
 	let jwt_flow = [AuthType::Jwt];
-	let has_jwt = services.config.jwt.enable;
 
 	let mut uiaainfo = UiaaInfo {
 		flows: has_password
@@ -108,6 +123,12 @@ where
 		.transpose()?
 	{
 		| Some(AuthData::Jwt(Jwt { ref token, .. })) => {
+			if sender_uses_sso {
+				return Err!(Request(
+					Forbidden("JWT UIAA is not allowed for SSO-origin users.",)
+				));
+			}
+
 			let sender_user = jwt::validate_user(services, token)?;
 			if !services.users.exists(&sender_user).await {
 				return Err!(Request(NotFound("User {sender_user} is not registered.")));
@@ -149,12 +170,7 @@ where
 				// the SSO fallback page can route re-authentication to the
 				// correct provider without any further heuristic lookups.
 				if let Some(ref idp) = bound_idp {
-					uiaainfo.params = to_raw_value(&json!({
-						"m.login.sso": {
-							"identity_providers": [{"id": idp}]
-						}
-					}))
-					.ok();
+					bind_sso_identity_provider(&mut uiaainfo, idp);
 				}
 
 				services
@@ -165,5 +181,90 @@ where
 			},
 			| _ => Err!(Request(NotJson("JSON body is not valid"))),
 		},
+	}
+}
+
+fn select_bound_sso_idp(
+	sender_uses_sso: bool,
+	device_idp: Option<String>,
+	identity_provider_count: usize,
+	default_idp: Option<String>,
+) -> Option<String> {
+	if !sender_uses_sso {
+		return None;
+	}
+
+	device_idp
+		.filter(|idp| !idp.is_empty())
+		.or_else(|| {
+			(identity_provider_count == 1)
+				.then_some(default_idp)
+				.flatten()
+		})
+}
+
+fn bind_sso_identity_provider(uiaainfo: &mut UiaaInfo, idp: &str) {
+	uiaainfo.params = to_raw_value(&json!({
+		"m.login.sso": {
+			"identity_providers": [{"id": idp}]
+		}
+	}))
+	.ok();
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json::Value as JsonValue;
+
+	use super::*;
+
+	#[test]
+	fn sso_idp_binding_prefers_request_device_idp() {
+		let selected =
+			select_bound_sso_idp(true, Some("apple".to_owned()), 1, Some("google".to_owned()));
+
+		assert_eq!(selected.as_deref(), Some("apple"));
+	}
+
+	#[test]
+	fn sso_idp_binding_falls_back_to_single_default_provider() {
+		let selected = select_bound_sso_idp(true, None, 1, Some("default".to_owned()));
+
+		assert_eq!(selected.as_deref(), Some("default"));
+	}
+
+	#[test]
+	fn sso_idp_binding_rejects_ambiguous_multi_provider_fallback() {
+		let selected = select_bound_sso_idp(true, None, 2, Some("default".to_owned()));
+
+		assert_eq!(selected, None);
+	}
+
+	#[test]
+	fn sso_idp_binding_is_not_available_for_password_origin_users() {
+		let selected =
+			select_bound_sso_idp(false, Some("apple".to_owned()), 1, Some("default".to_owned()));
+
+		assert_eq!(selected, None);
+	}
+
+	#[test]
+	fn bound_sso_idp_is_serialized_into_uiaa_params() {
+		let mut uiaainfo = UiaaInfo::default();
+
+		bind_sso_identity_provider(&mut uiaainfo, "apple");
+
+		let params: JsonValue = serde_json::from_str(
+			uiaainfo
+				.params
+				.as_ref()
+				.expect("params should be populated")
+				.get(),
+		)
+		.expect("valid params JSON");
+		assert_eq!(
+			params["m.login.sso"]["identity_providers"][0]["id"],
+			JsonValue::String("apple".to_owned()),
+		);
 	}
 }

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -203,6 +203,27 @@ fn check_storage(config: &Config) -> Result {
 		));
 	}
 
+	if config.mindroom_edit_purge_interval_secs == 0 {
+		return Err!(Config(
+			"mindroom_edit_purge_interval_secs",
+			"mindroom_edit_purge_interval_secs must be at least 1 second."
+		));
+	}
+
+	if config.mindroom_edit_purge_batch_size == 0 {
+		return Err!(Config(
+			"mindroom_edit_purge_batch_size",
+			"mindroom_edit_purge_batch_size must be at least 1."
+		));
+	}
+
+	if config.mindroom_edit_purge_scan_limit == 0 {
+		return Err!(Config(
+			"mindroom_edit_purge_scan_limit",
+			"mindroom_edit_purge_scan_limit must be at least 1."
+		));
+	}
+
 	// yeah, unless the user built a debug build hopefully for local testing only
 	#[cfg(not(debug_assertions))]
 	if config.server_name == "your.server.name" {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -3967,6 +3967,15 @@ pub struct IdentityProvider {
 	/// this provider will simply not be found when querying by `brand`.
 	pub client_id: String,
 
+	/// Additional client IDs whose signed ID tokens should be accepted by
+	/// native app login endpoints for this provider. For Sign in with Apple on
+	/// iOS this is usually the app bundle identifier, while `client_id`
+	/// remains the web Services ID used by the browser SSO flow.
+	///
+	/// default: []
+	#[serde(default)]
+	pub native_client_ids: BTreeSet<String>,
+
 	/// Secret key the provider generated for you along with the `client_id`
 	/// above. Unlike the `client_id`, the `client_secret` can be changed here
 	/// whenever the provider regenerates one for you.

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1204,13 +1204,19 @@ pub struct Config {
 
 	/// MSC3925: fold the most recent message edit (an `m.replace` relation)
 	/// into `unsigned.m.relations` on a served event as the full replacement
-	/// event, on the client read endpoints. Off by default: it adds a typed
-	/// index seek per served event and a server-authoritative edit summary that
-	/// most clients reconstruct locally anyway, so it is opt-in.
+	/// event, on the client read endpoints.
+	///
+	/// MindRoom fork: on by default. The fork purges superseded edits
+	/// (`mindroom_edit_purge_enabled`), so without this bundle a history
+	/// endpoint (`/messages`, `/context`, `/event`, ...) would serve an
+	/// original carrying its stale pre-edit body with no way for the client
+	/// to discover the surviving edit; bundling the kept edit onto the
+	/// original keeps history correct. Upstream defaults this off (opt-in)
+	/// because it adds a typed-index seek per served event.
 	///
 	/// reloadable: yes
-	/// default: false
-	#[serde(default)]
+	/// default: true
+	#[serde(default = "true_fn")]
 	pub bundle_edit_relations: bool,
 
 	/// MSC2675/MSC3267: fold reference relations (`m.reference`) into
@@ -3122,6 +3128,69 @@ pub struct Config {
 	#[serde(default)]
 	pub allow_invalid_tls_certificates: bool,
 
+	/// MindRoom: Collapse multiple m.replace (edit) events per target into
+	/// only the latest one in `/sync` timeline responses.
+	///
+	/// When enabled, if a `/sync` timeline batch contains multiple replacement
+	/// events targeting the same event, only the most recent replacement is
+	/// kept. This dramatically reduces bandwidth for streaming AI responses
+	/// that produce many intermediate edits.
+	///
+	/// default: false
+	#[serde(default)]
+	pub mindroom_compact_edits_enabled: bool,
+
+	/// MindRoom: Enable background purging of superseded m.replace events
+	/// from the database.
+	///
+	/// When enabled, a periodic background job will find m.replace events
+	/// that have been superseded by newer replacements and remove them from
+	/// storage. Only events older than `mindroom_edit_purge_min_age_secs`
+	/// are eligible.
+	///
+	/// default: false
+	#[serde(default)]
+	pub mindroom_edit_purge_enabled: bool,
+
+	/// MindRoom: Minimum age in seconds before a superseded edit becomes
+	/// eligible for purging. This prevents purging edits that clients may
+	/// still be paginating through.
+	///
+	/// default: 86400
+	#[serde(default = "default_mindroom_edit_purge_min_age_secs")]
+	pub mindroom_edit_purge_min_age_secs: u64,
+
+	/// MindRoom: How often (in seconds) to run the edit purge background job.
+	///
+	/// default: 3600
+	#[serde(default = "default_mindroom_edit_purge_interval_secs")]
+	pub mindroom_edit_purge_interval_secs: u64,
+
+	/// MindRoom: Maximum number of events to purge per cycle. Keeps
+	/// individual purge runs bounded so they don't block other work.
+	///
+	/// default: 1000
+	#[serde(default = "default_mindroom_edit_purge_batch_size")]
+	pub mindroom_edit_purge_batch_size: usize,
+
+	/// MindRoom: Floor for PDUs scanned per purge cycle.
+	///
+	/// This value competes with `mindroom_edit_purge_batch_size * 10`; the
+	/// effective per-cycle scan budget is:
+	/// `max(mindroom_edit_purge_batch_size * 10,
+	/// mindroom_edit_purge_scan_limit)`.
+	///
+	/// default: 100000
+	#[serde(default = "default_mindroom_edit_purge_scan_limit")]
+	pub mindroom_edit_purge_scan_limit: usize,
+
+	/// MindRoom: When true, log what would be purged without actually
+	/// deleting anything. Useful for testing the purge logic.
+	///
+	/// default: false
+	#[serde(default)]
+	pub mindroom_edit_purge_dry_run: bool,
+
 	/// Sets the `Access-Control-Allow-Origin` header included by this server in
 	/// all responses. A list of multiple values can be specified. The default
 	/// is an empty list. The actual header defaults to `*` upon an empty list.
@@ -4913,3 +4982,11 @@ fn default_media_storage_providers() -> BTreeSet<String> { ["media".to_owned()].
 fn default_multipart_threshold() -> ByteSize { ByteSize::mib(100) }
 
 fn default_multipart_part_size() -> ByteSize { ByteSize::mib(10) }
+
+fn default_mindroom_edit_purge_min_age_secs() -> u64 { 86_400 }
+
+fn default_mindroom_edit_purge_interval_secs() -> u64 { 3_600 }
+
+fn default_mindroom_edit_purge_batch_size() -> usize { 1_000 }
+
+fn default_mindroom_edit_purge_scan_limit() -> usize { 100_000 }

--- a/src/core/matrix/event.rs
+++ b/src/core/matrix/event.rs
@@ -20,7 +20,7 @@ use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 pub use self::{
 	filter::{Matches, trim_event_fields},
 	id::*,
-	relation::RelationTypeEqual,
+	relation::{ExtractRelatesToInfo, RelatesToInfo, RelationTypeEqual},
 	state_key::{StateKey, TypeStateKey},
 	type_ext::TypeExt,
 };

--- a/src/core/matrix/event/relation.rs
+++ b/src/core/matrix/event/relation.rs
@@ -1,10 +1,22 @@
-use ruma::events::relation::RelationType;
+use ruma::{OwnedEventId, events::relation::RelationType};
 use serde::Deserialize;
 
 use super::Event;
 
 pub trait RelationTypeEqual<E: Event> {
 	fn relation_type_equal(&self, event: &E) -> bool;
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExtractRelatesToInfo {
+	#[serde(rename = "m.relates_to")]
+	pub relates_to: RelatesToInfo,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RelatesToInfo {
+	pub rel_type: String,
+	pub event_id: OwnedEventId,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/database/map/remove.rs
+++ b/src/database/map/remove.rs
@@ -1,6 +1,6 @@
 use std::{convert::AsRef, fmt::Debug};
 
-use tuwunel_core::implement;
+use tuwunel_core::{Result, implement};
 
 use crate::util::or_else;
 
@@ -10,16 +10,26 @@ pub fn remove<K>(&self, key: &K)
 where
 	K: AsRef<[u8]> + ?Sized + Debug,
 {
+	self.remove_fallible(key)
+		.expect("database remove error");
+}
+
+#[implement(super::Map)]
+#[tracing::instrument(skip(self, key), fields(%self), level = "trace")]
+pub fn remove_fallible<K>(&self, key: &K) -> Result
+where
+	K: AsRef<[u8]> + ?Sized + Debug,
+{
 	let write_options = &self.write_options;
 	self.engine
 		.db
 		.delete_cf_opt(&self.cf(), key, write_options)
-		.or_else(or_else)
-		.expect("database remove error");
+		.or_else(or_else)?;
 
 	if !self.engine.corked() {
-		self.engine.flush().expect("database flush error");
+		self.engine.flush()?;
 	}
 
 	self.notify(key.as_ref());
+	Ok(())
 }

--- a/src/database/maps.rs
+++ b/src/database/maps.rs
@@ -575,6 +575,10 @@ pub(super) static MAPS: &[Descriptor] = &[
 		..descriptor::RANDOM_SMALL
 	},
 	Descriptor {
+		name: "userid_deactivation_reason",
+		..descriptor::RANDOM_SMALL
+	},
+	Descriptor {
 		name: "userid_displayname",
 		..descriptor::RANDOM_SMALL
 	},

--- a/src/main/args.rs
+++ b/src/main/args.rs
@@ -1,6 +1,9 @@
 //! Integration with `clap`
 
-use std::path::PathBuf;
+use std::{
+	path::PathBuf,
+	sync::atomic::{AtomicU64, Ordering},
+};
 
 use clap::{ArgAction, Parser};
 use tuwunel_core::{
@@ -212,6 +215,8 @@ pub struct Args {
 	pub gc_muzzy: Option<bool>,
 }
 
+static TEST_DATABASE_PATH_ID: AtomicU64 = AtomicU64::new(0);
+
 impl Args {
 	#[must_use]
 	pub fn default_test(name: &[&str]) -> Self {
@@ -220,8 +225,15 @@ impl Args {
 			.extend(name.iter().copied().map(ToOwned::to_owned));
 		args.option
 			.push("server_name=\"localhost\"".into());
+		args.option
+			.push(format!("database_path={:?}", default_test_database_path().to_string_lossy()));
 		args
 	}
+}
+
+fn default_test_database_path() -> PathBuf {
+	let id = TEST_DATABASE_PATH_ID.fetch_add(1, Ordering::Relaxed);
+	std::env::temp_dir().join(format!("tuwunel-test-{}-{id}", std::process::id()))
 }
 
 impl Default for Args {

--- a/src/mindroom-tests/Cargo.toml
+++ b/src/mindroom-tests/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mindroom_rebase_tests"
+edition.workspace = true
+publish = false
+
+[lib]
+path = "lib.rs"
+bench = false
+
+[dev-dependencies]
+axum.workspace = true
+base64.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tuwunel = { path = "../main" }
+tuwunel-api.workspace = true
+tuwunel-core.workspace = true
+tuwunel-service.workspace = true
+url.workspace = true
+
+[lints]
+workspace = true

--- a/src/mindroom-tests/lib.rs
+++ b/src/mindroom-tests/lib.rs
@@ -1,0 +1,4 @@
+//! Fork-owned regression test crate.
+//!
+//! Keep rebase-sensitive MindRoom tests here instead of adding test modules to
+//! upstream-heavy source files.

--- a/src/mindroom-tests/tests/admin_deactivate_erase.rs
+++ b/src/mindroom-tests/tests/admin_deactivate_erase.rs
@@ -1,0 +1,53 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use tuwunel_core::{Result, ruma::user_id};
+	use tuwunel_service::users::{DeactivationReason, PASSWORD_SENTINEL};
+
+	use super::support::Harness;
+
+	/// `POST /_synapse/mas/delete_user` (new upstream endpoint) performs
+	/// `full_deactivate(user, erase, DeactivationReason::Admin)`. Unlike
+	/// self-service deactivation, this must never leave an SSO reactivation
+	/// path open — an account deleted by an administrator stays deactivated
+	/// when the same SSO identity logs in again.
+	#[test]
+	fn admin_erase_deactivation_blocks_sso_reactivation() -> Result {
+		let harness = Harness::new("mindroom_rebase_admin_deactivate", [])?;
+
+		harness.with_services(|services| async move {
+			let user_id = user_id!("@mallory:localhost");
+
+			services
+				.users
+				.create(user_id, Some(PASSWORD_SENTINEL), Some("sso"))
+				.await?;
+
+			services
+				.deactivate
+				.full_deactivate(user_id, true, DeactivationReason::Admin)
+				.await?;
+
+			assert!(
+				services.users.is_deactivated(user_id).await?,
+				"admin deactivation should deactivate the account",
+			);
+
+			let reactivated = services
+				.users
+				.maybe_reactivate_deactivated_sso(user_id)
+				.await?;
+			assert!(
+				!reactivated,
+				"admin-erased deactivation must not be reversible by SSO login",
+			);
+			assert!(
+				services.users.is_deactivated(user_id).await?,
+				"account must remain deactivated after an SSO reactivation attempt",
+			);
+
+			Ok(())
+		})
+	}
+}

--- a/src/mindroom-tests/tests/apple_userinfo_fallback.rs
+++ b/src/mindroom-tests/tests/apple_userinfo_fallback.rs
@@ -1,0 +1,234 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use axum::{Json, Router, body::Body, http::StatusCode as AxumStatus, routing::any};
+	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as b64};
+	use serde_json::json;
+	use tower::ServiceExt;
+	use tuwunel_core::{
+		Result,
+		http::{Request, StatusCode, header},
+		ruma::user_id,
+	};
+	use url::Url;
+
+	use super::support::Harness;
+
+	/// End-to-end pin of the Apple userinfo fallback through the full SSO
+	/// callback flow: the token response's `id_token` must be persisted on the
+	/// session (`apply_token_response`), and when the userinfo endpoint fails
+	/// for an `appleoidc` provider, login must still complete from the
+	/// id_token claims (`complete_sso_session`). Both behaviors live in
+	/// rebase-sensitive regions of `sso_callback_route`.
+	#[test]
+	fn apple_login_succeeds_from_id_token_when_userinfo_fails() -> Result {
+		let mut harness = Harness::new("mindroom_rebase_apple_fallback", [])?;
+
+		let id_token = build_unsigned_id_token(&json!({
+			"sub": "apple-user-1",
+			"email": "fallback@example.test",
+		}));
+		let token_response = json!({
+			"token_type": "Bearer",
+			"access_token": "mock-apple-access-token",
+			"expires_in": 3600,
+			"id_token": id_token,
+		});
+
+		let mock = harness.mock_server(idp_router(token_response))?;
+		let base = mock.base_url.clone();
+		harness.args.option.extend([
+			"identity_provider.apple.brand=\"appleoidc\"".to_owned(),
+			"identity_provider.apple.client_id=\"apple-client\"".to_owned(),
+			"identity_provider.apple.client_secret=\"secret\"".to_owned(),
+			format!("identity_provider.apple.issuer_url=\"{base}\""),
+			format!(
+				"identity_provider.apple.discovery_url=\"{base}/.well-known/openid-configuration\""
+			),
+			"identity_provider.apple.callback_url=\"https://matrix.example.test/_matrix/client/unstable/login/sso/callback/apple-client\"".to_owned(),
+		]);
+
+		let expected_id_token = build_unsigned_id_token(&json!({
+			"sub": "apple-user-1",
+			"email": "fallback@example.test",
+		}));
+
+		let result = harness.with_services(|services| async move {
+			// SSO registration is gated by the provider's own `registration`
+			// flag (default true), so the callback registers this user from
+			// the id_token's email-derived preferred_username.
+			let user_id = user_id!("@fallback:localhost");
+
+			let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+			let router =
+				tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+
+			// Step 1: redirect grants a session and the grant cookie.
+			let response = router
+				.clone()
+				.oneshot(
+					Request::builder()
+						.method("GET")
+						.uri(
+							"/_matrix/client/v3/login/sso/redirect/apple-client?\
+							 redirectUrl=https%3A%2F%2Fclient.example.test%2Fdone",
+						)
+						.header("X-Forwarded-For", "127.0.0.1")
+						.body(Body::empty())
+						.expect("valid request"),
+				)
+				.await
+				.expect("router response");
+			assert_eq!(response.status(), StatusCode::FOUND, "SSO redirect should succeed");
+
+			let location = response
+				.headers()
+				.get(header::LOCATION)
+				.expect("redirect Location")
+				.to_str()
+				.expect("UTF-8 Location")
+				.to_owned();
+			let location = Url::parse(&location).expect("absolute redirect URL");
+			let query = location
+				.query_pairs()
+				.into_owned()
+				.collect::<BTreeMap<_, _>>();
+			let sess_id = query
+				.get("state")
+				.expect("state in grant query")
+				.clone();
+
+			let grant_cookie = response
+				.headers()
+				.get(header::SET_COOKIE)
+				.expect("grant session cookie")
+				.to_str()
+				.expect("UTF-8 cookie")
+				.split(';')
+				.next()
+				.expect("cookie name=value pair")
+				.to_owned();
+
+			// Step 2: callback exchanges the code; the mock IdP serves the
+			// token (with id_token) but hard-fails the userinfo endpoint.
+			let response = router
+				.clone()
+				.oneshot(
+					Request::builder()
+						.method("GET")
+						.uri(format!(
+							"/_matrix/client/unstable/login/sso/callback/apple-client?\
+							 code=mock-code&state={sess_id}",
+						))
+						.header(header::COOKIE, &grant_cookie)
+						.header("X-Forwarded-For", "127.0.0.1")
+						.body(Body::empty())
+						.expect("valid request"),
+				)
+				.await
+				.expect("router response");
+
+			let status = response.status();
+			let location = response
+				.headers()
+				.get(header::LOCATION)
+				.map(|location| {
+					location
+						.to_str()
+						.expect("UTF-8 Location")
+						.to_owned()
+				});
+			assert_eq!(
+				status,
+				StatusCode::FOUND,
+				"callback should complete login via the id_token fallback: {location:?}",
+			);
+
+			let location =
+				Url::parse(&location.expect("callback Location")).expect("absolute URL");
+			assert!(
+				location
+					.as_str()
+					.starts_with("https://client.example.test/done"),
+				"callback should redirect to the client redirectUrl: {location}",
+			);
+			assert!(
+				location
+					.query_pairs()
+					.any(|(key, value)| key == "loginToken" && !value.is_empty()),
+				"callback redirect should carry a loginToken: {location}",
+			);
+
+			// The session must have persisted the id_token the fallback used.
+			let session = services.oauth.sessions.get(&sess_id).await?;
+			assert_eq!(
+				session.id_token.as_deref(),
+				Some(expected_id_token.as_str()),
+				"token response id_token should be persisted on the session",
+			);
+			assert_eq!(
+				session.user_id.as_deref(),
+				Some(user_id),
+				"session should bind the user derived from the id_token email claim",
+			);
+
+			// And the registered user must be an active SSO-origin account.
+			assert!(services.users.exists(user_id).await, "fallback user should be registered");
+			assert_eq!(services.users.origin(user_id).await?, "sso");
+			assert!(services.users.is_active_local(user_id).await);
+
+			Ok(())
+		});
+
+		mock.handle.abort();
+		result
+	}
+
+	/// Discovery + token + failing-userinfo mock IdP. The fallback only
+	/// base64-decodes the id_token payload, so an unsigned JWT suffices.
+	fn idp_router(token_response: serde_json::Value) -> Router {
+		Router::new()
+			.route(
+				"/.well-known/openid-configuration",
+				any(|request: Request<Body>| async move {
+					let base = format!(
+						"http://{}",
+						request
+							.headers()
+							.get(header::HOST)
+							.expect("Host header")
+							.to_str()
+							.expect("UTF-8 Host"),
+					);
+					Json(json!({
+						"issuer": base,
+						"authorization_endpoint": format!("{base}/authorize"),
+						"token_endpoint": format!("{base}/token"),
+						"userinfo_endpoint": format!("{base}/userinfo"),
+						"revocation_endpoint": format!("{base}/revoke"),
+						"introspection_endpoint": format!("{base}/introspect"),
+					}))
+				}),
+			)
+			.route(
+				"/token",
+				any(move || {
+					let token_response = token_response.clone();
+					async move { Json(token_response) }
+				}),
+			)
+			.route(
+				"/userinfo",
+				any(|| async { (AxumStatus::INTERNAL_SERVER_ERROR, "userinfo unavailable") }),
+			)
+	}
+
+	fn build_unsigned_id_token(claims: &serde_json::Value) -> String {
+		let header = b64.encode(serde_json::to_vec(&json!({"alg": "none"})).expect("header"));
+		let payload = b64.encode(serde_json::to_vec(claims).expect("claims"));
+		format!("{header}.{payload}.signature")
+	}
+}

--- a/src/mindroom-tests/tests/deactivate_erase.rs
+++ b/src/mindroom-tests/tests/deactivate_erase.rs
@@ -1,0 +1,83 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+	use tuwunel_core::{
+		Result,
+		ruma::{events::RoomAccountDataEventType, user_id},
+	};
+	use tuwunel_service::users::{DeactivationReason, PASSWORD_SENTINEL};
+
+	use super::support::Harness;
+
+	#[test]
+	fn self_service_erase_deactivation_keeps_sso_reactivation_path() -> Result {
+		let harness = Harness::new("mindroom_rebase_deactivate", [])?;
+
+		harness.with_services(|services| async move {
+			let user_id = user_id!("@alice:localhost");
+			let account_data_type = RoomAccountDataEventType::Tag;
+			let account_data = json!({
+				"type": account_data_type.to_string(),
+				"content": {
+					"tags": {
+						"u.work": { "order": 0.1 }
+					}
+				}
+			});
+
+			services
+				.users
+				.create(user_id, Some(PASSWORD_SENTINEL), Some("sso"))
+				.await?;
+			services
+				.account_data
+				.update(None, user_id, account_data_type.clone(), &account_data)
+				.await?;
+			assert!(
+				services
+					.account_data
+					.get_raw(None, user_id, account_data_type.to_string().as_str())
+					.await
+					.is_ok(),
+				"test setup should store account data before deactivation",
+			);
+
+			services
+				.deactivate
+				.full_deactivate(user_id, true, DeactivationReason::SelfService)
+				.await?;
+
+			assert!(
+				services
+					.account_data
+					.get_raw(None, user_id, account_data_type.to_string().as_str())
+					.await
+					.is_err(),
+				"MSC4025 erase=true should remove global account data",
+			);
+
+			let reactivated = services
+				.users
+				.maybe_reactivate_deactivated_sso(user_id)
+				.await?;
+			assert!(
+				reactivated,
+				"self-service deactivation reason should still allow SSO reactivation after \
+				 erase",
+			);
+			assert!(
+				!services.users.is_deactivated(user_id).await?,
+				"reactivated SSO user should no longer be deactivated",
+			);
+			assert_eq!(
+				services.users.password_hash(user_id).await?,
+				PASSWORD_SENTINEL,
+				"SSO reactivation should restore the sentinel password",
+			);
+
+			Ok(())
+		})
+	}
+}

--- a/src/mindroom-tests/tests/edit_purge_bundle_compose.rs
+++ b/src/mindroom-tests/tests/edit_purge_bundle_compose.rs
@@ -1,0 +1,357 @@
+//! The MindRoom edit purge composes with upstream's `bundle_edit_relations`
+//! (MSC3925).
+//!
+//! The purge deletes every superseded `m.replace` edit and keeps exactly one
+//! per (target, sender). Upstream bundles the newest surviving edit onto the
+//! original at `unsigned.m.relations.m.replace`, read from the
+//! `relatesto_typed` typed index. The purge does NOT maintain that index (nor
+//! `tofrom_relation`), so it leaves dangling rows for the edits it deletes.
+//! These tests prove the two features compose:
+//!
+//!   1. after a real purge cycle deletes the superseded edit, a history
+//!      endpoint still bundles the surviving edit; and
+//!   2. a dangling *newest* typed-index row (its PDU purged) is skipped so the
+//!      bundler falls through to the newest surviving edit — never serving
+//!      stale pre-edit content, never erroring.
+//!
+//! The pre-purge assertions also pin the fork default `bundle_edit_relations =
+//! true`: if that default were reverted these tests would fail with no bundle.
+
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+
+	use axum::{Router, body::Body};
+	use serde_json::{Value as JsonValue, json};
+	use tower::ServiceExt;
+	use tuwunel_core::{
+		Result,
+		http::{Request, StatusCode, header},
+		ruma::user_id,
+	};
+	use tuwunel_service::Services;
+
+	use super::support::Harness;
+
+	const ALICE_TOKEN: &str = "mindroom-test-access-token-alice-0123456789";
+	const BOB_TOKEN: &str = "mindroom-test-access-token-bob-0123456789ab";
+
+	/// One harness per process (the tracing subscriber is global).
+	#[test]
+	fn edit_purge_composes_with_edit_bundling() -> Result {
+		let harness = Harness::new("mindroom_edit_purge_bundle_compose", [
+			"mindroom_edit_purge_enabled=true".to_owned(),
+			// Make every superseded edit immediately eligible for purge.
+			"mindroom_edit_purge_min_age_secs=0".to_owned(),
+		])?;
+
+		harness.with_services(|services| async move {
+			let (router, room_id) = setup_room(&services).await?;
+
+			real_purge_still_bundles_survivor(&services, &router, &room_id).await?;
+			dangling_newest_falls_through(&services, &router, &room_id).await?;
+
+			Ok(())
+		})
+	}
+
+	/// A real purge cycle deletes the superseded edit and keeps the newest; the
+	/// original still bundles the surviving edit afterwards, and the dangling
+	/// typed-index row the purge leaves for the deleted edit does not matter
+	/// (it is older than the survivor, so newest-first never reaches it).
+	async fn real_purge_still_bundles_survivor(
+		services: &Arc<Services>,
+		router: &Router,
+		room_id: &str,
+	) -> Result {
+		let original = send_text(router, room_id, ALICE_TOKEN, "compose-m1", "thinking…").await;
+		let edit1 =
+			send_edit(router, room_id, ALICE_TOKEN, "compose-e1", &original, "first answer")
+				.await;
+		let edit2 =
+			send_edit(router, room_id, ALICE_TOKEN, "compose-e2", &original, "final answer")
+				.await;
+
+		// Before the purge: the original bundles the newest edit.
+		let chunk = messages_chunk(router, &enc(room_id), ALICE_TOKEN).await;
+		assert_edit_bundle(replace_bundle(find_event(&chunk, &original)), &edit2, "final answer");
+
+		// Run one real purge cycle. It keeps edit2 and deletes edit1, leaving
+		// edit1's relatesto_typed / tofrom_relation rows dangling.
+		services.edit_purge.purge_cycle().await?;
+
+		assert!(
+			get_pdu_id(services, &edit1).await.is_none(),
+			"purge must delete the superseded edit"
+		);
+		assert!(get_pdu_id(services, &edit2).await.is_some(), "purge must keep the newest edit");
+
+		// After the purge: the original still bundles the surviving edit via the
+		// typed index. This is the whole point — the purge does not need to
+		// maintain relatesto_typed for history to stay correct.
+		let chunk = messages_chunk(router, &enc(room_id), ALICE_TOKEN).await;
+		assert_edit_bundle(replace_bundle(find_event(&chunk, &original)), &edit2, "final answer");
+
+		Ok(())
+	}
+
+	/// If the *newest* typed-index row is dangling (its PDU deleted the way the
+	/// purge deletes events), the bundler skips it and falls through to the
+	/// newest surviving edit instead of erroring or serving nothing.
+	async fn dangling_newest_falls_through(
+		services: &Arc<Services>,
+		router: &Router,
+		room_id: &str,
+	) -> Result {
+		let original = send_text(router, room_id, ALICE_TOKEN, "compose-m2", "thinking…").await;
+		let edit1 =
+			send_edit(router, room_id, ALICE_TOKEN, "compose-f1", &original, "draft one").await;
+		let edit2 =
+			send_edit(router, room_id, ALICE_TOKEN, "compose-f2", &original, "draft two").await;
+
+		// Delete only the newest edit's PDU rows, as the purge's `delete_event`
+		// does, leaving its typed-index row dangling as the newest candidate.
+		// (Nothing is sent after this: edit2 is the room's forward extremity and
+		// removing its PDU would break prev_event resolution of any later send.)
+		purge_event_rows(services, &edit2).await?;
+
+		let chunk = messages_chunk(router, &enc(room_id), ALICE_TOKEN).await;
+		// The dangling newest (edit2) is skipped; edit1 is the surviving edit.
+		assert_edit_bundle(replace_bundle(find_event(&chunk, &original)), &edit1, "draft one");
+
+		Ok(())
+	}
+
+	async fn setup_room(services: &Arc<Services>) -> Result<(Router, String)> {
+		let alice = user_id!("@alice:localhost");
+		let bob = user_id!("@bob:localhost");
+		for (user, token) in [(alice, ALICE_TOKEN), (bob, BOB_TOKEN)] {
+			services
+				.users
+				.create(user, Some("password"), None)
+				.await?;
+			services
+				.users
+				.create_device(user, None, (Some(token), None), None, None, None)
+				.await?;
+		}
+
+		let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+		let router =
+			tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+
+		let body = request(
+			&router,
+			"POST",
+			"/_matrix/client/v3/createRoom",
+			ALICE_TOKEN,
+			Some(json!({"preset": "public_chat"})),
+		)
+		.await;
+		let room_id = body["room_id"]
+			.as_str()
+			.expect("createRoom returns room_id")
+			.to_owned();
+
+		request(
+			&router,
+			"POST",
+			&format!("/_matrix/client/v3/rooms/{}/join", enc(&room_id)),
+			BOB_TOKEN,
+			Some(json!({})),
+		)
+		.await;
+
+		Ok((router, room_id))
+	}
+
+	/// Resolve an event's PduId, or `None` if its PDU rows are gone.
+	async fn get_pdu_id(services: &Arc<Services>, event_id: &str) -> Option<Vec<u8>> {
+		services
+			.timeline
+			.get_pdu_id(event_id.try_into().expect("valid event id"))
+			.await
+			.ok()
+			.map(|id| id.as_bytes().to_vec())
+	}
+
+	/// Delete an event's PDU rows the way the purge's `delete_event` does,
+	/// leaving its typed-index (`relatesto_typed`) and `tofrom_relation` rows
+	/// dangling. The bundler resolves a candidate row to a PDU via
+	/// `pduid_pdu`, so removing that row is what makes the row dangle.
+	async fn purge_event_rows(services: &Arc<Services>, event_id: &str) -> Result {
+		let pdu_id = services
+			.timeline
+			.get_pdu_id(event_id.try_into().expect("valid event id"))
+			.await?;
+		services.db["pduid_pdu"].remove(pdu_id.as_bytes());
+		services.db["eventid_pduid"].remove(event_id.as_bytes());
+
+		Ok(())
+	}
+
+	async fn messages_chunk(router: &Router, room: &str, token: &str) -> Vec<JsonValue> {
+		let messages = request(
+			router,
+			"GET",
+			&format!("/_matrix/client/v3/rooms/{room}/messages?dir=b&limit=100"),
+			token,
+			None,
+		)
+		.await;
+
+		messages["chunk"]
+			.as_array()
+			.expect("messages chunk")
+			.clone()
+	}
+
+	/// Upstream serializes the bundled edit as a sync-shaped message-like event
+	/// (`AnySyncMessageLikeEvent`): it carries `event_id`, `sender`, `type`,
+	/// `origin_server_ts`, and the `m.new_content` edit payload, but not
+	/// `room_id` (the parent event already carries the room context).
+	fn assert_edit_bundle(bundle: &JsonValue, edit_id: &str, new_body: &str) {
+		assert_eq!(
+			bundle["event_id"], *edit_id,
+			"bundle must be the surviving same-sender edit: {bundle}"
+		);
+		assert_eq!(bundle["sender"], "@alice:localhost", "bundle sender: {bundle}");
+		assert_eq!(bundle["type"], "m.room.message", "bundle type: {bundle}");
+		assert!(
+			bundle["origin_server_ts"].is_u64(),
+			"bundle must carry origin_server_ts (MindRoom Cinny requires it): {bundle}"
+		);
+		assert_eq!(
+			bundle["content"]["m.new_content"]["body"], *new_body,
+			"bundle content must carry the edited m.new_content: {bundle}"
+		);
+		assert_eq!(
+			bundle["content"]["m.relates_to"]["rel_type"], "m.replace",
+			"bundle content must retain m.relates_to: {bundle}"
+		);
+	}
+
+	fn replace_bundle(event: &JsonValue) -> &JsonValue {
+		let bundle = &event["unsigned"]["m.relations"]["m.replace"];
+		assert!(bundle.is_object(), "event must carry an m.replace bundle: {event}");
+		bundle
+	}
+
+	fn find_event<'a>(chunk: &'a [JsonValue], event_id: &str) -> &'a JsonValue {
+		chunk
+			.iter()
+			.find(|event| event["event_id"] == *event_id)
+			.unwrap_or_else(|| panic!("event {event_id} not found in chunk"))
+	}
+
+	async fn send_text(
+		router: &Router,
+		room: &str,
+		token: &str,
+		txn_id: &str,
+		body: &str,
+	) -> String {
+		send_message(router, room, token, txn_id, json!({"msgtype": "m.text", "body": body}))
+			.await
+	}
+
+	async fn send_message(
+		router: &Router,
+		room: &str,
+		token: &str,
+		txn_id: &str,
+		content: JsonValue,
+	) -> String {
+		let body = request(
+			router,
+			"PUT",
+			&format!("/_matrix/client/v3/rooms/{room}/send/m.room.message/{txn_id}"),
+			token,
+			Some(content),
+		)
+		.await;
+
+		body["event_id"]
+			.as_str()
+			.expect("send returns event_id")
+			.to_owned()
+	}
+
+	async fn send_edit(
+		router: &Router,
+		room: &str,
+		token: &str,
+		txn_id: &str,
+		target: &str,
+		new_body: &str,
+	) -> String {
+		send_message(
+			router,
+			room,
+			token,
+			txn_id,
+			json!({
+				"msgtype": "m.text",
+				"body": format!("* {new_body}"),
+				"m.new_content": {"msgtype": "m.text", "body": new_body},
+				"m.relates_to": {"rel_type": "m.replace", "event_id": target},
+			}),
+		)
+		.await
+	}
+
+	async fn request(
+		router: &Router,
+		method: &str,
+		uri: &str,
+		token: &str,
+		body: Option<JsonValue>,
+	) -> JsonValue {
+		let request = Request::builder()
+			.method(method)
+			.uri(uri)
+			.header(header::AUTHORIZATION, format!("Bearer {token}"))
+			.header(header::CONTENT_TYPE, "application/json")
+			.header("X-Forwarded-For", "127.0.0.1")
+			.body(body.map_or_else(Body::empty, |body| Body::from(body.to_string())))
+			.expect("valid request");
+
+		let response = router
+			.clone()
+			.oneshot(request)
+			.await
+			.expect("router response");
+
+		let status = response.status();
+		let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+			.await
+			.expect("readable response body");
+		assert_eq!(
+			status,
+			StatusCode::OK,
+			"{method} {uri} should succeed: {}",
+			String::from_utf8_lossy(&bytes),
+		);
+
+		serde_json::from_slice(&bytes).expect("JSON response body")
+	}
+
+	/// Percent-encode a room/event ID for use as a URI path segment.
+	fn enc(id: &str) -> String {
+		id.bytes()
+			.map(|byte| match byte {
+				| b'$' => "%24".to_owned(),
+				| b'!' => "%21".to_owned(),
+				| b':' => "%3A".to_owned(),
+				| b'+' => "%2B".to_owned(),
+				| b'/' => "%2F".to_owned(),
+				| b'=' => "%3D".to_owned(),
+				| b'?' => "%3F".to_owned(),
+				| b'#' => "%23".to_owned(),
+				| other => char::from(other).to_string(),
+			})
+			.collect()
+	}
+}

--- a/src/mindroom-tests/tests/messages_to_clamp.rs
+++ b/src/mindroom-tests/tests/messages_to_clamp.rs
@@ -1,0 +1,254 @@
+//! `/messages` must honour `to` as a *position*, not an exact event count.
+//!
+//! Upstream stopped pagination only when an event's count exactly equalled the
+//! `to` token (`Some(*count) != to`) and silently swallowed unparseable `to`
+//! values. A sync `next_batch` token is a global stream position that almost
+//! never equals an event count *in the requested room*, so a `to` bound taken
+//! from `/sync` — which the spec explicitly permits — was ignored entirely and
+//! the walk ran unbounded. MindRoom's nio fork pages `/messages` with sync
+//! tokens to recover gaps dropped by limited sync timelines, which is how the
+//! bug was found (live probes: `to=<sync token>` and even `to=garbage!!`
+//! returned HTTP 200 with an unclamped chunk).
+//!
+//! These tests pin the fix: pagination stops once the walk passes the `to`
+//! position in either direction, and an unparseable `to` fails the request
+//! (matching `from` handling) instead of being ignored.
+
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use axum::{Router, body::Body};
+	use serde_json::{Value as JsonValue, json};
+	use tower::ServiceExt;
+	use tuwunel_core::{
+		Result,
+		http::{Request, StatusCode, header},
+		ruma::user_id,
+	};
+
+	use super::support::Harness;
+
+	const ALICE_TOKEN: &str = "mindroom-test-access-token-alice-0123456789";
+
+	/// One harness per process (the tracing subscriber is global).
+	#[test]
+	fn messages_to_clamps_at_positions_between_events() -> Result {
+		let harness = Harness::new("mindroom_messages_to_clamp", [])?;
+
+		harness.with_services(|services| async move {
+			let alice = user_id!("@alice:localhost");
+			services
+				.users
+				.create(alice, Some("password"), None)
+				.await?;
+			services
+				.users
+				.create_device(alice, None, (Some(ALICE_TOKEN), None), None, None, None)
+				.await?;
+
+			let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+			let router =
+				tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+
+			let room_a = create_room(&router).await;
+
+			// Two messages before the position, three after. The position is a
+			// sync next_batch taken while another room advances the global
+			// stream, so it falls strictly *between* room A's events and equals
+			// none of their counts — exactly the shape of a sync token used as
+			// a pagination bound.
+			send_text(&router, &room_a, "m1").await;
+			send_text(&router, &room_a, "m2").await;
+			let _room_b = create_room(&router).await;
+			let position = sync_next_batch(&router).await;
+			send_text(&router, &room_a, "m3").await;
+			send_text(&router, &room_a, "m4").await;
+			send_text(&router, &room_a, "m5").await;
+
+			backward_walk_stops_at_position(&router, &room_a, &position).await;
+			forward_walk_starts_at_position(&router, &room_a, &position).await;
+			unparseable_to_fails_the_request(&router, &room_a).await;
+
+			Ok(())
+		})
+	}
+
+	/// dir=b from the room's head with `to=<position>` must return only the
+	/// events after the position and stop — not run past it to the room's
+	/// creation (the pre-fix behaviour, since no event count equals it).
+	async fn backward_walk_stops_at_position(router: &Router, room: &str, position: &str) {
+		let (status, body) = request(
+			router,
+			"GET",
+			&format!(
+				"/_matrix/client/v3/rooms/{}/messages?dir=b&limit=100&to={position}",
+				enc(room)
+			),
+			Some(ALICE_TOKEN),
+			None,
+		)
+		.await;
+
+		assert_eq!(status, StatusCode::OK, "clamped backward walk should succeed: {body}");
+		assert_eq!(
+			bodies(&body),
+			vec!["m5", "m4", "m3"],
+			"backward walk must stop at the `to` position: {body}"
+		);
+	}
+
+	/// dir=f from the position returns exactly the events after it; together
+	/// with the backward assertion this pins that the two directions partition
+	/// the room at the position.
+	async fn forward_walk_starts_at_position(router: &Router, room: &str, position: &str) {
+		let (status, body) = request(
+			router,
+			"GET",
+			&format!(
+				"/_matrix/client/v3/rooms/{}/messages?dir=f&limit=100&from={position}",
+				enc(room)
+			),
+			Some(ALICE_TOKEN),
+			None,
+		)
+		.await;
+
+		assert_eq!(status, StatusCode::OK, "forward walk from position should succeed: {body}");
+		assert_eq!(
+			bodies(&body),
+			vec!["m3", "m4", "m5"],
+			"forward walk must start at the position: {body}"
+		);
+	}
+
+	/// An unparseable `to` must fail the request like an unparseable `from`
+	/// does, not be silently ignored (the pre-fix behaviour returned HTTP 200
+	/// with an unbounded chunk).
+	async fn unparseable_to_fails_the_request(router: &Router, room: &str) {
+		let (status, body) = request(
+			router,
+			"GET",
+			&format!("/_matrix/client/v3/rooms/{}/messages?dir=b&limit=100&to=garbage!!", enc(room)),
+			Some(ALICE_TOKEN),
+			None,
+		)
+		.await;
+
+		assert!(
+			status.is_client_error() || status.is_server_error(),
+			"unparseable `to` must fail the request, got {status}: {body}"
+		);
+	}
+
+	async fn create_room(router: &Router) -> String {
+		let (status, body) = request(
+			router,
+			"POST",
+			"/_matrix/client/v3/createRoom",
+			Some(ALICE_TOKEN),
+			Some(json!({"preset": "public_chat"})),
+		)
+		.await;
+		assert_eq!(status, StatusCode::OK, "createRoom should succeed: {body}");
+
+		body["room_id"]
+			.as_str()
+			.expect("createRoom returns room_id")
+			.to_owned()
+	}
+
+	async fn send_text(router: &Router, room: &str, text: &str) -> String {
+		let (status, body) = request(
+			router,
+			"PUT",
+			&format!("/_matrix/client/v3/rooms/{}/send/m.room.message/txn-{text}", enc(room)),
+			Some(ALICE_TOKEN),
+			Some(json!({"msgtype": "m.text", "body": text})),
+		)
+		.await;
+		assert_eq!(status, StatusCode::OK, "send should succeed: {body}");
+
+		body["event_id"]
+			.as_str()
+			.expect("send returns event_id")
+			.to_owned()
+	}
+
+	async fn sync_next_batch(router: &Router) -> String {
+		let (status, body) = request(
+			router,
+			"GET",
+			"/_matrix/client/v3/sync?timeout=0",
+			Some(ALICE_TOKEN),
+			None,
+		)
+		.await;
+		assert_eq!(status, StatusCode::OK, "sync should succeed: {body}");
+
+		body["next_batch"]
+			.as_str()
+			.expect("sync returns next_batch")
+			.to_owned()
+	}
+
+	fn bodies(messages: &JsonValue) -> Vec<&str> {
+		messages["chunk"]
+			.as_array()
+			.expect("messages chunk")
+			.iter()
+			.filter(|event| event["type"] == "m.room.message")
+			.filter_map(|event| event["content"]["body"].as_str())
+			.collect()
+	}
+
+	async fn request(
+		router: &Router,
+		method: &str,
+		uri: &str,
+		token: Option<&str>,
+		body: Option<JsonValue>,
+	) -> (StatusCode, JsonValue) {
+		let mut builder = Request::builder()
+			.method(method)
+			.uri(uri)
+			.header(header::CONTENT_TYPE, "application/json")
+			.header("X-Forwarded-For", "127.0.0.1");
+		if let Some(token) = token {
+			builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+		}
+		let request = builder
+			.body(body.map_or_else(Body::empty, |body| Body::from(body.to_string())))
+			.expect("valid request");
+
+		let response = router
+			.clone()
+			.oneshot(request)
+			.await
+			.expect("router response");
+
+		let status = response.status();
+		let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+			.await
+			.expect("readable response body");
+
+		(status, serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null))
+	}
+
+	/// Percent-encode a room ID for use as a URI path segment.
+	fn enc(id: &str) -> String {
+		id.bytes()
+			.map(|byte| match byte {
+				| b'$' => "%24".to_owned(),
+				| b'!' => "%21".to_owned(),
+				| b':' => "%3A".to_owned(),
+				| b'+' => "%2B".to_owned(),
+				| b'/' => "%2F".to_owned(),
+				| b'=' => "%3D".to_owned(),
+				| b'?' => "%3F".to_owned(),
+				| b'#' => "%23".to_owned(),
+				| other => char::from(other).to_string(),
+			})
+			.collect()
+	}
+}

--- a/src/mindroom-tests/tests/sso_callback_completion.rs
+++ b/src/mindroom-tests/tests/sso_callback_completion.rs
@@ -1,0 +1,304 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use axum::{Json, Router, body::Body, http::StatusCode as AxumStatus, routing::any};
+	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as b64};
+	use serde_json::json;
+	use tower::ServiceExt;
+	use tuwunel_core::{
+		Result,
+		http::{Request, StatusCode, header},
+		ruma::user_id,
+	};
+	use tuwunel_service::users::DeactivationReason;
+	use url::Url;
+
+	use super::support::Harness;
+
+	/// Pin the branches of `complete_sso_session` that the new-user happy path
+	/// in `apple_userinfo_fallback` does not reach. `complete_sso_session` is
+	/// the helper extracted during the upstream-main rebase so the browser SSO
+	/// callback and the native Apple endpoint share one identity -> account
+	/// completion path; a rebase that silently drops or reorders a step inside
+	/// it still compiles, so these drive the real router (redirect -> callback)
+	/// to catch that.
+	///
+	/// The three scenarios run against three separate providers/identities in a
+	/// single server, because each `with_services` initializes the global
+	/// tracing subscriber and a test binary can only do that once.
+	#[test]
+	fn complete_sso_session_reuse_rejection_and_reactivation() -> Result {
+		let mut harness = Harness::new("mindroom_rebase_sso_completion", [])?;
+
+		// Scenario A: re-login reuses the identity and deletes the prior session.
+		let reuse = harness.mock_server(idp_router("sub-reuse", "reuseone@example.test"))?;
+		// Scenario B: an admin-deactivated account is rejected on re-login.
+		let admin = harness.mock_server(idp_router("sub-admin", "reusetwo@example.test"))?;
+		// Scenario C: a self-deactivated account is reactivated on re-login.
+		let reactivate =
+			harness.mock_server(idp_router("sub-self", "reusethree@example.test"))?;
+
+		harness
+			.args
+			.option
+			.extend(provider_options("reuse", "reuse-client", &reuse.base_url));
+		harness
+			.args
+			.option
+			.extend(provider_options("admin", "admin-client", &admin.base_url));
+		harness.args.option.extend(provider_options(
+			"reactivate",
+			"reactivate-client",
+			&reactivate.base_url,
+		));
+
+		let result = harness.with_services(|services| async move {
+			let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+			let router =
+				tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+
+			// --- Scenario A: identity reuse + previous-session deletion --------
+			let reuse_user = user_id!("@reuseone:localhost");
+			let (sess1, status1, location1) = drive_login(&router, "reuse-client").await;
+			assert_eq!(status1, StatusCode::FOUND, "first login should complete: {location1:?}");
+			assert!(has_login_token(location1.as_ref()), "first login should mint a loginToken");
+			assert!(services.users.exists(reuse_user).await, "first login should register");
+			assert_eq!(services.users.origin(reuse_user).await?, "sso");
+			assert!(
+				services.oauth.sessions.get(&sess1).await.is_ok(),
+				"first login's session should be committed",
+			);
+
+			let (sess2, status2, location2) = drive_login(&router, "reuse-client").await;
+			assert_eq!(status2, StatusCode::FOUND, "re-login should complete: {location2:?}");
+			assert!(has_login_token(location2.as_ref()), "re-login should mint a loginToken");
+			assert_ne!(sess1, sess2, "re-login should use a fresh session id");
+			assert!(services.users.is_active_local(reuse_user).await);
+			assert!(
+				services.oauth.sessions.get(&sess2).await.is_ok(),
+				"the newest session should be committed",
+			);
+			assert!(
+				services.oauth.sessions.get(&sess1).await.is_err(),
+				"re-login should delete the previous session for the same identity",
+			);
+
+			// --- Scenario B: admin-deactivated accounts cannot re-login --------
+			let admin_user = user_id!("@reusetwo:localhost");
+			let (_a1, admin_status1, _al1) = drive_login(&router, "admin-client").await;
+			assert_eq!(admin_status1, StatusCode::FOUND, "admin-scenario first login registers");
+
+			services
+				.deactivate
+				.full_deactivate(admin_user, false, DeactivationReason::Admin)
+				.await?;
+			assert!(services.users.is_deactivated(admin_user).await?);
+
+			let (_a2, admin_status2, admin_location2) =
+				drive_login(&router, "admin-client").await;
+			assert_ne!(
+				admin_status2,
+				StatusCode::FOUND,
+				"admin-deactivated account must not complete SSO login: {admin_location2:?}",
+			);
+			assert!(
+				!has_login_token(admin_location2.as_ref()),
+				"a rejected login must not mint a loginToken: {admin_location2:?}",
+			);
+			assert!(
+				services.users.is_deactivated(admin_user).await?,
+				"account must stay deactivated after the rejected re-login",
+			);
+
+			// --- Scenario C: self-deactivated accounts reactivate on re-login --
+			let self_user = user_id!("@reusethree:localhost");
+			let (_c1, self_status1, _cl1) = drive_login(&router, "reactivate-client").await;
+			assert_eq!(self_status1, StatusCode::FOUND, "self-scenario first login registers");
+
+			services
+				.deactivate
+				.full_deactivate(self_user, false, DeactivationReason::SelfService)
+				.await?;
+			assert!(services.users.is_deactivated(self_user).await?);
+
+			let (_c2, self_status2, self_location2) =
+				drive_login(&router, "reactivate-client").await;
+			assert_eq!(
+				self_status2,
+				StatusCode::FOUND,
+				"self-deactivated account should reactivate + complete: {self_location2:?}",
+			);
+			assert!(
+				has_login_token(self_location2.as_ref()),
+				"reactivated login should mint a loginToken: {self_location2:?}",
+			);
+			assert!(
+				services.users.is_active_local(self_user).await,
+				"self-deactivated account should be active again after SSO re-login",
+			);
+
+			Ok(())
+		});
+
+		reuse.handle.abort();
+		admin.handle.abort();
+		reactivate.handle.abort();
+		result
+	}
+
+	fn provider_options(id: &str, client: &str, base: &str) -> Vec<String> {
+		vec![
+			format!("identity_provider.{id}.brand=\"appleoidc\""),
+			format!("identity_provider.{id}.client_id=\"{client}\""),
+			format!("identity_provider.{id}.client_secret=\"secret\""),
+			format!("identity_provider.{id}.issuer_url=\"{base}\""),
+			format!(
+				"identity_provider.{id}.discovery_url=\"{base}/.well-known/openid-configuration\""
+			),
+			format!(
+				"identity_provider.{id}.callback_url=\"https://matrix.example.test/_matrix/client/unstable/login/sso/callback/{client}\""
+			),
+		]
+	}
+
+	/// Drive one full redirect -> callback for `client` and return
+	/// `(sess_id, callback_status, callback_location)`. The redirect is always
+	/// expected to succeed (pre-auth); the callback status/location are
+	/// returned unasserted so callers can pin both success and rejection.
+	async fn drive_login(router: &Router, client: &str) -> (String, StatusCode, Option<String>) {
+		let response = router
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("GET")
+					.uri(format!(
+						"/_matrix/client/v3/login/sso/redirect/{client}?redirectUrl=https%3A%2F%\
+						 2Fclient.example.test%2Fdone",
+					))
+					.header("X-Forwarded-For", "127.0.0.1")
+					.body(Body::empty())
+					.expect("valid request"),
+			)
+			.await
+			.expect("router response");
+		assert_eq!(response.status(), StatusCode::FOUND, "SSO redirect should succeed");
+
+		let location = response
+			.headers()
+			.get(header::LOCATION)
+			.expect("redirect Location")
+			.to_str()
+			.expect("UTF-8 Location")
+			.to_owned();
+		let location = Url::parse(&location).expect("absolute redirect URL");
+		let sess_id = location
+			.query_pairs()
+			.into_owned()
+			.collect::<BTreeMap<_, _>>()
+			.get("state")
+			.expect("state in grant query")
+			.clone();
+
+		let grant_cookie = response
+			.headers()
+			.get(header::SET_COOKIE)
+			.expect("grant session cookie")
+			.to_str()
+			.expect("UTF-8 cookie")
+			.split(';')
+			.next()
+			.expect("cookie name=value pair")
+			.to_owned();
+
+		let response = router
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("GET")
+					.uri(format!(
+						"/_matrix/client/unstable/login/sso/callback/{client}?code=mock-code&\
+						 state={sess_id}",
+					))
+					.header(header::COOKIE, &grant_cookie)
+					.header("X-Forwarded-For", "127.0.0.1")
+					.body(Body::empty())
+					.expect("valid request"),
+			)
+			.await
+			.expect("router response");
+
+		let status = response.status();
+		let location = response
+			.headers()
+			.get(header::LOCATION)
+			.map(|value| value.to_str().expect("UTF-8 Location").to_owned());
+
+		(sess_id, status, location)
+	}
+
+	fn has_login_token(location: Option<&String>) -> bool {
+		location
+			.and_then(|location| Url::parse(location).ok())
+			.is_some_and(|location| {
+				location
+					.query_pairs()
+					.any(|(key, value)| key == "loginToken" && !value.is_empty())
+			})
+	}
+
+	/// Discovery + token + failing-userinfo mock IdP; the appleoidc id_token
+	/// fallback carries a stable `sub` so every login maps to one identity.
+	fn idp_router(sub: &str, email: &str) -> Router {
+		let id_token = build_unsigned_id_token(&json!({ "sub": sub, "email": email }));
+		let token_response = json!({
+			"token_type": "Bearer",
+			"access_token": "mock-access-token",
+			"expires_in": 3600,
+			"id_token": id_token,
+		});
+
+		Router::new()
+			.route(
+				"/.well-known/openid-configuration",
+				any(|request: Request<Body>| async move {
+					let base = format!(
+						"http://{}",
+						request
+							.headers()
+							.get(header::HOST)
+							.expect("Host header")
+							.to_str()
+							.expect("UTF-8 Host"),
+					);
+					Json(json!({
+						"issuer": base,
+						"authorization_endpoint": format!("{base}/authorize"),
+						"token_endpoint": format!("{base}/token"),
+						"userinfo_endpoint": format!("{base}/userinfo"),
+						"revocation_endpoint": format!("{base}/revoke"),
+						"introspection_endpoint": format!("{base}/introspect"),
+					}))
+				}),
+			)
+			.route(
+				"/token",
+				any(move || {
+					let token_response = token_response.clone();
+					async move { Json(token_response) }
+				}),
+			)
+			.route(
+				"/userinfo",
+				any(|| async { (AxumStatus::INTERNAL_SERVER_ERROR, "userinfo unavailable") }),
+			)
+	}
+
+	fn build_unsigned_id_token(claims: &serde_json::Value) -> String {
+		let header = b64.encode(serde_json::to_vec(&json!({"alg": "none"})).expect("header"));
+		let payload = b64.encode(serde_json::to_vec(claims).expect("claims"));
+		format!("{header}.{payload}.signature")
+	}
+}

--- a/src/mindroom-tests/tests/sso_redirect.rs
+++ b/src/mindroom-tests/tests/sso_redirect.rs
@@ -1,0 +1,92 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use axum::{Router, body::Body};
+	use tower::ServiceExt;
+	use tuwunel_core::{
+		Result,
+		http::{Request, StatusCode, header},
+	};
+	use url::Url;
+
+	use super::support::Harness;
+
+	#[test]
+	fn sso_redirect_keeps_extra_authorization_params_without_overriding_grant_params() -> Result {
+		let mut harness = Harness::new("mindroom_rebase_sso_redirect", [])?;
+		let discovery = harness.discovery_server("https://idp.example.test")?;
+		harness.args.option.extend([
+			"identity_provider.test.brand=\"test\"".to_owned(),
+			"identity_provider.test.client_id=\"test-client\"".to_owned(),
+			"identity_provider.test.client_secret=\"secret\"".to_owned(),
+			"identity_provider.test.issuer_url=\"https://idp.example.test\"".to_owned(),
+			format!("identity_provider.test.discovery_url=\"{}\"", discovery.url),
+			"identity_provider.test.callback_url=\"https://matrix.example.test/_matrix/client/unstable/login/sso/callback/test-client\"".to_owned(),
+			"identity_provider.test.extra_authorization_parameters={prompt=\"login\",client_id=\"evil-client\",state=\"evil-state\",redirect_uri=\"https://evil.example/callback\",response_type=\"implicit\"}".to_owned(),
+		]);
+
+		let result = harness.with_services(|services| async move {
+			let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+			let router =
+				tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+			let response = router
+				.oneshot(
+					Request::builder()
+						.method("GET")
+						.uri(
+							"/_matrix/client/v3/login/sso/redirect/test-client?\
+							 redirectUrl=https%3A%2F%2Fclient.example.test%2Fdone",
+						)
+						.header("X-Forwarded-For", "127.0.0.1")
+						.body(Body::empty())
+						.expect("valid request"),
+				)
+				.await
+				.expect("router response");
+
+			assert_eq!(response.status(), StatusCode::FOUND);
+			let location = response
+				.headers()
+				.get(header::LOCATION)
+				.expect("SSO response should include Location")
+				.to_str()
+				.expect("Location header should be UTF-8");
+			let location = Url::parse(location).expect("Location should be an absolute URL");
+			let query = location
+				.query_pairs()
+				.into_owned()
+				.collect::<BTreeMap<_, _>>();
+
+			assert_eq!(query.get("prompt").map(String::as_str), Some("login"));
+			assert_eq!(query.get("client_id").map(String::as_str), Some("test-client"));
+			assert_eq!(query.get("response_type").map(String::as_str), Some("code"));
+			assert_eq!(
+				query.get("redirect_uri").map(String::as_str),
+				Some(
+					"https://matrix.example.test/_matrix/client/unstable/login/sso/callback/test-client",
+				),
+			);
+			assert_ne!(query.get("state").map(String::as_str), Some("evil-state"));
+
+			let set_cookie = response
+				.headers()
+				.get(header::SET_COOKIE)
+				.expect("SSO response should include grant cookie")
+				.to_str()
+				.expect("Set-Cookie header should be UTF-8");
+			assert!(
+				set_cookie.contains("Path=/_matrix/client/"),
+				"Matrix client callback should use the hardened shared client cookie path: \
+				 {set_cookie}",
+			);
+
+			Ok(())
+		});
+
+		discovery.handle.abort();
+		result
+	}
+}

--- a/src/mindroom-tests/tests/support/mod.rs
+++ b/src/mindroom-tests/tests/support/mod.rs
@@ -1,0 +1,97 @@
+#![allow(dead_code)]
+
+use std::{future::Future, sync::Arc};
+
+use axum::Router;
+use serde_json::json;
+use tuwunel::{Args, Runtime, Server};
+use tuwunel_core::Result;
+use tuwunel_service::Services;
+
+pub(crate) struct Harness {
+	pub(crate) args: Args,
+	runtime: Runtime,
+}
+
+impl Harness {
+	pub(crate) fn new(name: &str, options: impl IntoIterator<Item = String>) -> Result<Self> {
+		let mut args = Args::default_test(&[name, "fresh", "cleanup"]);
+		args.maintenance = true;
+		args.option.extend(options);
+		let runtime = Runtime::new(Some(&args))?;
+
+		Ok(Self { args, runtime })
+	}
+
+	pub(crate) fn discovery_server(&self, issuer: &'static str) -> Result<DiscoveryServer> {
+		self.runtime.block_on(async move {
+			let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+			let addr = listener.local_addr()?;
+			let response = json!({
+				"issuer": issuer,
+				"authorization_endpoint": format!("{issuer}/authorize"),
+				"token_endpoint": format!("{issuer}/token"),
+				"userinfo_endpoint": format!("{issuer}/userinfo"),
+				"revocation_endpoint": format!("{issuer}/revoke"),
+				"introspection_endpoint": format!("{issuer}/introspect"),
+			});
+			let app = Router::new().fallback(move || {
+				let response = response.clone();
+				async move { axum::Json(response) }
+			});
+			let handle = tokio::spawn(async move {
+				let _: std::io::Result<()> = axum::serve(listener, app).await;
+			});
+
+			Ok(DiscoveryServer {
+				url: format!("http://{addr}/.well-known/openid-configuration"),
+				handle,
+			})
+		})
+	}
+
+	/// Serve an arbitrary axum router on an ephemeral local port, for tests
+	/// that need a richer identity-provider mock than `discovery_server`.
+	pub(crate) fn mock_server(&self, app: Router) -> Result<MockServer> {
+		self.runtime.block_on(async move {
+			let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+			let addr = listener.local_addr()?;
+			let handle = tokio::spawn(async move {
+				let _: std::io::Result<()> = axum::serve(listener, app).await;
+			});
+
+			Ok(MockServer {
+				base_url: format!("http://{addr}"),
+				handle,
+			})
+		})
+	}
+
+	pub(crate) fn with_services<F, Fut>(&self, test: F) -> Result
+	where
+		F: FnOnce(Arc<Services>) -> Fut,
+		Fut: Future<Output = Result>,
+	{
+		let server = Server::new(Some(&self.args), Some(&self.runtime))?;
+
+		self.runtime.block_on(async {
+			let services = tuwunel::async_start(&server).await?;
+			let result = test(services.clone()).await;
+			let shutdown_result = server.server.shutdown();
+			drop(services);
+
+			let stop_result = tuwunel::async_stop(&server).await;
+			result.and(shutdown_result).and(stop_result)
+		})
+	}
+}
+
+pub(crate) struct DiscoveryServer {
+	pub(crate) url: String,
+	pub(crate) handle: tokio::task::JoinHandle<()>,
+}
+
+pub(crate) struct MockServer {
+	pub(crate) base_url: String,
+	pub(crate) handle: tokio::task::JoinHandle<()>,
+}

--- a/src/mindroom-tests/tests/synapse_admin_deactivate.rs
+++ b/src/mindroom-tests/tests/synapse_admin_deactivate.rs
@@ -1,0 +1,146 @@
+mod support;
+
+#[cfg(test)]
+mod tests {
+	use axum::{
+		Router,
+		body::Body,
+		http::{Request, StatusCode},
+	};
+	use tower::ServiceExt;
+	use tuwunel_core::{Result, ruma::user_id};
+	use tuwunel_service::users::PASSWORD_SENTINEL;
+
+	use super::support::Harness;
+
+	/// The Synapse admin deactivation endpoints are upstream code whose calls
+	/// into `users.deactivate_account` get re-adapted at every rebase to pass
+	/// `DeactivationReason::Admin` (see the doc comment on
+	/// `DeactivationReason`). Pin the observable contract at the route level
+	/// for both endpoints: an account deactivated through them records the
+	/// admin reason and is not resurrected by SSO re-login.
+	#[test]
+	fn synapse_admin_deactivation_records_admin_reason() -> Result {
+		let harness = Harness::new("mindroom_rebase_synapse_admin_deactivate", [])?;
+
+		harness.with_services(|services| async move {
+			// The server user is always an admin (`user_is_admin` short-circuit),
+			// which avoids standing up the admin room in the test database.
+			let admin = services.globals.server_user.clone();
+			if !services.users.exists(&admin).await {
+				services
+					.users
+					.create(&admin, Some(PASSWORD_SENTINEL), None)
+					.await?;
+			}
+
+			let token = "mindroom-test-synapse-admin-token-0123456789";
+			services
+				.users
+				.create_device(&admin, None, (Some(token), None), None, None, None)
+				.await?;
+
+			let (state, _guard) = tuwunel_api::router::state::create(services.clone());
+			let router =
+				tuwunel_api::router::build(Router::new(), &services.server).with_state(state);
+
+			// `POST /_synapse/admin/v1/deactivate/{user_id}`
+			let alice = user_id!("@sso-admin-deact-v1:localhost");
+			services
+				.users
+				.create(alice, Some(PASSWORD_SENTINEL), Some("sso"))
+				.await?;
+
+			let response = router
+				.clone()
+				.oneshot(
+					Request::builder()
+						.method("POST")
+						.uri(format!("/_synapse/admin/v1/deactivate/{alice}"))
+						.header("Authorization", format!("Bearer {token}"))
+						.header("Content-Type", "application/json")
+						.header("X-Forwarded-For", "127.0.0.1")
+						.body(Body::from(r#"{"erase":false}"#))
+						.expect("valid request"),
+				)
+				.await
+				.expect("router response");
+			assert_eq!(
+				response.status(),
+				StatusCode::OK,
+				"v1 deactivate should succeed for the server admin",
+			);
+
+			assert!(
+				services.users.is_deactivated(alice).await?,
+				"v1 deactivate should deactivate the account",
+			);
+			assert_eq!(
+				services
+					.users
+					.deactivation_reason(alice)
+					.await
+					.as_deref(),
+				Some("admin"),
+				"v1 deactivate must record the admin reason",
+			);
+			assert!(
+				!services
+					.users
+					.maybe_reactivate_deactivated_sso(alice)
+					.await?,
+				"an account the v1 endpoint deactivated must not SSO-reactivate",
+			);
+
+			// `PUT /_synapse/admin/v2/users/{user_id}` with `deactivated: true`
+			let bob = user_id!("@sso-admin-deact-v2:localhost");
+			services
+				.users
+				.create(bob, Some(PASSWORD_SENTINEL), Some("sso"))
+				.await?;
+
+			let response = router
+				.clone()
+				.oneshot(
+					Request::builder()
+						.method("PUT")
+						.uri(format!("/_synapse/admin/v2/users/{bob}"))
+						.header("Authorization", format!("Bearer {token}"))
+						.header("Content-Type", "application/json")
+						.header("X-Forwarded-For", "127.0.0.1")
+						.body(Body::from(r#"{"deactivated":true}"#))
+						.expect("valid request"),
+				)
+				.await
+				.expect("router response");
+			assert_eq!(
+				response.status(),
+				StatusCode::OK,
+				"v2 create-or-modify of an existing user should succeed",
+			);
+
+			assert!(
+				services.users.is_deactivated(bob).await?,
+				"v2 deactivated flag should deactivate the account",
+			);
+			assert_eq!(
+				services
+					.users
+					.deactivation_reason(bob)
+					.await
+					.as_deref(),
+				Some("admin"),
+				"v2 deactivated flag must record the admin reason",
+			);
+			assert!(
+				!services
+					.users
+					.maybe_reactivate_deactivated_sso(bob)
+					.await?,
+				"an account the v2 endpoint deactivated must not SSO-reactivate",
+			);
+
+			Ok(())
+		})
+	}
+}

--- a/src/service/deactivate/mod.rs
+++ b/src/service/deactivate/mod.rs
@@ -8,7 +8,7 @@ use ruma::{
 };
 use tuwunel_core::{Event, Result, info, pdu::PduBuilder, warn};
 
-use crate::profile::Propagation;
+use crate::{profile::Propagation, users::DeactivationReason};
 
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
@@ -33,10 +33,15 @@ impl Service {
 	///
 	/// When `erase` is `true`, additionally erase non-event data per
 	/// MSC4025: all global and per-room account data for the user.
-	pub async fn full_deactivate(&self, user_id: &UserId, erase: bool) -> Result {
+	pub async fn full_deactivate(
+		&self,
+		user_id: &UserId,
+		erase: bool,
+		reason: DeactivationReason,
+	) -> Result {
 		self.services
 			.users
-			.deactivate_account(user_id)
+			.deactivate_account(user_id, reason)
 			.await?;
 
 		self.services

--- a/src/service/edit_purge/mod.rs
+++ b/src/service/edit_purge/mod.rs
@@ -1,0 +1,2303 @@
+use std::{
+	collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
+	sync::Arc,
+	time::Duration,
+};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use ruma::{
+	Mxc, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, ServerName, UserId,
+};
+use serde_json::Value as JsonValue;
+use tokio::{
+	sync::{Mutex, Notify},
+	time::{MissedTickBehavior, interval},
+};
+use tuwunel_core::{
+	Result, Server, debug, info,
+	matrix::{
+		event::{Event, ExtractRelatesToInfo},
+		pdu::{PduEvent, RawPduId},
+	},
+	utils, warn,
+};
+use tuwunel_database::{Database, Map, serialize_to_vec};
+
+use crate::rooms::timeline::bias_count;
+
+pub struct Service {
+	interval: Duration,
+	interrupt: Notify,
+	pduid_pdu: Arc<Map>,
+	eventid_pduid: Arc<Map>,
+	eventid_shorteventid: Arc<Map>,
+	shorteventid_eventid: Arc<Map>,
+	roomid_tscount_pducount: Arc<Map>,
+	/// Last-scanned pdu_id key for incremental scanning.
+	last_scan_key: Mutex<Option<Vec<u8>>>,
+	/// Latest replacement seen so far for each (target, sender) during the
+	/// current full-table scan pass. This is persisted across purge cycles so
+	/// replacements split across scan windows are still compared.
+	latest_replace_by_target_sender:
+		Mutex<HashMap<(OwnedEventId, OwnedUserId), ReplaceCandidate>>,
+	/// Superseded candidates discovered in previous cycles but not yet deleted
+	/// because `batch_size` was reached.
+	pending_superseded_candidates: Mutex<VecDeque<(OwnedEventId, ReplaceCandidate)>>,
+	services: Services,
+}
+
+struct Services {
+	server: Arc<Server>,
+	db: Arc<Database>,
+	media: SidecarMedia,
+}
+
+enum SidecarMedia {
+	Runtime(Arc<crate::services::OnceServices>),
+	#[cfg(test)]
+	Test(Arc<dyn TestSidecarMedia>),
+}
+
+impl SidecarMedia {
+	async fn mxc_is_owned_by_user(&self, mxc: &Mxc<'_>, user: &UserId) -> bool {
+		match self {
+			| Self::Runtime(services) =>
+				services
+					.media
+					.mxc_is_owned_by_user(mxc, user)
+					.await,
+			#[cfg(test)]
+			| Self::Test(media) => media.mxc_is_owned_by_user(mxc, user).await,
+		}
+	}
+
+	async fn delete_owned_by(&self, mxc: &Mxc<'_>, user: &UserId) -> Result<bool> {
+		match self {
+			| Self::Runtime(services) => services.media.delete_owned_by(mxc, user).await,
+			#[cfg(test)]
+			| Self::Test(media) => media.delete_owned_by(mxc, user).await,
+		}
+	}
+}
+
+#[cfg(test)]
+#[async_trait]
+trait TestSidecarMedia: Send + Sync {
+	async fn mxc_is_owned_by_user(&self, mxc: &Mxc<'_>, user: &UserId) -> bool;
+
+	async fn delete_owned_by(&self, mxc: &Mxc<'_>, user: &UserId) -> Result<bool>;
+}
+
+/// A candidate replacement event with its metadata.
+#[derive(Clone)]
+struct ReplaceCandidate {
+	/// event_id for deterministic tie-breaks.
+	event_id: OwnedEventId,
+	/// Sender of the replacement event, used to verify media ownership.
+	sender: OwnedUserId,
+	/// The raw PduId bytes for deletion from pduid_pdu.
+	pdu_id_bytes: Vec<u8>,
+	/// Room and timestamp for removal from roomid_tscount_pducount.
+	room_id: OwnedRoomId,
+	origin_server_ts_ms: u64,
+	/// MindRoom long-text sidecar media referenced by this replacement event.
+	sidecar_mxcs: Vec<OwnedMxcUri>,
+}
+
+fn compare_replace_candidates(a: &ReplaceCandidate, b: &ReplaceCandidate) -> std::cmp::Ordering {
+	a.pdu_id_bytes
+		.cmp(&b.pdu_id_bytes)
+		.then_with(|| a.event_id.cmp(&b.event_id))
+}
+
+fn next_scan_start_key(key: &[u8]) -> Vec<u8> {
+	let mut next = Vec::with_capacity(key.len().saturating_add(1));
+	next.extend_from_slice(key);
+	next.push(0);
+	next
+}
+
+#[async_trait]
+impl crate::Service for Service {
+	fn build(args: &crate::Args<'_>) -> Result<Arc<Self>> {
+		let db = &args.db;
+		Ok(Arc::new(Self {
+			interval: Duration::from_secs(
+				args.server
+					.config
+					.mindroom_edit_purge_interval_secs,
+			),
+			interrupt: Notify::new(),
+			pduid_pdu: db["pduid_pdu"].clone(),
+			eventid_pduid: db["eventid_pduid"].clone(),
+			eventid_shorteventid: db["eventid_shorteventid"].clone(),
+			shorteventid_eventid: db["shorteventid_eventid"].clone(),
+			roomid_tscount_pducount: db["roomid_tscount_pducount"].clone(),
+			last_scan_key: Mutex::new(None),
+			latest_replace_by_target_sender: Mutex::new(HashMap::new()),
+			pending_superseded_candidates: Mutex::new(VecDeque::new()),
+			services: Services {
+				server: args.server.clone(),
+				db: args.db.clone(),
+				media: SidecarMedia::Runtime(args.services.clone()),
+			},
+		}))
+	}
+
+	#[tracing::instrument(skip_all, name = "edit_purge", level = "debug")]
+	async fn worker(self: Arc<Self>) -> Result {
+		if !self
+			.services
+			.server
+			.config
+			.mindroom_edit_purge_enabled
+		{
+			debug!("MindRoom edit purge disabled");
+			return Ok(());
+		}
+
+		if self.services.db.is_read_only() {
+			warn!("MindRoom edit purge enabled but database is read-only; skipping purge worker");
+			return Ok(());
+		}
+
+		info!(
+			"MindRoom edit purge worker started (interval={}s, min_age={}s, batch={})",
+			self.services
+				.server
+				.config
+				.mindroom_edit_purge_interval_secs,
+			self.services
+				.server
+				.config
+				.mindroom_edit_purge_min_age_secs,
+			self.services
+				.server
+				.config
+				.mindroom_edit_purge_batch_size,
+		);
+
+		let mut i = interval(self.interval);
+		i.set_missed_tick_behavior(MissedTickBehavior::Delay);
+		i.reset_after(self.interval);
+		let shutdown = self.services.server.until_shutdown();
+		tokio::pin!(shutdown);
+		loop {
+			tokio::select! {
+				() = self.interrupt.notified() => break,
+				() = &mut shutdown => break,
+				_ = i.tick() => (),
+			}
+
+			if let Err(e) = self.purge_cycle().await {
+				warn!(%e, "MindRoom edit purge cycle failed");
+			}
+		}
+
+		Ok(())
+	}
+
+	async fn interrupt(&self) { self.interrupt.notify_waiters(); }
+
+	fn name(&self) -> &str { crate::service::make_name(std::module_path!()) }
+}
+
+impl Service {
+	/// Run a single purge cycle: incrementally scan PDUs, find superseded
+	/// m.replace events, and delete them with corked writes (batched flush),
+	/// not as a single transactional unit.
+	///
+	/// Public so the maintenance worker, an operator, and integration tests can
+	/// trigger a cycle on demand; it does not consult
+	/// `mindroom_edit_purge_enabled` (the worker loop gates on that), only
+	/// `mindroom_edit_purge_dry_run`.
+	#[allow(clippy::too_many_lines)]
+	#[tracing::instrument(skip_all, level = "debug")]
+	pub async fn purge_cycle(&self) -> Result {
+		let config = &self.services.server.config;
+		let min_age_ms = config
+			.mindroom_edit_purge_min_age_secs
+			.saturating_mul(1000);
+		let batch_size = config.mindroom_edit_purge_batch_size;
+		let scan_limit = config
+			.mindroom_edit_purge_batch_size
+			.saturating_mul(10)
+			.max(config.mindroom_edit_purge_scan_limit);
+		let backlog_cap = scan_limit
+			.max(batch_size.saturating_mul(32))
+			.max(1_000);
+		let dry_run = config.mindroom_edit_purge_dry_run;
+		let now_ms = utils::millis_since_unix_epoch();
+		let cutoff_ms = now_ms.saturating_sub(min_age_ms);
+
+		// Phase 1: Incrementally scan PDUs from the last cursor position and
+		// compare m.replace events against per-(target, sender) latest state that
+		// persists across cycles during a full-table scan pass.
+		let mut superseded_candidates: Vec<(OwnedEventId, ReplaceCandidate)> = Vec::new();
+		let pending_len = self
+			.pending_superseded_candidates
+			.lock()
+			.await
+			.len();
+		let should_scan = pending_len < backlog_cap;
+		let mut latest_replace_by_target_sender =
+			self.latest_replace_by_target_sender.lock().await;
+
+		let mut last_key: Option<Vec<u8>> = None;
+		let mut scanned: usize = 0;
+		let mut reached_end = true;
+		let mut reset_scan_state = false;
+
+		if should_scan {
+			let resume_key = self.last_scan_key.lock().await.clone();
+			// raw_stream_from is inclusive, so move to the next lexicographic key
+			// to avoid reprocessing the last key from the previous cycle.
+			let resume_from_key = resume_key.as_deref().map(next_scan_start_key);
+
+			let stream = resume_from_key
+				.as_ref()
+				.map_or_else(
+					|| self.pduid_pdu.raw_stream().boxed(),
+					|key| self.pduid_pdu.raw_stream_from(key).boxed(),
+				)
+				.peekable();
+			tokio::pin!(stream);
+
+			while let Some(kv) = stream.next().await {
+				let Ok((key, value)) = kv else {
+					continue;
+				};
+
+				last_key = Some(key.to_vec());
+				scanned = scanned.saturating_add(1);
+
+				if let Ok(pdu) = serde_json::from_slice::<PduEvent>(value)
+					&& let Ok(content) = pdu.get_content::<ExtractRelatesToInfo>()
+					&& content.relates_to.rel_type == "m.replace"
+				{
+					let ts: u64 = pdu.origin_server_ts.into();
+					if ts <= cutoff_ms {
+						let target_event_id = content.relates_to.event_id;
+						let group_key = (target_event_id.clone(), pdu.sender.clone());
+						let candidate = ReplaceCandidate {
+							event_id: pdu.event_id.clone(),
+							sender: pdu.sender.clone(),
+							pdu_id_bytes: key.to_vec(),
+							room_id: pdu.room_id.clone(),
+							origin_server_ts_ms: ts,
+							sidecar_mxcs: extract_mindroom_long_text_sidecar_mxcs(&pdu),
+						};
+
+						match latest_replace_by_target_sender.entry(group_key) {
+							| Entry::Vacant(entry) => {
+								entry.insert(candidate);
+							},
+							| Entry::Occupied(mut entry) => {
+								if compare_replace_candidates(&candidate, entry.get()).is_gt() {
+									let superseded =
+										std::mem::replace(entry.get_mut(), candidate);
+									superseded_candidates.push((target_event_id, superseded));
+								} else {
+									superseded_candidates.push((target_event_id, candidate));
+								}
+							},
+						}
+					}
+				}
+
+				// Backpressure: stop scanning when the pending queue is near capacity.
+				if pending_len.saturating_add(superseded_candidates.len()) >= backlog_cap {
+					reached_end = false;
+					break;
+				}
+
+				// Limit scan size per cycle to avoid blocking too long;
+				// we'll resume from this position next cycle.
+				if scanned >= scan_limit {
+					reached_end = stream.as_mut().peek().await.is_none();
+					break;
+				}
+			}
+		} else {
+			debug!(
+				backlog = pending_len,
+				cap = backlog_cap,
+				"MindRoom edit purge backlog is full; skipping scan this cycle"
+			);
+		}
+
+		// Under sustained high write load this pass may never reach the end; cap
+		// retained latest-state entries to avoid unbounded growth.
+		let latest_state_cap = scan_limit.saturating_mul(4).max(10_000);
+		if latest_replace_by_target_sender.len() > latest_state_cap {
+			warn!(
+				groups = latest_replace_by_target_sender.len(),
+				cap = latest_state_cap,
+				"MindRoom edit purge latest-state cache exceeded cap; resetting scan pass"
+			);
+			latest_replace_by_target_sender.clear();
+			reset_scan_state = true;
+		}
+
+		// Update the cursor: if we reached the end, reset to None (start
+		// over next cycle). Otherwise, save the last key for resuming.
+		{
+			let mut cursor = self.last_scan_key.lock().await;
+			if !should_scan {
+				// Preserve existing cursor when skipping scans due to backlog
+				// pressure.
+			} else if reached_end || reset_scan_state {
+				*cursor = None;
+				latest_replace_by_target_sender.clear();
+			} else {
+				*cursor = last_key;
+			}
+		}
+		drop(latest_replace_by_target_sender);
+
+		// Phase 2: Purge superseded events discovered during this and prior scan
+		// windows.
+		let mut purge_count: usize = 0;
+		let mut target_ids: HashSet<OwnedEventId> = HashSet::new();
+		let mut pending_superseded = self.pending_superseded_candidates.lock().await;
+		pending_superseded.extend(superseded_candidates);
+		let purge_budget = pending_superseded.len().min(batch_size);
+		let purge_batch: Vec<_> = pending_superseded.drain(..purge_budget).collect();
+		drop(pending_superseded);
+
+		let cork = if !dry_run {
+			Some(self.services.db.cork_and_flush())
+		} else {
+			None
+		};
+
+		let mut sidecar_cleanup_candidates: Vec<(OwnedEventId, ReplaceCandidate)> = Vec::new();
+		for (target_event_id, candidate) in purge_batch {
+			if dry_run {
+				info!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					"[dry-run] Would purge superseded edit"
+				);
+				purge_count = purge_count.saturating_add(1);
+				target_ids.insert(target_event_id.clone());
+				sidecar_cleanup_candidates.push((target_event_id, candidate));
+				continue;
+			}
+
+			if self.delete_event(&candidate) {
+				debug!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					"Purged superseded edit event"
+				);
+				purge_count = purge_count.saturating_add(1);
+				target_ids.insert(target_event_id.clone());
+				sidecar_cleanup_candidates.push((target_event_id, candidate));
+			} else {
+				let mut pending = self.pending_superseded_candidates.lock().await;
+				pending.push_back((target_event_id, candidate));
+			}
+		}
+		drop(cork);
+
+		let protected_mxcs = self
+			.retained_referenced_mxcs(&sidecar_cleanup_candidates)
+			.await;
+		for (target_event_id, candidate) in sidecar_cleanup_candidates {
+			self.process_sidecar_media(&target_event_id, &candidate, dry_run, &protected_mxcs)
+				.await;
+		}
+
+		let target_count = target_ids.len();
+		let remaining_backlog = self
+			.pending_superseded_candidates
+			.lock()
+			.await
+			.len();
+
+		if purge_count > 0 || target_count > 0 || remaining_backlog > 0 {
+			info!(
+				"MindRoom edit purge: {}purged {purge_count} superseded edits for \
+				 {target_count} target events (scanned {scanned} PDUs, backlog \
+				 {remaining_backlog})",
+				if dry_run { "[dry-run] would have " } else { "" },
+			);
+		} else {
+			debug!("MindRoom edit purge: no superseded edits found (scanned {scanned} PDUs)");
+		}
+
+		Ok(())
+	}
+
+	/// Delete a superseded edit event from the database.
+	///
+	/// Returns true only when all targeted row/index removals succeeded.
+	/// Returns false when purge should retry this candidate in a later cycle.
+	fn delete_event(&self, candidate: &ReplaceCandidate) -> bool {
+		// Remove from pduid_pdu (the main event storage)
+		if let Err(e) = self
+			.pduid_pdu
+			.remove_fallible(&candidate.pdu_id_bytes)
+		{
+			warn!(
+				%e,
+				event_id = %candidate.event_id,
+				"Failed to remove superseded edit from pduid_pdu; will retry candidate"
+			);
+			return false;
+		}
+
+		// Remove from eventid_pduid (event_id -> pdu_id index)
+		if let Err(e) = self
+			.eventid_pduid
+			.remove_fallible(candidate.event_id.as_bytes())
+		{
+			warn!(
+				%e,
+				event_id = %candidate.event_id,
+				"Failed to remove superseded edit from eventid_pduid; will retry candidate"
+			);
+			return false;
+		}
+
+		let pdu_count = RawPduId::from(candidate.pdu_id_bytes.as_slice()).count();
+		let room_id: &RoomId = candidate.room_id.as_ref();
+		let ts_index_key = match serialize_to_vec((
+			room_id,
+			candidate.origin_server_ts_ms,
+			bias_count(pdu_count),
+		)) {
+			| Ok(key) => key,
+			| Err(e) => {
+				warn!(
+					%e,
+					event_id = %candidate.event_id,
+					room_id = %candidate.room_id,
+					ts = candidate.origin_server_ts_ms,
+					"Failed to serialize room timestamp index key; will retry candidate"
+				);
+				return false;
+			},
+		};
+
+		if self
+			.roomid_tscount_pducount
+			.get_blocking(&ts_index_key)
+			.is_ok_and(|indexed_count| &*indexed_count == pdu_count.as_slice())
+			&& let Err(e) = self
+				.roomid_tscount_pducount
+				.remove_fallible(&ts_index_key)
+		{
+			warn!(
+				%e,
+				event_id = %candidate.event_id,
+				room_id = %candidate.room_id,
+				ts = candidate.origin_server_ts_ms,
+				"Failed to remove superseded edit from roomid_tscount_pducount; will retry candidate"
+			);
+			return false;
+		}
+
+		// Remove from eventid_shorteventid / shorteventid_eventid
+		// (short numeric ID mappings that would otherwise be orphaned)
+		if let Ok(short_bytes) = self
+			.eventid_shorteventid
+			.get_blocking(candidate.event_id.as_bytes())
+			&& let Err(e) = self
+				.shorteventid_eventid
+				.remove_fallible(&*short_bytes)
+		{
+			warn!(
+				%e,
+				event_id = %candidate.event_id,
+				"Failed to remove superseded edit from shorteventid_eventid; will retry candidate"
+			);
+			return false;
+		}
+
+		if let Err(e) = self
+			.eventid_shorteventid
+			.remove_fallible(candidate.event_id.as_bytes())
+		{
+			warn!(
+				%e,
+				event_id = %candidate.event_id,
+				"Failed to remove superseded edit from eventid_shorteventid; will retry candidate"
+			);
+			return false;
+		}
+
+		// Note: we intentionally do NOT remove from tofrom_relation.
+		// The relation entry is tiny (16 bytes) and removing it could
+		// affect federation or relation queries. The PDU itself being
+		// gone is sufficient — lookups via the relation will simply
+		// fail to find the PDU and skip it.
+		true
+	}
+
+	async fn process_sidecar_media(
+		&self,
+		target_event_id: &OwnedEventId,
+		candidate: &ReplaceCandidate,
+		dry_run: bool,
+		protected_mxcs: &HashSet<OwnedMxcUri>,
+	) {
+		if candidate.sidecar_mxcs.is_empty() {
+			return;
+		}
+
+		let local_server_name: &ServerName = self.services.server.name.as_ref();
+		if candidate.sender.server_name() != local_server_name {
+			warn!(
+				event_id = %candidate.event_id,
+				sender = %candidate.sender,
+				target = %target_event_id,
+				"Skipping MindRoom long-text sidecar cleanup for non-local edit sender"
+			);
+			return;
+		}
+
+		for mxc_uri in &candidate.sidecar_mxcs {
+			if protected_mxcs.contains(mxc_uri) {
+				debug!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					mxc = %mxc_uri,
+					"Skipping MindRoom long-text sidecar media deletion; MXC is still \
+					 referenced by a retained event"
+				);
+				continue;
+			}
+
+			let Ok(mxc_server_name) = mxc_uri.server_name() else {
+				warn!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					mxc = %mxc_uri,
+					"Skipping invalid MindRoom long-text sidecar MXC"
+				);
+				continue;
+			};
+
+			if mxc_server_name != local_server_name {
+				debug!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					mxc = %mxc_uri,
+					"Skipping remote MindRoom long-text sidecar MXC"
+				);
+				continue;
+			}
+
+			let Ok(mxc) = Mxc::try_from(mxc_uri.as_str()) else {
+				warn!(
+					event_id = %candidate.event_id,
+					target = %target_event_id,
+					mxc = %mxc_uri,
+					"Skipping unparsable MindRoom long-text sidecar MXC"
+				);
+				continue;
+			};
+
+			if dry_run {
+				if self
+					.services
+					.media
+					.mxc_is_owned_by_user(&mxc, &candidate.sender)
+					.await
+				{
+					info!(
+						event_id = %candidate.event_id,
+						target = %target_event_id,
+						mxc = %mxc_uri,
+						"[dry-run] Would delete MindRoom long-text sidecar media"
+					);
+				} else {
+					warn!(
+						event_id = %candidate.event_id,
+						target = %target_event_id,
+						mxc = %mxc_uri,
+						sender = %candidate.sender,
+						"[dry-run] Would not delete MindRoom long-text sidecar media; \
+						 ownership check failed"
+					);
+				}
+				continue;
+			}
+
+			match self
+				.services
+				.media
+				.delete_owned_by(&mxc, &candidate.sender)
+				.await
+			{
+				| Ok(true) => {
+					debug!(
+						event_id = %candidate.event_id,
+						target = %target_event_id,
+						mxc = %mxc_uri,
+						"Deleted MindRoom long-text sidecar media for purged edit"
+					);
+				},
+				| Ok(false) => {
+					warn!(
+						event_id = %candidate.event_id,
+						target = %target_event_id,
+						mxc = %mxc_uri,
+						sender = %candidate.sender,
+						"Skipping MindRoom long-text sidecar media deletion; ownership check \
+						 failed"
+					);
+				},
+				| Err(e) => {
+					warn!(
+						%e,
+						event_id = %candidate.event_id,
+						target = %target_event_id,
+						mxc = %mxc_uri,
+						"Failed to delete MindRoom long-text sidecar media for purged edit"
+					);
+				},
+			}
+		}
+	}
+
+	async fn retained_referenced_mxcs(
+		&self,
+		cleanup_candidates: &[(OwnedEventId, ReplaceCandidate)],
+	) -> HashSet<OwnedMxcUri> {
+		let candidate_mxcs: HashSet<OwnedMxcUri> = cleanup_candidates
+			.iter()
+			.flat_map(|(_, candidate)| candidate.sidecar_mxcs.iter().cloned())
+			.collect();
+
+		if candidate_mxcs.is_empty() {
+			return HashSet::new();
+		}
+
+		let ignored_event_ids: HashSet<OwnedEventId> = cleanup_candidates
+			.iter()
+			.map(|(_, candidate)| candidate.event_id.clone())
+			.collect();
+		let mut protected_mxcs = HashSet::new();
+		let stream = self.pduid_pdu.raw_stream();
+		tokio::pin!(stream);
+
+		while let Some(kv) = stream.next().await {
+			let Ok((_key, value)) = kv else {
+				continue;
+			};
+
+			let Ok(pdu) = serde_json::from_slice::<PduEvent>(value) else {
+				continue;
+			};
+
+			if ignored_event_ids.contains(&pdu.event_id) {
+				continue;
+			}
+
+			let content = pdu.get_content_as_value();
+			collect_referenced_candidate_mxcs(&content, &candidate_mxcs, &mut protected_mxcs);
+
+			if protected_mxcs.len() == candidate_mxcs.len() {
+				break;
+			}
+		}
+
+		protected_mxcs
+	}
+}
+
+fn extract_mindroom_long_text_sidecar_mxcs(pdu: &PduEvent) -> Vec<OwnedMxcUri> {
+	let content = pdu.get_content_as_value();
+	let mut mxcs = Vec::new();
+
+	collect_mindroom_long_text_sidecar_mxcs(&content, &mut mxcs);
+	if let Some(new_content) = content.get("m.new_content") {
+		collect_mindroom_long_text_sidecar_mxcs(new_content, &mut mxcs);
+	}
+
+	mxcs
+}
+
+fn collect_mindroom_long_text_sidecar_mxcs(content: &JsonValue, mxcs: &mut Vec<OwnedMxcUri>) {
+	if content.get("msgtype").and_then(JsonValue::as_str) != Some("m.file") {
+		return;
+	}
+
+	let Some(long_text) = content.get("io.mindroom.long_text") else {
+		return;
+	};
+
+	if long_text
+		.get("version")
+		.and_then(JsonValue::as_u64)
+		!= Some(2)
+		|| long_text
+			.get("encoding")
+			.and_then(JsonValue::as_str)
+			!= Some("matrix_event_content_json")
+	{
+		return;
+	}
+
+	let url = content.get("url").and_then(JsonValue::as_str);
+	let encrypted_url = content
+		.get("file")
+		.and_then(|file| file.get("url"))
+		.and_then(JsonValue::as_str);
+
+	for mxc in url.into_iter().chain(encrypted_url) {
+		let mxc = OwnedMxcUri::from(mxc.to_owned());
+		if mxc.is_valid() && !mxcs.iter().any(|existing| existing == &mxc) {
+			mxcs.push(mxc);
+		}
+	}
+}
+
+fn collect_referenced_candidate_mxcs(
+	value: &JsonValue,
+	candidate_mxcs: &HashSet<OwnedMxcUri>,
+	protected_mxcs: &mut HashSet<OwnedMxcUri>,
+) {
+	match value {
+		| JsonValue::String(s) if s.starts_with("mxc://") => {
+			let mxc = OwnedMxcUri::from(s.to_owned());
+			if candidate_mxcs.contains(&mxc) {
+				protected_mxcs.insert(mxc);
+			}
+		},
+		| JsonValue::Array(items) =>
+			for item in items {
+				collect_referenced_candidate_mxcs(item, candidate_mxcs, protected_mxcs);
+			},
+		| JsonValue::Object(map) =>
+			for item in map.values() {
+				collect_referenced_candidate_mxcs(item, candidate_mxcs, protected_mxcs);
+			},
+		| _ => {},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		collections::{HashMap, VecDeque},
+		fs,
+		path::{Path, PathBuf},
+		sync::{
+			Arc, Mutex as StdMutex, OnceLock,
+			atomic::{AtomicU64, Ordering},
+		},
+		time::Duration,
+	};
+
+	use async_trait::async_trait;
+	use ruma::{
+		EventId, Mxc, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, UInt, UserId,
+	};
+	use serde_json::value::RawValue;
+	use tokio::{
+		sync::{Mutex, MutexGuard, Notify},
+		time::timeout,
+	};
+	use tracing::subscriber::NoSubscriber;
+	use tuwunel_core::{
+		Result, Server,
+		config::Config,
+		log::{Logging, capture::State as CaptureState},
+		matrix::pdu::{EventHash, PduCount, PduEvent, PduId, RawPduId},
+		metrics::Metrics,
+		utils,
+	};
+	use tuwunel_database::{Database, serialize_to_vec};
+
+	use super::{Service, Services, SidecarMedia, TestSidecarMedia, bias_count};
+
+	static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(1);
+	static TEST_DB_OPEN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+	#[derive(Clone, Copy)]
+	struct HarnessConfig {
+		min_age_secs: u64,
+		batch_size: usize,
+		scan_limit: usize,
+		dry_run: bool,
+		enabled: bool,
+		read_only: bool,
+	}
+
+	impl Default for HarnessConfig {
+		fn default() -> Self {
+			Self {
+				min_age_secs: 0,
+				batch_size: 100,
+				scan_limit: 100_000,
+				dry_run: false,
+				enabled: true,
+				read_only: false,
+			}
+		}
+	}
+
+	struct TestHarness {
+		service: Arc<Service>,
+		media: Arc<TestMedia>,
+		_temp_dir: PathBuf,
+		// Keep this field last so database handles drop before the test lock is released.
+		_db_guard: MutexGuard<'static, ()>,
+	}
+
+	#[derive(Default)]
+	struct TestMedia {
+		owners: StdMutex<HashMap<String, OwnedUserId>>,
+	}
+
+	#[async_trait]
+	impl TestSidecarMedia for TestMedia {
+		async fn mxc_is_owned_by_user(&self, mxc: &Mxc<'_>, user: &UserId) -> bool {
+			self.owners
+				.lock()
+				.expect("test media lock")
+				.get(&mxc.to_string())
+				.is_some_and(|owner| owner == user)
+		}
+
+		async fn delete_owned_by(&self, mxc: &Mxc<'_>, user: &UserId) -> Result<bool> {
+			let mxc = mxc.to_string();
+			let mut owners = self.owners.lock().expect("test media lock");
+			if owners.get(&mxc).is_none_or(|owner| owner != user) {
+				return Ok(false);
+			}
+
+			owners.remove(&mxc);
+			Ok(true)
+		}
+	}
+
+	#[derive(Clone)]
+	struct StoredEvent {
+		event_id: OwnedEventId,
+		room_id: OwnedRoomId,
+		origin_server_ts_ms: u64,
+		pdu_key: Vec<u8>,
+		pdu_count: Vec<u8>,
+		short_key: Vec<u8>,
+	}
+
+	async fn make_harness(cfg: HarnessConfig) -> TestHarness {
+		let db_guard = TEST_DB_OPEN_LOCK
+			.get_or_init(|| Mutex::new(()))
+			.lock()
+			.await;
+		let temp_dir = unique_temp_dir();
+
+		if cfg.read_only {
+			let bootstrap_cfg = HarnessConfig { read_only: false, ..cfg };
+			let (bootstrap_server, bootstrap_db) = open_server_db(&temp_dir, bootstrap_cfg).await;
+			drop(bootstrap_db);
+			drop(bootstrap_server);
+		}
+
+		let (server, db) = open_server_db(&temp_dir, cfg).await;
+		let media = Arc::new(TestMedia::default());
+		let service = Arc::new(Service {
+			interval: Duration::from_secs(server.config.mindroom_edit_purge_interval_secs),
+			interrupt: Notify::new(),
+			pduid_pdu: db["pduid_pdu"].clone(),
+			eventid_pduid: db["eventid_pduid"].clone(),
+			eventid_shorteventid: db["eventid_shorteventid"].clone(),
+			shorteventid_eventid: db["shorteventid_eventid"].clone(),
+			roomid_tscount_pducount: db["roomid_tscount_pducount"].clone(),
+			last_scan_key: Mutex::new(None),
+			latest_replace_by_target_sender: Mutex::new(HashMap::new()),
+			pending_superseded_candidates: Mutex::new(VecDeque::new()),
+			services: Services {
+				server,
+				db,
+				media: SidecarMedia::Test(media.clone()),
+			},
+		});
+
+		TestHarness {
+			service,
+			media,
+			_temp_dir: temp_dir,
+			_db_guard: db_guard,
+		}
+	}
+
+	async fn open_server_db(temp_dir: &Path, cfg: HarnessConfig) -> (Arc<Server>, Arc<Database>) {
+		let db_path = temp_dir.join("db");
+		let config_path = temp_dir.join(if cfg.read_only {
+			"tuwunel-read-only.toml"
+		} else {
+			"tuwunel.toml"
+		});
+
+		fs::create_dir_all(temp_dir).expect("create test temp dir");
+		let config_contents = format!(
+			r#"[global]
+server_name = "example.com"
+database_path = "{}"
+mindroom_edit_purge_enabled = {}
+mindroom_edit_purge_min_age_secs = {}
+mindroom_edit_purge_interval_secs = 60
+mindroom_edit_purge_batch_size = {}
+mindroom_edit_purge_scan_limit = {}
+mindroom_edit_purge_dry_run = {}
+rocksdb_read_only = {}
+"#,
+			db_path.display(),
+			cfg.enabled,
+			cfg.min_age_secs,
+			cfg.batch_size,
+			cfg.scan_limit,
+			cfg.dry_run,
+			cfg.read_only,
+		);
+		fs::write(&config_path, config_contents).expect("write test config");
+
+		let figment = Config::load(std::iter::once(config_path.as_path())).expect("load config");
+		let config = Config::new(&figment).expect("parse config");
+		let log = Logging {
+			reload: Default::default(),
+			capture: Arc::new(CaptureState::new()),
+			subscriber: Arc::new(NoSubscriber::new()),
+		};
+		let runtime = tokio::runtime::Handle::current();
+		let metrics = Metrics::new(Some(&runtime));
+		let server = Arc::new(Server::new(config, Some(&runtime), log, metrics));
+		let db = Database::open(&server)
+			.await
+			.expect("open test database");
+
+		(server, db)
+	}
+
+	fn unique_temp_dir() -> PathBuf {
+		let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+		let pid = std::process::id();
+		let path = std::env::temp_dir().join(format!("tuwunel-edit-purge-{pid}-{id}"));
+		fs::create_dir_all(&path).expect("create unique test dir");
+		path
+	}
+
+	fn pdu_key(index: u32) -> Vec<u8> {
+		let raw = RawPduId::from(PduId {
+			shortroomid: 1,
+			count: PduCount::Normal(u64::from(index)),
+		});
+		raw.as_bytes().to_vec()
+	}
+
+	fn make_pdu(event_id: &str, sender: &str, ts: u64, replace_target: Option<&str>) -> PduEvent {
+		let content = replace_target.map_or_else(
+			|| r#"{"body":"original"}"#.to_owned(),
+			|target| {
+				format!(
+					r#"{{"body":"edited","m.relates_to":{{"rel_type":"m.replace","event_id":"{target}"}}}}"#
+				)
+			},
+		);
+
+		make_pdu_with_content(event_id, sender, ts, content)
+	}
+
+	fn make_pdu_with_content(event_id: &str, sender: &str, ts: u64, content: String) -> PduEvent {
+		PduEvent {
+			kind: ruma::events::TimelineEventType::RoomMessage,
+			content: RawValue::from_string(content)
+				.expect("valid JSON content")
+				.into(),
+			event_id: EventId::parse(event_id).expect("valid event id"),
+			room_id: OwnedRoomId::try_from("!room:example.com").expect("valid room id"),
+			sender: OwnedUserId::try_from(sender).expect("valid sender"),
+			state_key: None,
+			redacts: None,
+			prev_events: Default::default(),
+			auth_events: Default::default(),
+			origin_server_ts: UInt::try_from(ts).expect("valid timestamp"),
+			depth: UInt::try_from(1_u64).expect("valid depth"),
+			hashes: EventHash::default(),
+			origin: None,
+			unsigned: None,
+		}
+	}
+
+	fn long_text_sidecar_content(target: &str, mxc: &str) -> String {
+		format!(
+			r#"{{
+				"body":"message-content.json",
+				"msgtype":"m.file",
+				"url":"{mxc}",
+				"io.mindroom.long_text":{{
+					"version":2,
+					"encoding":"matrix_event_content_json"
+				}},
+				"m.relates_to":{{
+					"rel_type":"m.replace",
+					"event_id":"{target}"
+				}}
+			}}"#
+		)
+	}
+
+	fn encrypted_long_text_sidecar_content(target: &str, mxc: &str) -> String {
+		format!(
+			r#"{{
+				"body":"message-content.json",
+				"msgtype":"m.file",
+				"file":{{"url":"{mxc}"}},
+				"io.mindroom.long_text":{{
+					"version":2,
+					"encoding":"matrix_event_content_json"
+				}},
+				"m.relates_to":{{
+					"rel_type":"m.replace",
+					"event_id":"{target}"
+				}}
+			}}"#
+		)
+	}
+
+	fn normal_file_content(target: &str, mxc: &str) -> String {
+		format!(
+			r#"{{
+				"body":"ordinary-file.bin",
+				"msgtype":"m.file",
+				"url":"{mxc}",
+				"m.relates_to":{{
+					"rel_type":"m.replace",
+					"event_id":"{target}"
+				}}
+			}}"#
+		)
+	}
+
+	fn insert_event(
+		service: &Service,
+		key_index: u32,
+		event_id: &str,
+		sender: &str,
+		ts: u64,
+		replace_target: Option<&str>,
+	) -> StoredEvent {
+		let pdu = make_pdu(event_id, sender, ts, replace_target);
+		let event_id = pdu.event_id.clone();
+		let room_id = pdu.room_id.clone();
+		let origin_server_ts_ms = u64::from(pdu.origin_server_ts);
+		let key = pdu_key(key_index);
+		let pdu_count = RawPduId::from(key.as_slice()).count();
+		let short_key = key_index.to_be_bytes().to_vec();
+		let value = serde_json::to_vec(&pdu).expect("serialize pdu");
+
+		service.pduid_pdu.insert(&key, value);
+		service
+			.eventid_pduid
+			.insert(event_id.as_bytes(), &key);
+		service
+			.eventid_shorteventid
+			.insert(event_id.as_bytes(), &short_key);
+		service
+			.shorteventid_eventid
+			.insert(&short_key, event_id.as_bytes());
+		let room_id_ref: &RoomId = room_id.as_ref();
+		service
+			.roomid_tscount_pducount
+			.put_raw((room_id_ref, origin_server_ts_ms, bias_count(pdu_count)), pdu_count);
+
+		StoredEvent {
+			event_id,
+			room_id,
+			origin_server_ts_ms,
+			pdu_key: key,
+			pdu_count: pdu_count.to_vec(),
+			short_key,
+		}
+	}
+
+	fn insert_event_with_content(
+		service: &Service,
+		key_index: u32,
+		event_id: &str,
+		sender: &str,
+		ts: u64,
+		content: String,
+	) -> StoredEvent {
+		let pdu = make_pdu_with_content(event_id, sender, ts, content);
+		let event_id = pdu.event_id.clone();
+		let room_id = pdu.room_id.clone();
+		let origin_server_ts_ms = u64::from(pdu.origin_server_ts);
+		let key = pdu_key(key_index);
+		let pdu_count = RawPduId::from(key.as_slice()).count();
+		let short_key = key_index.to_be_bytes().to_vec();
+		let value = serde_json::to_vec(&pdu).expect("serialize pdu");
+
+		service.pduid_pdu.insert(&key, value);
+		service
+			.eventid_pduid
+			.insert(event_id.as_bytes(), &key);
+		service
+			.eventid_shorteventid
+			.insert(event_id.as_bytes(), &short_key);
+		service
+			.shorteventid_eventid
+			.insert(&short_key, event_id.as_bytes());
+		let room_id_ref: &RoomId = room_id.as_ref();
+		service
+			.roomid_tscount_pducount
+			.put_raw((room_id_ref, origin_server_ts_ms, bias_count(pdu_count)), pdu_count);
+
+		StoredEvent {
+			event_id,
+			room_id,
+			origin_server_ts_ms,
+			pdu_key: key,
+			pdu_count: pdu_count.to_vec(),
+			short_key,
+		}
+	}
+
+	fn assert_event_present(service: &Service, event: &StoredEvent) {
+		assert!(
+			service
+				.pduid_pdu
+				.get_blocking(&event.pdu_key)
+				.is_ok(),
+			"expected pduid_pdu entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_pduid
+				.get_blocking(event.event_id.as_bytes())
+				.is_ok(),
+			"expected eventid_pduid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_shorteventid
+				.get_blocking(event.event_id.as_bytes())
+				.is_ok(),
+			"expected eventid_shorteventid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.shorteventid_eventid
+				.get_blocking(&event.short_key)
+				.is_ok(),
+			"expected shorteventid_eventid entry for {}",
+			event.event_id,
+		);
+		let room_id: &RoomId = event.room_id.as_ref();
+		let ts_index_key = serialize_to_vec((
+			room_id,
+			event.origin_server_ts_ms,
+			bias_count(RawPduId::from(event.pdu_key.as_slice()).count()),
+		))
+		.expect("serialize timestamp index key");
+		let indexed_count = service
+			.roomid_tscount_pducount
+			.get_blocking(&ts_index_key)
+			.unwrap_or_else(|_| {
+				panic!("expected roomid_tscount_pducount entry for {}", event.event_id)
+			});
+		assert_eq!(
+			&*indexed_count,
+			event.pdu_count.as_slice(),
+			"expected timestamp index to point at {}",
+			event.event_id,
+		);
+	}
+
+	fn assert_event_absent(service: &Service, event: &StoredEvent) {
+		assert!(
+			service
+				.pduid_pdu
+				.get_blocking(&event.pdu_key)
+				.is_err(),
+			"expected no pduid_pdu entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_pduid
+				.get_blocking(event.event_id.as_bytes())
+				.is_err(),
+			"expected no eventid_pduid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_shorteventid
+				.get_blocking(event.event_id.as_bytes())
+				.is_err(),
+			"expected no eventid_shorteventid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.shorteventid_eventid
+				.get_blocking(&event.short_key)
+				.is_err(),
+			"expected no shorteventid_eventid entry for {}",
+			event.event_id,
+		);
+		let room_id: &RoomId = event.room_id.as_ref();
+		let ts_index_key = serialize_to_vec((
+			room_id,
+			event.origin_server_ts_ms,
+			bias_count(RawPduId::from(event.pdu_key.as_slice()).count()),
+		))
+		.expect("serialize timestamp index key");
+		assert!(
+			service
+				.roomid_tscount_pducount
+				.get_blocking(&ts_index_key)
+				.is_err(),
+			"expected no roomid_tscount_pducount entry for {}",
+			event.event_id,
+		);
+	}
+
+	fn assert_event_payload_indexes_absent(service: &Service, event: &StoredEvent) {
+		assert!(
+			service
+				.pduid_pdu
+				.get_blocking(&event.pdu_key)
+				.is_err(),
+			"expected no pduid_pdu entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_pduid
+				.get_blocking(event.event_id.as_bytes())
+				.is_err(),
+			"expected no eventid_pduid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.eventid_shorteventid
+				.get_blocking(event.event_id.as_bytes())
+				.is_err(),
+			"expected no eventid_shorteventid entry for {}",
+			event.event_id,
+		);
+		assert!(
+			service
+				.shorteventid_eventid
+				.get_blocking(&event.short_key)
+				.is_err(),
+			"expected no shorteventid_eventid entry for {}",
+			event.event_id,
+		);
+	}
+
+	fn create_media_for_user(harness: &TestHarness, mxc: &str, user: &str) {
+		Mxc::try_from(mxc).expect("valid MXC");
+		let user = OwnedUserId::try_from(user).expect("valid user id");
+		harness
+			.media
+			.owners
+			.lock()
+			.expect("test media lock")
+			.insert(mxc.to_owned(), user);
+	}
+
+	fn assert_media_present(harness: &TestHarness, mxc: &str) {
+		Mxc::try_from(mxc).expect("valid MXC");
+		assert!(
+			harness
+				.media
+				.owners
+				.lock()
+				.expect("test media lock")
+				.contains_key(mxc),
+			"expected media {mxc} to exist",
+		);
+	}
+
+	fn assert_media_absent(harness: &TestHarness, mxc: &str) {
+		Mxc::try_from(mxc).expect("valid MXC");
+		assert!(
+			!harness
+				.media
+				.owners
+				.lock()
+				.expect("test media lock")
+				.contains_key(mxc),
+			"expected media {mxc} to be absent",
+		);
+	}
+
+	#[test]
+	fn extract_long_text_sidecar_mxcs_deduplicates_plain_and_encrypted_urls() {
+		let sidecar_mxc = "mxc://example.com/dedupSidecar";
+		let pdu = make_pdu_with_content(
+			"$edit_sidecar_extract:example.com",
+			"@alice:example.com",
+			1_000,
+			format!(
+				r#"{{
+					"body":"message-content.json",
+					"msgtype":"m.file",
+					"url":"{sidecar_mxc}",
+					"file":{{"url":"{sidecar_mxc}"}},
+					"io.mindroom.long_text":{{
+						"version":2,
+						"encoding":"matrix_event_content_json"
+					}},
+					"m.relates_to":{{
+						"rel_type":"m.replace",
+						"event_id":"$target_sidecar_extract:example.com"
+					}}
+				}}"#
+			),
+		);
+
+		let mxcs = super::extract_mindroom_long_text_sidecar_mxcs(&pdu);
+
+		assert_eq!(mxcs, vec![OwnedMxcUri::from(sidecar_mxc.to_owned())]);
+	}
+
+	#[tokio::test]
+	async fn purge_basic_keeps_only_latest_edit() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_basic:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let edit1 = insert_event(
+			service,
+			1,
+			"$edit_basic_1:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_basic:example.com"),
+		);
+		let edit2 = insert_event(
+			service,
+			2,
+			"$edit_basic_2:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_basic:example.com"),
+		);
+		let edit3 = insert_event(
+			service,
+			3,
+			"$edit_basic_3:example.com",
+			"@alice:example.com",
+			3_000,
+			Some("$target_basic:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &edit1);
+		assert_event_absent(service, &edit2);
+		assert_event_present(service, &edit3);
+	}
+
+	#[tokio::test]
+	async fn purge_prefers_pdu_order_over_timestamp() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_order:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let newer_by_count_older_ts = insert_event(
+			service,
+			2,
+			"$edit_order_keep:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_order:example.com"),
+		);
+		let older_by_count_newer_ts = insert_event(
+			service,
+			1,
+			"$edit_order_drop:example.com",
+			"@alice:example.com",
+			4_000,
+			Some("$target_order:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_present(service, &newer_by_count_older_ts);
+		assert_event_absent(service, &older_by_count_newer_ts);
+	}
+
+	#[tokio::test]
+	async fn purge_preserves_timestamp_index_for_retained_edit_with_same_timestamp() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let shared_edit_ts = 1_000;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_same_ts:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let old_edit = insert_event(
+			service,
+			1,
+			"$edit_same_ts_old:example.com",
+			"@alice:example.com",
+			shared_edit_ts,
+			Some("$target_same_ts:example.com"),
+		);
+		let latest_edit = insert_event(
+			service,
+			2,
+			"$edit_same_ts_new:example.com",
+			"@alice:example.com",
+			shared_edit_ts,
+			Some("$target_same_ts:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_payload_indexes_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+	}
+
+	#[tokio::test]
+	async fn purge_respects_min_age_threshold() {
+		let harness = make_harness(HarnessConfig {
+			min_age_secs: 60,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+		let now_ms = utils::millis_since_unix_epoch();
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_min_age:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(2_000),
+			None,
+		);
+		let recent_edit1 = insert_event(
+			service,
+			1,
+			"$edit_recent_1:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(1_000),
+			Some("$target_min_age:example.com"),
+		);
+		let recent_edit2 = insert_event(
+			service,
+			2,
+			"$edit_recent_2:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(500),
+			Some("$target_min_age:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_present(service, &recent_edit1);
+		assert_event_present(service, &recent_edit2);
+	}
+
+	#[tokio::test]
+	async fn purge_groups_edits_by_sender() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sender:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let alice_edit1 = insert_event(
+			service,
+			1,
+			"$edit_sender_alice_1:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_sender:example.com"),
+		);
+		let bob_edit1 = insert_event(
+			service,
+			2,
+			"$edit_sender_bob_1:example.com",
+			"@bob:example.com",
+			1_500,
+			Some("$target_sender:example.com"),
+		);
+		let alice_edit2 = insert_event(
+			service,
+			3,
+			"$edit_sender_alice_2:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_sender:example.com"),
+		);
+		let bob_edit2 = insert_event(
+			service,
+			4,
+			"$edit_sender_bob_2:example.com",
+			"@bob:example.com",
+			2_500,
+			Some("$target_sender:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &alice_edit1);
+		assert_event_present(service, &alice_edit2);
+		assert_event_absent(service, &bob_edit1);
+		assert_event_present(service, &bob_edit2);
+	}
+
+	#[tokio::test]
+	async fn purge_groups_edits_by_target() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+
+		let target1 = insert_event(
+			service,
+			0,
+			"$target_multi_a:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let target2 = insert_event(
+			service,
+			1,
+			"$target_multi_b:example.com",
+			"@alice:example.com",
+			200,
+			None,
+		);
+
+		let target1_edit1 = insert_event(
+			service,
+			2,
+			"$edit_multi_a_1:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_multi_a:example.com"),
+		);
+		let target1_edit2 = insert_event(
+			service,
+			3,
+			"$edit_multi_a_2:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_multi_a:example.com"),
+		);
+		let target2_edit1 = insert_event(
+			service,
+			4,
+			"$edit_multi_b_1:example.com",
+			"@alice:example.com",
+			1_500,
+			Some("$target_multi_b:example.com"),
+		);
+		let target2_edit2 = insert_event(
+			service,
+			5,
+			"$edit_multi_b_2:example.com",
+			"@alice:example.com",
+			2_500,
+			Some("$target_multi_b:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target1);
+		assert_event_present(service, &target2);
+		assert_event_absent(service, &target1_edit1);
+		assert_event_present(service, &target1_edit2);
+		assert_event_absent(service, &target2_edit1);
+		assert_event_present(service, &target2_edit2);
+	}
+
+	#[tokio::test]
+	async fn purge_single_edit_is_not_removed() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_single:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let single_edit = insert_event(
+			service,
+			1,
+			"$edit_single:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_single:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_present(service, &single_edit);
+	}
+
+	#[tokio::test]
+	async fn purge_dry_run_does_not_delete_events() {
+		let harness = make_harness(HarnessConfig {
+			dry_run: true,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+		let sidecar_mxc = "mxc://example.com/dryRunSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_dry_run:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, sidecar_mxc, "@alice:example.com");
+		let edit1 = insert_event_with_content(
+			service,
+			1,
+			"$edit_dry_run_1:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_dry_run:example.com", sidecar_mxc),
+		);
+		let edit2 = insert_event(
+			service,
+			2,
+			"$edit_dry_run_2:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_dry_run:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_present(service, &edit1);
+		assert_event_present(service, &edit2);
+		assert_media_present(&harness, sidecar_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_deletes_superseded_mindroom_long_text_sidecar_media() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let sidecar_mxc = "mxc://example.com/supersededSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_delete:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, sidecar_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_delete_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_delete:example.com", sidecar_mxc),
+		);
+		let latest_edit = insert_event(
+			service,
+			2,
+			"$edit_sidecar_delete_latest:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_sidecar_delete:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_absent(&harness, sidecar_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_preserves_latest_edit_sidecar_media() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let old_mxc = "mxc://example.com/oldSidecar";
+		let latest_mxc = "mxc://example.com/latestSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_latest:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, old_mxc, "@alice:example.com");
+		create_media_for_user(&harness, latest_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_latest_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_latest:example.com", old_mxc),
+		);
+		let latest_edit = insert_event_with_content(
+			service,
+			2,
+			"$edit_sidecar_latest_new:example.com",
+			"@alice:example.com",
+			2_000,
+			encrypted_long_text_sidecar_content("$target_sidecar_latest:example.com", latest_mxc),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_absent(&harness, old_mxc);
+		assert_media_present(&harness, latest_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_preserves_sidecar_reused_by_latest_edit() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let shared_mxc = "mxc://example.com/reusedLatestSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_reused:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, shared_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_reused_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_reused:example.com", shared_mxc),
+		);
+		let latest_edit = insert_event_with_content(
+			service,
+			2,
+			"$edit_sidecar_reused_new:example.com",
+			"@alice:example.com",
+			2_000,
+			long_text_sidecar_content("$target_sidecar_reused:example.com", shared_mxc),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_present(&harness, shared_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_preserves_sidecar_reused_by_pending_edit() {
+		let harness = make_harness(HarnessConfig {
+			batch_size: 1,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+		let shared_mxc = "mxc://example.com/reusedPendingSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_pending:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, shared_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_pending_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_pending:example.com", shared_mxc),
+		);
+		let pending_edit = insert_event_with_content(
+			service,
+			2,
+			"$edit_sidecar_pending_mid:example.com",
+			"@alice:example.com",
+			2_000,
+			long_text_sidecar_content("$target_sidecar_pending:example.com", shared_mxc),
+		);
+		let latest_edit = insert_event(
+			service,
+			3,
+			"$edit_sidecar_pending_latest:example.com",
+			"@alice:example.com",
+			3_000,
+			Some("$target_sidecar_pending:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &pending_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_present(&harness, shared_mxc);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("second purge cycle succeeds");
+
+		assert_event_absent(service, &pending_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_absent(&harness, shared_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_preserves_sidecar_reused_by_recent_edit() {
+		let harness = make_harness(HarnessConfig {
+			min_age_secs: 60,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+		let now_ms = utils::millis_since_unix_epoch();
+		let shared_mxc = "mxc://example.com/reusedRecentSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_recent:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(130_000),
+			None,
+		);
+		create_media_for_user(&harness, shared_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_recent_old:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(120_000),
+			long_text_sidecar_content("$target_sidecar_recent:example.com", shared_mxc),
+		);
+		let older_latest_edit = insert_event(
+			service,
+			2,
+			"$edit_sidecar_recent_mid:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(110_000),
+			Some("$target_sidecar_recent:example.com"),
+		);
+		let recent_edit = insert_event_with_content(
+			service,
+			3,
+			"$edit_sidecar_recent_new:example.com",
+			"@alice:example.com",
+			now_ms.saturating_sub(1_000),
+			long_text_sidecar_content("$target_sidecar_recent:example.com", shared_mxc),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &older_latest_edit);
+		assert_event_present(service, &recent_edit);
+		assert_media_present(&harness, shared_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_does_not_delete_normal_file_attachment_media() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let attachment_mxc = "mxc://example.com/ordinaryAttachment";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_normal_file:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, attachment_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_normal_file_old:example.com",
+			"@alice:example.com",
+			1_000,
+			normal_file_content("$target_normal_file:example.com", attachment_mxc),
+		);
+		let latest_edit = insert_event(
+			service,
+			2,
+			"$edit_normal_file_latest:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_normal_file:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_present(&harness, attachment_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_does_not_delete_sidecar_owned_by_different_user() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let sidecar_mxc = "mxc://example.com/notAliceSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_owner:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, sidecar_mxc, "@bob:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_owner_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_owner:example.com", sidecar_mxc),
+		);
+		let latest_edit = insert_event(
+			service,
+			2,
+			"$edit_sidecar_owner_latest:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_sidecar_owner:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_present(&harness, sidecar_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_does_not_delete_remote_sidecar_media() {
+		let harness = make_harness(HarnessConfig::default()).await;
+		let service = &harness.service;
+		let remote_mxc = "mxc://remote.example/remoteSidecar";
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_sidecar_remote:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		create_media_for_user(&harness, remote_mxc, "@alice:example.com");
+		let old_edit = insert_event_with_content(
+			service,
+			1,
+			"$edit_sidecar_remote_old:example.com",
+			"@alice:example.com",
+			1_000,
+			long_text_sidecar_content("$target_sidecar_remote:example.com", remote_mxc),
+		);
+		let latest_edit = insert_event(
+			service,
+			2,
+			"$edit_sidecar_remote_latest:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_sidecar_remote:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &old_edit);
+		assert_event_present(service, &latest_edit);
+		assert_media_present(&harness, remote_mxc);
+	}
+
+	#[tokio::test]
+	async fn purge_respects_batch_size_limit() {
+		let harness = make_harness(HarnessConfig {
+			batch_size: 2,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_batch:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let edit1 = insert_event(
+			service,
+			1,
+			"$edit_batch_1:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_batch:example.com"),
+		);
+		let edit2 = insert_event(
+			service,
+			2,
+			"$edit_batch_2:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_batch:example.com"),
+		);
+		let edit3 = insert_event(
+			service,
+			3,
+			"$edit_batch_3:example.com",
+			"@alice:example.com",
+			3_000,
+			Some("$target_batch:example.com"),
+		);
+		let edit4 = insert_event(
+			service,
+			4,
+			"$edit_batch_4:example.com",
+			"@alice:example.com",
+			4_000,
+			Some("$target_batch:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("purge cycle succeeds");
+
+		assert_event_present(service, &target);
+		assert_event_absent(service, &edit1);
+		assert_event_absent(service, &edit2);
+		assert_event_present(service, &edit3);
+		assert_event_present(service, &edit4);
+
+		// Remaining superseded candidates should stay in backlog and purge on
+		// subsequent cycles.
+		service
+			.purge_cycle()
+			.await
+			.expect("second purge cycle succeeds");
+
+		assert_event_absent(service, &edit3);
+		assert_event_present(service, &edit4);
+	}
+
+	#[tokio::test]
+	async fn purge_across_scan_windows_persists_latest_state() {
+		let harness = make_harness(HarnessConfig {
+			batch_size: 1,
+			scan_limit: 10,
+			..HarnessConfig::default()
+		})
+		.await;
+		let service = &harness.service;
+		assert_eq!(
+			service
+				.services
+				.server
+				.config
+				.mindroom_edit_purge_batch_size,
+			1
+		);
+		assert_eq!(
+			service
+				.services
+				.server
+				.config
+				.mindroom_edit_purge_scan_limit,
+			10
+		);
+
+		let target = insert_event(
+			service,
+			0,
+			"$target_windows:example.com",
+			"@alice:example.com",
+			100,
+			None,
+		);
+		let older_edit = insert_event(
+			service,
+			1,
+			"$edit_windows_old:example.com",
+			"@alice:example.com",
+			1_000,
+			Some("$target_windows:example.com"),
+		);
+
+		{
+			let _cork = service.services.db.cork_and_flush();
+			for i in 2..=18_u32 {
+				service
+					.pduid_pdu
+					.insert(&pdu_key(i), br"not-json");
+			}
+		}
+
+		let newer_edit = insert_event(
+			service,
+			19,
+			"$edit_windows_new:example.com",
+			"@alice:example.com",
+			2_000,
+			Some("$target_windows:example.com"),
+		);
+
+		service
+			.purge_cycle()
+			.await
+			.expect("first purge cycle succeeds");
+		assert_event_present(service, &target);
+		assert_event_present(service, &older_edit);
+		assert!(service.last_scan_key.lock().await.is_some());
+
+		service
+			.purge_cycle()
+			.await
+			.expect("second purge cycle succeeds");
+
+		assert_event_absent(service, &older_edit);
+		assert_event_present(service, &newer_edit);
+		assert!(service.last_scan_key.lock().await.is_none());
+	}
+
+	#[tokio::test]
+	async fn worker_exits_gracefully_when_database_is_read_only() {
+		let harness = make_harness(HarnessConfig {
+			read_only: true,
+			..HarnessConfig::default()
+		})
+		.await;
+
+		let result = timeout(
+			Duration::from_secs(1),
+			<Service as crate::Service>::worker(harness.service.clone()),
+		)
+		.await;
+
+		assert!(result.is_ok(), "worker timed out on read-only database");
+		assert!(
+			result.expect("timeout already checked").is_ok(),
+			"worker should return Ok on read-only database"
+		);
+	}
+}

--- a/src/service/emergency/mod.rs
+++ b/src/service/emergency/mod.rs
@@ -9,6 +9,8 @@ use ruma::{
 };
 use tuwunel_core::{Result, debug_warn, error, warn};
 
+use crate::users::DeactivationReason;
+
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
 }
@@ -92,7 +94,7 @@ impl Service {
 			// logs out any users still in the server service account and removes sessions
 			self.services
 				.users
-				.deactivate_account(server_user)
+				.deactivate_account(server_user, DeactivationReason::Admin)
 				.await
 		}
 	}

--- a/src/service/media/data.rs
+++ b/src/service/media/data.rs
@@ -333,6 +333,18 @@ impl Data {
 			.await
 	}
 
+	pub(super) async fn mxc_is_owned_by_user(&self, mxc: &Mxc<'_>, user_id: &UserId) -> bool {
+		let Ok(key) = serialize_key((mxc, user_id)) else {
+			return false;
+		};
+
+		let Ok(owner) = self.mediaid_user.get(&key).await else {
+			return false;
+		};
+
+		owner.as_ref() == user_id.as_str().as_bytes()
+	}
+
 	/// Gets all the media keys in our database (this includes all the metadata
 	/// associated with it such as width, height, content-type, etc)
 	pub(crate) async fn get_all_media_keys(&self) -> Vec<Vec<u8>> {

--- a/src/service/media/mod.rs
+++ b/src/service/media/mod.rs
@@ -275,6 +275,18 @@ impl Service {
 		}
 	}
 
+	pub async fn mxc_is_owned_by_user(&self, mxc: &Mxc<'_>, user: &UserId) -> bool {
+		self.db.mxc_is_owned_by_user(mxc, user).await
+	}
+
+	pub async fn delete_owned_by(&self, mxc: &Mxc<'_>, user: &UserId) -> Result<bool> {
+		if !self.mxc_is_owned_by_user(mxc, user).await {
+			return Ok(false);
+		}
+
+		self.delete(mxc).await.map(|()| true)
+	}
+
 	/// Deletes all media by the specified user
 	///
 	/// currently, this is only practical for local users

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -12,6 +12,7 @@ pub mod appservice;
 pub mod client;
 pub mod config;
 pub mod deactivate;
+pub mod edit_purge;
 pub mod emergency;
 pub mod federation;
 pub mod fetcher;

--- a/src/service/pusher/mod.rs
+++ b/src/service/pusher/mod.rs
@@ -13,11 +13,12 @@ use ipaddress::IPAddress;
 use ruma::{
 	DeviceId, OwnedDeviceId, OwnedRoomId, OwnedUserId, RoomId, UserId,
 	api::client::push::{Pusher, PusherKind, set_pusher},
-	events::{AnySyncTimelineEvent, room::power_levels::RoomPowerLevels},
+	events::{AnySyncTimelineEvent, TimelineEventType, room::power_levels::RoomPowerLevels},
 	push::{Action, PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
 	serde::Raw,
 	uint,
 };
+use serde_json::{Value as JsonValue, value::to_raw_value};
 use tuwunel_core::{
 	Err, Result, err, implement,
 	utils::{
@@ -30,12 +31,129 @@ use tuwunel_database::{Database, Deserialized, Ignore, Interfix, Json, Map};
 
 pub use self::append::Notified;
 
+const MINDROOM_STREAM_STATUS_KEY: &str = "io.mindroom.stream_status";
+const MINDROOM_TERMINAL_STREAM_STATUSES: [&str; 4] =
+	["completed", "cancelled", "interrupted", "error"];
+
 pub struct Service {
 	services: Arc<crate::services::OnceServices>,
 	notification_increment_mutex: MutexMap<(OwnedRoomId, OwnedUserId), ()>,
 	highlight_increment_mutex: MutexMap<(OwnedRoomId, OwnedUserId), ()>,
 	db: Data,
 	suppressed: suppressed::SuppressedQueue,
+}
+
+enum MindroomPushEvaluation {
+	Suppress,
+	Normalize(Raw<AnySyncTimelineEvent>),
+	Unchanged,
+}
+
+pub(super) fn mindroom_terminal_push_content(
+	event_type: &TimelineEventType,
+	content: &JsonValue,
+) -> Option<JsonValue> {
+	if !is_terminal_mindroom_edit(content) {
+		return None;
+	}
+
+	match event_type {
+		| TimelineEventType::RoomMessage => content.as_object()?.get("m.new_content").cloned(),
+		| TimelineEventType::RoomEncrypted => {
+			let mut encrypted_content = content.clone();
+			encrypted_content
+				.as_object_mut()?
+				.remove("m.relates_to");
+			Some(encrypted_content)
+		},
+		| _ => None,
+	}
+}
+
+fn is_terminal_mindroom_edit(content: &JsonValue) -> bool {
+	let Some((content, stream_status)) = mindroom_stream_content(content) else {
+		return false;
+	};
+	if !MINDROOM_TERMINAL_STREAM_STATUSES.contains(&stream_status) {
+		return false;
+	}
+
+	content
+		.get("m.relates_to")
+		.and_then(JsonValue::as_object)
+		.and_then(|relation| relation.get("rel_type"))
+		.and_then(JsonValue::as_str)
+		== Some("m.replace")
+}
+
+fn mindroom_stream_content(
+	content: &JsonValue,
+) -> Option<(&serde_json::Map<String, JsonValue>, &str)> {
+	// This is an event-level protocol signal, not an account privilege: senders
+	// may opt their own streamed events into these notification semantics.
+	let content = content.as_object()?;
+	let stream_status = content
+		.get(MINDROOM_STREAM_STATUS_KEY)
+		.and_then(JsonValue::as_str)?;
+	Some((content, stream_status))
+}
+
+pub(super) fn mindroom_push_suppressed(pdu: &Raw<AnySyncTimelineEvent>) -> bool {
+	matches!(mindroom_push_evaluation(pdu), MindroomPushEvaluation::Suppress)
+}
+
+#[cfg(test)]
+fn mindroom_terminal_push_event(
+	pdu: &Raw<AnySyncTimelineEvent>,
+) -> Option<Raw<AnySyncTimelineEvent>> {
+	match mindroom_push_evaluation(pdu) {
+		| MindroomPushEvaluation::Normalize(event) => Some(event),
+		| MindroomPushEvaluation::Suppress | MindroomPushEvaluation::Unchanged => None,
+	}
+}
+
+fn mindroom_push_evaluation(pdu: &Raw<AnySyncTimelineEvent>) -> MindroomPushEvaluation {
+	let Ok(mut event) = serde_json::to_value(pdu) else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	let Some(event_type) = event.get("type").and_then(JsonValue::as_str) else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	if !matches!(event_type, "m.room.message" | "m.room.encrypted") {
+		return MindroomPushEvaluation::Unchanged;
+	}
+	let Some(content) = event.get("content") else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	let Some((_, stream_status)) = mindroom_stream_content(content) else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	// Only known terminal states may notify. Future intermediate states fail
+	// closed so a new producer state cannot accidentally reintroduce push spam.
+	if !MINDROOM_TERMINAL_STREAM_STATUSES.contains(&stream_status) {
+		return MindroomPushEvaluation::Suppress;
+	}
+	if !is_terminal_mindroom_edit(content) {
+		return MindroomPushEvaluation::Unchanged;
+	}
+
+	let push_content =
+		mindroom_terminal_push_content(&TimelineEventType::from(event_type), content);
+	let Some(push_content) = push_content else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+
+	// Evaluate the completed replacement as the final message it represents.
+	// This lets ordinary room, DM, mention, and mute rules decide the push result
+	// instead of the generic edit-suppression rule swallowing the terminal update.
+	let Some(event_content) = event.get_mut("content") else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	*event_content = push_content;
+	let Ok(raw_event) = to_raw_value(&event) else {
+		return MindroomPushEvaluation::Unchanged;
+	};
+	MindroomPushEvaluation::Normalize(Raw::from_json(raw_event))
 }
 
 struct Data {
@@ -240,6 +358,13 @@ pub async fn get_actions<'a>(
 	pdu: &Raw<AnySyncTimelineEvent>,
 	room_id: &RoomId,
 ) -> &'a [Action] {
+	let mindroom_push = mindroom_push_evaluation(pdu);
+	let pdu = match &mindroom_push {
+		| MindroomPushEvaluation::Suppress => return &[],
+		| MindroomPushEvaluation::Normalize(event) => event,
+		| MindroomPushEvaluation::Unchanged => pdu,
+	};
+
 	let user_display_name = self
 		.services
 		.profile

--- a/src/service/pusher/send.rs
+++ b/src/service/pusher/send.rs
@@ -37,6 +37,9 @@ where
 		.ok();
 
 	let serialized = event.to_format();
+	if self.services.config.push_everything && super::mindroom_push_suppressed(&serialized) {
+		return Ok(());
+	}
 	let actions = self
 		.get_actions(user_id, ruleset, power_levels.as_ref(), &serialized, event.room_id())
 		.await;
@@ -170,7 +173,11 @@ async fn send_notice<Pdu: Event>(
 				}
 				notify.sender = Some(event.sender().to_owned());
 				notify.event_type = Some(event.kind().to_owned());
-				notify.content = serde_json::value::to_raw_value(event.content()).ok();
+				let event_content = event.get_content_as_value();
+				let push_content =
+					super::mindroom_terminal_push_content(event.kind(), &event_content)
+						.unwrap_or(event_content);
+				notify.content = serde_json::value::to_raw_value(&push_content).ok();
 
 				if *event.kind() == TimelineEventType::RoomMember {
 					notify.user_is_target = event.state_key() == Some(event.sender().as_str());

--- a/src/service/pusher/tests.rs
+++ b/src/service/pusher/tests.rs
@@ -1,7 +1,19 @@
 #![cfg(test)]
 
-use ruma::{EventId, RoomId, UserId};
+use ruma::{
+	EventId, RoomId, UserId,
+	events::{AnySyncTimelineEvent, TimelineEventType},
+	owned_room_id, owned_user_id,
+	push::{Action, PushConditionRoomCtx, Ruleset},
+	serde::Raw,
+	uint,
+};
+use serde_json::Value as JsonValue;
 use tuwunel_database::{Interfix, SEP, serialize_to_vec};
+
+use super::{
+	mindroom_push_suppressed, mindroom_terminal_push_content, mindroom_terminal_push_event,
+};
 
 const ROOM: &str = "!room:example.com";
 const USER: &str = "@user:example.com";
@@ -19,6 +31,58 @@ fn thread_key(root: &EventId) -> Vec<u8> {
 }
 fn interfix_prefix() -> Vec<u8> {
 	serialize_to_vec((user(), room(), Interfix)).expect("serialize prefix")
+}
+
+fn stream_event(sender: &str, status: &str, msgtype: &str) -> Raw<AnySyncTimelineEvent> {
+	serde_json::from_value(serde_json::json!({
+		"content": {
+			"body": "* final answer",
+			"io.mindroom.stream_status": status,
+			"m.new_content": {
+				"body": "final answer",
+				"io.mindroom.stream_status": status,
+				"msgtype": msgtype,
+			},
+			"m.relates_to": {"event_id": "$original", "rel_type": "m.replace"},
+			"msgtype": msgtype,
+		},
+		"event_id": "$edit",
+		"origin_server_ts": 1,
+		"sender": sender,
+		"type": "m.room.message",
+	}))
+	.expect("valid timeline event")
+}
+
+fn encrypted_stream_event(sender: &str, status: &str, edit: bool) -> Raw<AnySyncTimelineEvent> {
+	let mut content = serde_json::json!({
+		"algorithm": "m.megolm.v1.aes-sha2",
+		"ciphertext": "encrypted payload",
+		"device_id": "DEVICE",
+		"io.mindroom.stream_status": status,
+		"sender_key": "sender key",
+		"session_id": "session",
+	});
+	if edit {
+		content
+			.as_object_mut()
+			.expect("content object")
+			.insert(
+				"m.relates_to".into(),
+				serde_json::json!({
+				"event_id": "$original",
+				"rel_type": "m.replace",
+				}),
+			);
+	}
+	serde_json::from_value(serde_json::json!({
+		"content": content,
+		"event_id": "$encrypted_edit",
+		"origin_server_ts": 1,
+		"sender": sender,
+		"type": "m.room.encrypted",
+	}))
+	.expect("valid encrypted timeline event")
 }
 
 /// Main `(user, room)` and thread `(user, room, root)` rows share a CF.
@@ -60,4 +124,148 @@ fn thread_prefix_sweep_preserves_main() {
 	assert!(a.starts_with(&prefix));
 	assert!(b.starts_with(&prefix));
 	assert!(!main.starts_with(&prefix));
+}
+
+#[test]
+fn terminal_mindroom_edit_is_normalized_for_push_rules() {
+	let event = stream_event("@mindroom_helper:example.com", "completed", "m.text");
+	let normalized = mindroom_terminal_push_event(&event).expect("terminal event");
+	let value: JsonValue = serde_json::from_str(normalized.json().get()).expect("event json");
+	let content = value["content"]
+		.as_object()
+		.expect("content object");
+
+	assert!(!content.contains_key("m.relates_to"));
+	assert!(!content.contains_key("m.new_content"));
+	assert_eq!(content.get("body").and_then(JsonValue::as_str), Some("final answer"));
+}
+
+#[test]
+fn nonterminal_stream_edit_is_not_normalized() {
+	let streaming = stream_event("@mindroom_helper:example.com", "streaming", "m.notice");
+
+	assert!(mindroom_terminal_push_event(&streaming).is_none());
+}
+
+#[test]
+fn stream_protocol_is_sender_agnostic() {
+	let remote = stream_event("@mindroom_helper:remote.example", "completed", "m.text");
+	let ordinary_user = stream_event("@alice:example.com", "completed", "m.text");
+
+	assert!(mindroom_terminal_push_event(&remote).is_some());
+	assert!(mindroom_terminal_push_event(&ordinary_user).is_some());
+}
+
+#[test]
+fn terminal_encrypted_edit_removes_only_the_exposed_relation() {
+	let event = encrypted_stream_event("@mindroom_helper:example.com", "completed", true);
+	let normalized = mindroom_terminal_push_event(&event).expect("terminal encrypted event");
+	let value: JsonValue = serde_json::from_str(normalized.json().get()).expect("event json");
+	let content = value["content"]
+		.as_object()
+		.expect("content object");
+
+	assert!(!content.contains_key("m.relates_to"));
+	assert_eq!(
+		content
+			.get("ciphertext")
+			.and_then(JsonValue::as_str),
+		Some("encrypted payload")
+	);
+	assert_eq!(
+		content
+			.get("io.mindroom.stream_status")
+			.and_then(JsonValue::as_str),
+		Some("completed")
+	);
+}
+
+#[test]
+fn encrypted_gateway_content_matches_push_rule_normalization() {
+	let event = encrypted_stream_event("@mindroom_helper:example.com", "completed", true);
+	let value: JsonValue = serde_json::from_str(event.json().get()).expect("event json");
+	let content =
+		mindroom_terminal_push_content(&TimelineEventType::RoomEncrypted, &value["content"])
+			.expect("terminal encrypted content");
+
+	assert!(content.get("m.relates_to").is_none());
+	assert_eq!(
+		content
+			.get("ciphertext")
+			.and_then(JsonValue::as_str),
+		Some("encrypted payload")
+	);
+}
+
+#[test]
+fn nonterminal_stream_events_are_suppressed_for_any_sender() {
+	let encrypted_pending =
+		encrypted_stream_event("@mindroom_helper:example.com", "pending", false);
+	let encrypted_streaming =
+		encrypted_stream_event("@mindroom_helper:example.com", "streaming", true);
+	let remote_pending =
+		encrypted_stream_event("@mindroom_helper:remote.example", "pending", false);
+	let future_intermediate =
+		encrypted_stream_event("@mindroom_helper:example.com", "paused", true);
+
+	assert!(mindroom_push_suppressed(&encrypted_pending));
+	assert!(mindroom_push_suppressed(&encrypted_streaming));
+	assert!(mindroom_push_suppressed(&remote_pending));
+	assert!(mindroom_push_suppressed(&future_intermediate));
+}
+
+#[tokio::test]
+async fn terminal_mindroom_edit_uses_normal_message_push_rule() {
+	let user = owned_user_id!("@user:example.com");
+	let ruleset = Ruleset::server_default(&user);
+	let context = PushConditionRoomCtx::new(
+		owned_room_id!("!room:example.com"),
+		uint!(3),
+		user,
+		"User".into(),
+	);
+	let event = stream_event("@mindroom_helper:example.com", "completed", "m.text");
+
+	assert!(
+		ruleset
+			.get_actions(&event, &context)
+			.await
+			.is_empty()
+	);
+	let normalized = mindroom_terminal_push_event(&event).expect("terminal event");
+	assert!(
+		ruleset
+			.get_actions(&normalized, &context)
+			.await
+			.iter()
+			.any(|action| matches!(action, Action::Notify))
+	);
+}
+
+#[tokio::test]
+async fn terminal_encrypted_edit_uses_encrypted_message_push_rule() {
+	let user = owned_user_id!("@user:example.com");
+	let ruleset = Ruleset::server_default(&user);
+	let context = PushConditionRoomCtx::new(
+		owned_room_id!("!room:example.com"),
+		uint!(3),
+		user,
+		"User".into(),
+	);
+	let event = encrypted_stream_event("@mindroom_helper:example.com", "completed", true);
+
+	assert!(
+		ruleset
+			.get_actions(&event, &context)
+			.await
+			.is_empty()
+	);
+	let normalized = mindroom_terminal_push_event(&event).expect("terminal encrypted event");
+	assert!(
+		ruleset
+			.get_actions(&normalized, &context)
+			.await
+			.iter()
+			.any(|action| matches!(action, Action::Notify))
+	);
 }

--- a/src/service/services.rs
+++ b/src/service/services.rs
@@ -9,8 +9,8 @@ use tuwunel_database::Database;
 
 pub(crate) use crate::OnceServices;
 use crate::{
-	account_data, admin, appservice, client, config, deactivate, emergency, federation, fetcher,
-	globals, key_backups,
+	account_data, admin, appservice, client, config, deactivate, edit_purge, emergency,
+	federation, fetcher, globals, key_backups,
 	manager::Manager,
 	media, membership, oauth, presence, profile, pusher, registration_tokens, resolver,
 	rooms::{self, retention},
@@ -25,6 +25,7 @@ pub struct Services {
 	pub appservice: Arc<appservice::Service>,
 	pub config: Arc<config::Service>,
 	pub client: Arc<client::Service>,
+	pub edit_purge: Arc<edit_purge::Service>,
 	pub emergency: Arc<emergency::Service>,
 	pub fetcher: Arc<fetcher::Service>,
 	pub globals: Arc<globals::Service>,
@@ -92,6 +93,7 @@ pub async fn build(server: Arc<Server>) -> Result<Arc<Self>> {
 		resolver: resolver::Service::build(&args)?,
 		client: client::Service::build(&args)?,
 		config: config::Service::build(&args)?,
+		edit_purge: edit_purge::Service::build(&args)?,
 		emergency: emergency::Service::build(&args)?,
 		fetcher: fetcher::Service::build(&args)?,
 		globals: globals::Service::build(&args)?,
@@ -159,6 +161,7 @@ pub(crate) fn services(&self) -> impl Iterator<Item = Arc<dyn Service>> + Send {
 		cast!(self.resolver),
 		cast!(self.client),
 		cast!(self.config),
+		cast!(self.edit_purge),
 		cast!(self.emergency),
 		cast!(self.fetcher),
 		cast!(self.globals),

--- a/src/service/users/device.rs
+++ b/src/service/users/device.rs
@@ -109,7 +109,19 @@ pub async fn remove_device(&self, user_id: &UserId, device_id: &DeviceId) {
 		.await
 		.ok();
 
-	// TODO: Remove onetimekeys
+	// Remove the identity keys the device uploaded; leaving them behind
+	// would make a later login re-using this device id collide with the
+	// immutability check in /keys/upload.
+	self.db.keyid_key.del((user_id, device_id));
+
+	// Remove one-time keys.
+	if let Some(otk) = self.db.onetimekeyid4225_otk.as_ref() {
+		let prefix = (user_id, device_id, Interfix);
+		otk.keys_prefix_raw(&prefix)
+			.ignore_err()
+			.ready_for_each(|key| otk.remove(key))
+			.await;
+	}
 
 	// MSC2732: drop fallback keys for this device.
 	let prefix = (user_id, device_id, Interfix);

--- a/src/service/users/mod.rs
+++ b/src/service/users/mod.rs
@@ -3,6 +3,7 @@ pub mod device;
 mod keys;
 mod ldap;
 mod register;
+mod sso;
 
 use std::sync::Arc;
 
@@ -25,7 +26,7 @@ use tuwunel_core::{
 };
 use tuwunel_database::{Deserialized, Json, Map};
 
-pub use self::{keys::parse_master_key, register::Register};
+pub use self::{keys::parse_master_key, register::Register, sso::DeactivationReason};
 
 pub const PASSWORD_SENTINEL: &str = "*";
 pub const PASSWORD_DISABLED: &str = "";
@@ -65,6 +66,7 @@ struct Data {
 	userid_dehydrateddevice: Arc<Map>,
 	userid_devicelistversion: Arc<Map>,
 	userid_erased: Arc<Map>,
+	userid_deactivation_reason: Arc<Map>,
 	userid_lastonetimekeyupdate: Arc<Map>,
 	userid_locked: Arc<Map>,
 	userid_masterkeyid: Arc<Map>,
@@ -100,6 +102,7 @@ impl crate::Service for Service {
 				userid_dehydrateddevice: args.db["userid_dehydrateddevice"].clone(),
 				userid_devicelistversion: args.db["userid_devicelistversion"].clone(),
 				userid_erased: args.db["userid_erased"].clone(),
+				userid_deactivation_reason: args.db["userid_deactivation_reason"].clone(),
 				userid_lastonetimekeyupdate: args.db["userid_lastonetimekeyupdate"].clone(),
 				userid_locked: args.db["userid_locked"].clone(),
 				userid_masterkeyid: args.db["userid_masterkeyid"].clone(),
@@ -161,7 +164,11 @@ impl Service {
 	}
 
 	/// Deactivate account
-	pub async fn deactivate_account(&self, user_id: &UserId) -> Result {
+	pub async fn deactivate_account(
+		&self,
+		user_id: &UserId,
+		reason: DeactivationReason,
+	) -> Result {
 		// Revoke any SSO authorizations
 		self.services
 			.oauth
@@ -178,6 +185,7 @@ impl Service {
 		// Systems like changing the password without logging in should check if the
 		// account is deactivated.
 		self.set_password(user_id, None).await?;
+		self.set_deactivation_reason(user_id, reason);
 
 		// TODO: Unhook 3PID
 		Ok(())
@@ -330,6 +338,12 @@ impl Service {
 			.deserialized()
 	}
 
+	/// Sets the origin of the user (password/sso/ldap/...).
+	#[inline]
+	pub fn set_origin(&self, user_id: &UserId, origin: &str) {
+		self.db.userid_origin.insert(user_id, origin);
+	}
+
 	/// Returns whether the user has a password. Disabled accounts and
 	/// registrations setting a sentinel password will return false here.
 	pub async fn has_password(&self, user_id: &UserId) -> Result<bool> {
@@ -349,6 +363,8 @@ impl Service {
 
 	/// Hash and set the user's password to the Argon2 hash
 	pub async fn set_password(&self, user_id: &UserId, password: Option<&str>) -> Result {
+		let keep_existing_origin = matches!(password, Some(PASSWORD_SENTINEL));
+
 		// Cannot change the password of a LDAP user. There are two special cases :
 		// - a `None` password can be used to deactivate a LDAP user
 		// - a "*" password is used as the default password of an active LDAP user
@@ -381,7 +397,10 @@ impl Service {
 			},
 			| Some(Ok(hash)) => {
 				self.db.userid_password.insert(user_id, hash);
-				self.db.userid_origin.insert(user_id, "password");
+				self.db.userid_deactivation_reason.remove(user_id);
+				if !keep_existing_origin {
+					self.db.userid_origin.insert(user_id, "password");
+				}
 			},
 			| Some(Err(e)) => {
 				return Err!(Request(InvalidParam(

--- a/src/service/users/sso.rs
+++ b/src/service/users/sso.rs
@@ -1,0 +1,356 @@
+use futures::StreamExt;
+use ruma::UserId;
+use tuwunel_core::{Result, utils};
+use tuwunel_database::Deserialized;
+
+use super::{PASSWORD_SENTINEL, Service};
+
+/// Why deactivations carry a reason. Fork-only: neither Synapse nor upstream
+/// Tuwunel has this concept.
+///
+/// Synapse models deactivation as a bare `users.deactivated` flag (plus the
+/// separate, admin-imposed MSC3823 `suspended` flag) and stores no reason
+/// anywhere. It hard-blocks a deactivated account from completing SSO login
+/// (`auth.py` renders the `sso_account_deactivated_template` 403 page), and
+/// its admin-only `activate_account` expects a password hash to be set
+/// afterwards — which passwordless SSO accounts don't have. Upstream Tuwunel
+/// likewise stores no reason; since v1.8.1 an admin can reactivate a
+/// passwordless user via `PASSWORD_SENTINEL`, but there is no self-service
+/// path in either server.
+///
+/// This fork adds self-service reactivation: a *self*-deactivated SSO-origin
+/// account is restored when the same IdP identity returns
+/// (`maybe_reactivate_deactivated_sso`). Persisting who initiated the
+/// deactivation is what makes that safe — admin deactivations must stay
+/// final, or a banned user could resurrect their account by simply logging
+/// in again. The reason is therefore a *required* parameter of
+/// `deactivate_account`: every new call site (typically new upstream
+/// Synapse-admin endpoints appearing at each rebase) fails to compile until
+/// it explicitly classifies itself as self-service or administrative,
+/// instead of inheriting a default.
+///
+/// Deliberately not upstreamed: reversible deactivation contradicts the
+/// semantics Synapse established (its closest concept, MSC3823 suspension,
+/// is admin-imposed and different), so upstreaming would effectively require
+/// an MSC first. Recorded here so future rebases don't have to re-derive
+/// this from the Synapse sources; see also the design note in
+/// `FORK_CHANGES.md`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeactivationReason {
+	SelfService,
+	Admin,
+}
+
+impl DeactivationReason {
+	const fn as_str(self) -> &'static str {
+		match self {
+			| Self::SelfService => "self",
+			| Self::Admin => "admin",
+		}
+	}
+}
+
+fn can_reactivate_deactivated_sso(reason: Option<&str>) -> bool { matches!(reason, Some("self")) }
+
+impl Service {
+	/// Reactivate a deactivated local SSO account.
+	///
+	/// This is used for users who self-deactivated and later return through the
+	/// same SSO identity. The account remains the same MXID, but can
+	/// authenticate again.
+	pub async fn maybe_reactivate_deactivated_sso(&self, user_id: &UserId) -> Result<bool> {
+		if !self.services.globals.user_is_local(user_id) {
+			return Ok(false);
+		}
+
+		if !self.is_deactivated(user_id).await? {
+			return Ok(false);
+		}
+
+		let Ok(origin) = self.origin(user_id).await else {
+			return Ok(false);
+		};
+
+		if origin != "sso" {
+			return Ok(false);
+		}
+
+		if !can_reactivate_deactivated_sso(self.deactivation_reason(user_id).await.as_deref()) {
+			return Ok(false);
+		}
+
+		self.set_password(user_id, Some(PASSWORD_SENTINEL))
+			.await?;
+		Ok(true)
+	}
+
+	pub async fn deactivation_reason(&self, user_id: &UserId) -> Option<String> {
+		self.db
+			.userid_deactivation_reason
+			.get(user_id)
+			.await
+			.deserialized()
+			.ok()
+	}
+
+	#[inline]
+	pub fn set_deactivation_reason(&self, user_id: &UserId, reason: DeactivationReason) {
+		self.db
+			.userid_deactivation_reason
+			.insert(user_id, reason.as_str());
+	}
+
+	/// Compatibility repair for legacy SSO users whose origin was accidentally
+	/// rewritten to `password` during account creation.
+	pub async fn maybe_repair_legacy_sso_origin(&self, user_id: &UserId) -> bool {
+		let oauth_sessions = self
+			.services
+			.oauth
+			.sessions
+			.get_sess_id_by_user(user_id);
+		futures::pin_mut!(oauth_sessions);
+
+		let Some(Ok(_)) = oauth_sessions.next().await else {
+			return false;
+		};
+
+		let Ok(origin) = self.origin(user_id).await else {
+			return false;
+		};
+
+		if origin != "password" {
+			return false;
+		}
+
+		let Ok(password_hash) = self.password_hash(user_id).await else {
+			return false;
+		};
+
+		if password_hash.is_empty() {
+			return false;
+		}
+
+		let is_sentinel_password = password_hash == PASSWORD_SENTINEL
+			|| utils::hash::verify_password(PASSWORD_SENTINEL, &password_hash).is_ok();
+		if !is_sentinel_password {
+			return false;
+		}
+
+		self.set_origin(user_id, "sso");
+		true
+	}
+
+	#[cfg(test)]
+	fn test_can_reactivate_deactivated_sso(reason: Option<&str>) -> bool {
+		can_reactivate_deactivated_sso(reason)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs,
+		path::{Path, PathBuf},
+		sync::{
+			Arc,
+			atomic::{AtomicU64, Ordering},
+		},
+	};
+
+	use ruma::user_id;
+	use tracing::subscriber::NoSubscriber;
+	use tuwunel_core::{
+		Server,
+		config::Config,
+		log::{Logging, capture::State as CaptureState},
+		metrics::Metrics,
+	};
+
+	use super::{super::PASSWORD_SENTINEL, DeactivationReason, Service};
+	use crate::Services;
+
+	static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(1);
+
+	#[test]
+	fn sso_reactivation_requires_self_deactivation_reason() {
+		assert!(Service::test_can_reactivate_deactivated_sso(Some("self")));
+		assert!(!Service::test_can_reactivate_deactivated_sso(None));
+		assert!(!Service::test_can_reactivate_deactivated_sso(Some("admin")));
+		assert!(!Service::test_can_reactivate_deactivated_sso(Some("unknown")));
+	}
+
+	#[tokio::test]
+	async fn self_deactivated_sso_account_reactivates() {
+		let temp_dir = unique_temp_dir();
+		let services = open_services(&temp_dir).await;
+		let user_id = user_id!("@alice:example.com");
+
+		services
+			.users
+			.create(user_id, Some(PASSWORD_SENTINEL), Some("sso"))
+			.await
+			.expect("create SSO user");
+		services
+			.users
+			.deactivate_account(user_id, DeactivationReason::SelfService)
+			.await
+			.expect("deactivate SSO user");
+
+		let reactivated = services
+			.users
+			.maybe_reactivate_deactivated_sso(user_id)
+			.await
+			.expect("reactivation check should succeed");
+
+		assert!(reactivated, "self-deactivated SSO user should reactivate");
+		assert!(
+			!services
+				.users
+				.is_deactivated(user_id)
+				.await
+				.expect("deactivation state"),
+			"user should no longer be deactivated"
+		);
+		assert_eq!(
+			services
+				.users
+				.origin(user_id)
+				.await
+				.expect("origin"),
+			"sso",
+			"reactivation should preserve SSO origin"
+		);
+		assert_eq!(
+			services
+				.users
+				.password_hash(user_id)
+				.await
+				.expect("password hash"),
+			PASSWORD_SENTINEL,
+			"reactivation should restore the sentinel password"
+		);
+
+		cleanup_temp_dir(&temp_dir);
+	}
+
+	#[tokio::test]
+	async fn admin_deactivated_sso_account_does_not_reactivate() {
+		let temp_dir = unique_temp_dir();
+		let services = open_services(&temp_dir).await;
+		let user_id = user_id!("@alice:example.com");
+
+		services
+			.users
+			.create(user_id, Some(PASSWORD_SENTINEL), Some("sso"))
+			.await
+			.expect("create SSO user");
+		services
+			.users
+			.deactivate_account(user_id, DeactivationReason::Admin)
+			.await
+			.expect("deactivate SSO user");
+
+		let reactivated = services
+			.users
+			.maybe_reactivate_deactivated_sso(user_id)
+			.await
+			.expect("reactivation check should succeed");
+
+		assert!(!reactivated, "admin-deactivated SSO user must stay deactivated");
+		assert!(
+			services
+				.users
+				.is_deactivated(user_id)
+				.await
+				.expect("deactivation state"),
+			"user should remain deactivated"
+		);
+
+		cleanup_temp_dir(&temp_dir);
+	}
+
+	#[tokio::test]
+	async fn self_deactivated_password_account_does_not_reactivate_as_sso() {
+		let temp_dir = unique_temp_dir();
+		let services = open_services(&temp_dir).await;
+		let user_id = user_id!("@alice:example.com");
+
+		services
+			.users
+			.create(user_id, Some("password"), Some("password"))
+			.await
+			.expect("create password user");
+		services
+			.users
+			.deactivate_account(user_id, DeactivationReason::SelfService)
+			.await
+			.expect("deactivate password user");
+
+		let reactivated = services
+			.users
+			.maybe_reactivate_deactivated_sso(user_id)
+			.await
+			.expect("reactivation check should succeed");
+
+		assert!(!reactivated, "password-origin user must not reactivate via SSO path");
+		assert!(
+			services
+				.users
+				.is_deactivated(user_id)
+				.await
+				.expect("deactivation state"),
+			"user should remain deactivated"
+		);
+		assert_eq!(
+			services
+				.users
+				.origin(user_id)
+				.await
+				.expect("origin"),
+			"password",
+			"SSO reactivation check should not change user origin"
+		);
+
+		cleanup_temp_dir(&temp_dir);
+	}
+
+	async fn open_services(temp_dir: &Path) -> Arc<Services> {
+		let db_path = temp_dir.join("db");
+		let config_path = temp_dir.join("tuwunel.toml");
+
+		fs::create_dir_all(temp_dir).expect("create test temp dir");
+		let config_contents = format!(
+			r#"[global]
+server_name = "example.com"
+database_path = "{}"
+"#,
+			db_path.display(),
+		);
+		fs::write(&config_path, config_contents).expect("write test config");
+
+		let figment = Config::load(std::iter::once(config_path.as_path())).expect("load config");
+		let config = Config::new(&figment).expect("parse config");
+		let log = Logging {
+			reload: Default::default(),
+			capture: Arc::new(CaptureState::new()),
+			subscriber: Arc::new(NoSubscriber::new()),
+		};
+		let runtime = tokio::runtime::Handle::current();
+		let metrics = Metrics::new(Some(&runtime));
+		let server = Arc::new(Server::new(config, Some(&runtime), log, metrics));
+
+		Services::build(server)
+			.await
+			.expect("build services")
+	}
+
+	fn unique_temp_dir() -> PathBuf {
+		let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+		let pid = std::process::id();
+		let path = std::env::temp_dir().join(format!("tuwunel-users-{pid}-{id}"));
+		fs::create_dir_all(&path).expect("create unique test dir");
+		path
+	}
+
+	fn cleanup_temp_dir(path: &Path) { let _: std::io::Result<()> = fs::remove_dir_all(path); }
+}

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1009,13 +1009,19 @@
 
 # MSC3925: fold the most recent message edit (an `m.replace` relation)
 # into `unsigned.m.relations` on a served event as the full replacement
-# event, on the client read endpoints. Off by default: it adds a typed
-# index seek per served event and a server-authoritative edit summary that
-# most clients reconstruct locally anyway, so it is opt-in.
+# event, on the client read endpoints.
+#
+# MindRoom fork: on by default. The fork purges superseded edits
+# (`mindroom_edit_purge_enabled`), so without this bundle a history
+# endpoint (`/messages`, `/context`, `/event`, ...) would serve an
+# original carrying its stale pre-edit body with no way for the client
+# to discover the surviving edit; bundling the kept edit onto the
+# original keeps history correct. Upstream defaults this off (opt-in)
+# because it adds a typed-index seek per served event.
 #
 # reloadable: yes
 #
-#bundle_edit_relations = false
+#bundle_edit_relations = true
 
 # MSC2675/MSC3267: fold reference relations (`m.reference`) into
 # `unsigned.m.relations` on a served event as `{ chunk: [{ event_id },
@@ -2737,6 +2743,55 @@
 # reloadable: yes
 #
 #config_reload_signal = true
+
+# MindRoom: Collapse multiple m.replace (edit) events per target into
+# only the latest one in `/sync` timeline responses.
+#
+# When enabled, if a `/sync` timeline batch contains multiple replacement
+# events targeting the same event, only the most recent replacement is
+# kept. This dramatically reduces bandwidth for streaming AI responses
+# that produce many intermediate edits.
+#
+#mindroom_compact_edits_enabled = false
+
+# MindRoom: Enable background purging of superseded m.replace events
+# from the database.
+#
+# When enabled, a periodic background job will find m.replace events
+# that have been superseded by newer replacements and remove them from
+# storage. Only events older than `mindroom_edit_purge_min_age_secs`
+# are eligible.
+#
+#mindroom_edit_purge_enabled = false
+
+# MindRoom: Minimum age in seconds before a superseded edit becomes
+# eligible for purging. This prevents purging edits that clients may
+# still be paginating through.
+#
+#mindroom_edit_purge_min_age_secs = 86400
+
+# MindRoom: How often (in seconds) to run the edit purge background job.
+#
+#mindroom_edit_purge_interval_secs = 3600
+
+# MindRoom: Maximum number of events to purge per cycle. Keeps
+# individual purge runs bounded so they don't block other work.
+#
+#mindroom_edit_purge_batch_size = 1000
+
+# MindRoom: Floor for PDUs scanned per purge cycle.
+#
+# This value competes with `mindroom_edit_purge_batch_size * 10`; the
+# effective per-cycle scan budget is:
+# `max(mindroom_edit_purge_batch_size * 10,
+# mindroom_edit_purge_scan_limit)`.
+#
+#mindroom_edit_purge_scan_limit = 100000
+
+# MindRoom: When true, log what would be purged without actually
+# deleting anything. Useful for testing the purge logic.
+#
+#mindroom_edit_purge_dry_run = false
 
 # Sets the `Access-Control-Allow-Origin` header included by this server in
 # all responses. A list of multiple values can be specified. The default

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -3402,6 +3402,13 @@
 #
 #client_id =
 
+# Additional client IDs whose signed ID tokens should be accepted by
+# native app login endpoints for this provider. For Sign in with Apple on
+# iOS this is usually the app bundle identifier, while `client_id`
+# remains the web Services ID used by the browser SSO flow.
+#
+#native_client_ids = []
+
 # Secret key the provider generated for you along with the `client_id`
 # above. Unlike the `client_id`, the `client_secret` can be changed here
 # whenever the provider regenerates one for you.


### PR DESCRIPTION
## Problem

`/messages` stopped pagination only when an event's count exactly equalled the `to` token (`Some(*count) != to`) and silently swallowed unparseable `to` values (`flat_ok()`). A sync `next_batch` token is a global stream position that almost never equals an event count *in the requested room*, so a `to` bound taken from `/sync` — which [the spec explicitly permits](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmessages) — was ignored entirely and the walk ran unbounded.

Live probes against the lab server: `to=<sync token>` and even `to=garbage!!` both returned HTTP 200 with unclamped chunks.

Found by mindroom-nio's limited-timeline backfill (mindroom-ai/mindroom-nio#13), which pages `/messages` with sync tokens to recover events dropped by limited sync timelines. The nio client treats `to` as best-effort and does not depend on this fix — but with it, the server clamps the walk at the sync position, which also closes a federation topological-ordering edge case that client code cannot detect.

## Fix

- Stop the walk once it *passes* the `to` position in either direction (`count < to` forward, `count > to` backward), rather than only on exact count equality. Exact-equality events remain excluded, matching the previous behavior for the cases where it did work.
- Fail the request on an unparseable `to` (`transpose()?`), consistent with how an unparseable `from` fails, instead of silently ignoring it.

## Tests

New `src/mindroom-tests/tests/messages_to_clamp.rs` integration test drives the real router: it takes a sync `next_batch` while a second room advances the global stream (so the position falls strictly between the test room's events and equals none of their counts — the exact shape of the reported bug), then asserts the backward walk stops at the position, the forward walk starts at it (the two directions partition the room), and an unparseable `to` fails the request. The test fails against the previous behavior (backward walk runs past the position to room creation).

Full `mindroom_rebase_tests` suite passes; `cargo clippy -p tuwunel_api` is clean. `FORK_CHANGES.md` documents the change as fork change 6 — candidate for upstreaming.