### PR TITLE
signals: gate the trace import to unix

### DIFF
--- a/src/main/signals.rs
+++ b/src/main/signals.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use tokio::signal;
-use tuwunel_core::{debug_error, trace, warn};
+#[cfg(unix)]
+use tuwunel_core::trace;
+use tuwunel_core::{debug_error, warn};
 
 use super::server::Server;
 


### PR DESCRIPTION
### What does this PR do?

`src/main/signals.rs` imports `trace` unconditionally, but the only use is inside
the `#[cfg(unix)]` `enable()`. Every non-unix target therefore builds with:

```
warning: unused import: `trace`
 --> src/main/signals.rs:4:33
  |
4 | use tuwunel_core::{debug_error, trace, warn};
  |                                 ^^^^^
```

Gating the import to `unix` removes it. `debug_error` and `warn` are used by both
the unix and the non-unix `enable()`, so they stay ungated.

```diff
 use tokio::signal;
-use tuwunel_core::{debug_error, trace, warn};
+#[cfg(unix)]
+use tuwunel_core::trace;
+use tuwunel_core::{debug_error, warn};
```

This mirrors the gating the crate already uses elsewhere — `src/main/health.rs`
splits its unix-only imports the same way.

Three lines, no behaviour change on any target.

**On verification.** CI builds Linux only, where this warning appears neither
before nor after, so CI cannot demonstrate the fix. It was observed on an
`x86_64-pc-windows-msvc` build of v1.8.2, and the reasoning holds for any
non-unix target. `cargo check` and `cargo clippy` on the unix path are clean
before and after.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; no runtime path is touched.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
