### PR TITLE
main: gate the restart import to unix

### DIFF
--- a/src/main/main.rs
+++ b/src/main/main.rs
@@ -1,6 +1,9 @@
+#[cfg(unix)]
 use std::sync::atomic::Ordering;
 
-use tuwunel::{Server, args, health::check, restart, runtime::Runtime};
+#[cfg(unix)]
+use tuwunel::restart;
+use tuwunel::{Server, args, health::check, runtime::Runtime};
 use tuwunel_core::{Result, debug_info};
 
 // Bionic rejects an under-aligned PT_TLS segment on arm64.


### PR DESCRIPTION
### What does this PR do?

`src/main/restart.rs` is `#![cfg(unix)]`. A cfg-false module file is *absent*,
not empty, so on a non-unix target `tuwunel::restart` does not exist and the
unconditional import in `main.rs` is a hard error:

```
error[E0432]: unresolved import `tuwunel::restart`
 --> src/main/main.rs:3:47
  |
3 | use tuwunel::{Server, args, health::check, restart, runtime::Runtime};
  |                                            ^^^^^^^ no `restart` in the root
```

The call site is already gated:

```rust
#[cfg(unix)]
if server.server.restarting.load(Ordering::Acquire) {
    restart::restart();
}
```

so this only extends the same condition to the import that serves it. `Ordering`
follows for the same reason — its sole use is inside that block, so it is an
unused import on any non-unix target.

```diff
+#[cfg(unix)]
 use std::sync::atomic::Ordering;
 
-use tuwunel::{Server, args, health::check, restart, runtime::Runtime};
+#[cfg(unix)]
+use tuwunel::restart;
+use tuwunel::{Server, args, health::check, runtime::Runtime};
```

No behaviour change on unix. Same class of fix as #526.

**On verification.** CI builds Linux only, where none of this appears, so CI
cannot demonstrate the change. It was observed building v1.8.2 for
`x86_64-pc-windows-msvc`; the module-absence behaviour is reproducible with a
three-file crate on any host. `cargo check` and `cargo clippy` on the unix path
are clean before and after.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; no runtime path is touched.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
