### PR TITLE
router/serve: restore the cfg(unix) gating the listener refactor dropped

### DIFF
--- a/src/router/serve.rs
+++ b/src/router/serve.rs
@@ -3,10 +3,10 @@ mod plain;
 mod tls;
 mod unix;
 
+#[cfg(unix)]
+use std::{borrow::Cow, os::unix::net::UnixListener};
 use std::{
-	borrow::Cow,
 	net::{SocketAddr, TcpListener},
-	os::unix::net::UnixListener,
 	path::Path,
 	sync::{Arc, atomic::Ordering},
 };
@@ -29,16 +29,22 @@ pub(super) async fn serve(services: Arc<Services>, handle: ServerHandle) -> Resu
 
 	let socket_path = &config.unix_socket_path;
 
+	#[cfg(unix)]
 	let (passed_tcp_listeners, passed_unix_listeners) = systemd_listeners()?;
+	#[cfg(not(unix))]
+	let passed_tcp_listeners: Vec<TcpListener> = Vec::new();
 
 	let addrs = config.get_bind_addrs();
 
+	#[cfg(unix)]
 	let log_addrs = make_log_addrs(
 		&addrs,
 		socket_path.as_deref(),
 		&passed_tcp_listeners,
 		&passed_unix_listeners,
 	)?;
+	#[cfg(not(unix))]
+	let log_addrs = make_log_addrs(&addrs, socket_path.as_deref(), &passed_tcp_listeners)?;
 
 	let mut futures = vec![];
 
@@ -128,6 +134,7 @@ pub(super) async fn serve(services: Arc<Services>, handle: ServerHandle) -> Resu
 	Ok(())
 }
 
+#[cfg(unix)]
 fn make_log_addrs(
 	tcp_addrs: &[SocketAddr],
 	unix_path: Option<&Path>,
@@ -165,7 +172,7 @@ fn make_log_addrs(
 		.collect()
 }
 
-#[cfg(all(feature = "systemd", target_os = "linux"))]
+#[cfg(all(unix, feature = "systemd", target_os = "linux"))]
 fn systemd_listeners() -> Result<(Vec<TcpListener>, Vec<UnixListener>)> {
 	use std::os::fd::FromRawFd;
 
@@ -204,5 +211,33 @@ fn systemd_listeners() -> Result<(Vec<TcpListener>, Vec<UnixListener>)> {
 	Ok((tcp, unix))
 }
 
-#[cfg(any(not(feature = "systemd"), not(target_os = "linux")))]
+#[cfg(all(
+	unix,
+	any(not(feature = "systemd"), not(target_os = "linux"))
+))]
 fn systemd_listeners() -> Result<(Vec<TcpListener>, Vec<UnixListener>)> { Ok((vec![], vec![])) }
+
+#[cfg(not(unix))]
+fn make_log_addrs(
+	tcp_addrs: &[SocketAddr],
+	unix_path: Option<&Path>,
+	tcp_listeners: &[TcpListener],
+) -> Result<Vec<String>> {
+	let tcp_log_addrs = tcp_addrs.iter().map(|addr| format!("tcp:{addr}"));
+
+	let unix_log_addr = unix_path.as_ref().map(|socket_path| {
+		let path = socket_path.to_string_lossy();
+		format!("unix:{path}")
+	});
+
+	let passed_tcp_log_addrs = tcp_listeners.iter().map(|listener| {
+		let addr = listener.local_addr()?;
+		Ok(format!("passed:tcp:{addr}"))
+	});
+
+	tcp_log_addrs
+		.map(Ok)
+		.chain(unix_log_addr.into_iter().map(Ok))
+		.chain(passed_tcp_log_addrs)
+		.collect()
+}


### PR DESCRIPTION
### What does this PR do?

`src/router/serve/unix.rs` is `#![cfg(unix)]`, and `serve.rs` used to respect
that. Through v1.5.1 it contained no unix-specific code at all — the socket work
lived entirely inside that gated submodule and `serve.rs` itself was
platform-neutral.

`da92b973 Refactor axum listener setup, fixes #374` moved that work inline
without carrying the gate across. `serve.rs` now has:

- an unconditional `use std::os::unix::net::UnixListener`,
- an unconditional `systemd_listeners()?`,
- `make_log_addrs(…, &passed_unix_listeners)`, whose signature takes
  `&[UnixListener]`,
- both `systemd_listeners` variants selected on `not(target_os = "linux")`,
  which includes targets that have no unix sockets at all.

The file therefore no longer compiles off unix. v1.8.2 added `Cow` for the
`map_or` inside `make_log_addrs`, which inherits the same problem.

This puts the gate back:

- the unix-only import, the `passed_unix_listeners` data flow and
  `make_log_addrs` go behind `#[cfg(unix)]`;
- both `systemd_listeners` cfgs gain `unix`;
- a `#[cfg(not(unix))]` `make_log_addrs` keeps the TCP and configured-path
  entries, which is all a target without unix sockets can report.

Rather than adding a non-unix `systemd_listeners` stub, the non-unix path skips
the call and starts from an empty listener set — socket activation is unix-only
by construction, so there is nothing for a stub to mean.

**The unix code path is unchanged.** Every added cfg selects on unix exactly what
was selected before: `target_os = "linux"` already implies `unix`, and the
narrowed second `systemd_listeners` variant still applies to macOS and the BSDs.
The narrowing only excludes targets where that variant's return type could not be
constructed anyway.

**On verification.** CI builds Linux only, where this is a no-op both before and
after, so CI cannot demonstrate the change. It was observed building v1.8.2 for
`x86_64-pc-windows-msvc`. `cargo check` and `cargo clippy` on the unix path are
clean before and after.

Third in the series with #526 and #527.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; the unix path is unchanged.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
