### PR TITLE
logging: Submit events natively to journald under systemd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,6 +5319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-journald"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5395,6 +5406,7 @@ dependencies = [
  "tokio-metrics",
  "tracing",
  "tracing-flame",
+ "tracing-journald",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tuwunel_admin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -597,6 +597,9 @@ default-features = false
 [workspace.dependencies.tracing-flame]
 version = "0.2"
 
+[workspace.dependencies.tracing-journald]
+version = "0.3"
+
 [workspace.dependencies.tracing-opentelemetry]
 version = "0.33"
 

--- a/docs/deploying/generic.md
+++ b/docs/deploying/generic.md
@@ -102,6 +102,12 @@ On systems where rsyslog is used alongside journald (i.e. Red Hat-based distros
 and OpenSUSE), put `$EscapeControlCharactersOnReceive off` inside
 `/etc/rsyslog.conf` to allow color in logs.
 
+When running as a systemd service on Linux, Tuwunel submits its logs directly
+to journald with each entry's severity preserved as the journal priority, so
+`journalctl --priority warning` catches Tuwunel's warnings and errors. Metadata
+such as the target and source location is attached as journal fields. Set
+`log_journald = false` in the config to write plain console output instead.
+
 If you are using a different `database_path` other than the systemd unit
 configured default `/var/lib/tuwunel`, you need to add your path to the
 systemd unit's `ReadWritePaths=`. This can be done by either directly editing

--- a/src/admin/debug/change_log_level.rs
+++ b/src/admin/debug/change_log_level.rs
@@ -5,7 +5,7 @@ use crate::admin_command;
 
 #[admin_command]
 pub(super) async fn change_log_level(&self, filter: Option<String>, reset: bool) -> Result {
-	let handles = &["console"];
+	let handles = &["console", "journald"];
 
 	let filter = reset
 		.then_some(&self.services.config.log)

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1427,6 +1427,19 @@ pub struct Config {
 	#[serde(default)]
 	pub log_to_stderr: bool,
 
+	/// Submits log output directly to the journald socket instead of the
+	/// console when running under systemd on Linux. Each entry carries its
+	/// actual severity as the journal priority, so tools such as `journalctl
+	/// --priority warning` catch Tuwunel's warnings and errors; console output
+	/// is captured by journald at a single fixed priority instead. Metadata
+	/// like the target and source location is attached as journal fields.
+	/// This option has no effect when not running under systemd or on builds
+	/// without the 'systemd' feature.
+	///
+	/// default: true
+	#[serde(default = "true_fn")]
+	pub log_journald: bool,
+
 	/// Setting to false disables the logging/tracing system at a lower level.
 	/// In contrast to configuring an empty `log` string where the system is
 	/// still operating but muted, when this option is false the system was not

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -175,6 +175,7 @@ sentry_telemetry = [
 	"tuwunel-router/sentry_telemetry",
 ]
 systemd = [
+	"dep:tracing-journald",
 	"tuwunel-router/systemd",
 ]
 # enable the tokio_console server ncompatible with release_max_log_level
@@ -232,6 +233,8 @@ tokio-metrics.workspace = true
 tokio.workspace = true
 tracing-flame.optional = true
 tracing-flame.workspace = true
+tracing-journald.optional = true
+tracing-journald.workspace = true
 tracing-opentelemetry.optional = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true

--- a/src/main/logging.rs
+++ b/src/main/logging.rs
@@ -8,7 +8,10 @@ use tuwunel_core::{
 	Result,
 	config::Config,
 	debug_warn, err,
-	log::{ConsoleFormat, ConsoleWriter, LogLevelReloadHandles, Logging, capture, fmt_span},
+	log::{
+		ConsoleFormat, ConsoleWriter, LogLevelReloadHandles, Logging, capture, fmt_span,
+		is_systemd_mode,
+	},
 	result::UnwrapOrErr,
 };
 #[cfg(feature = "perf_measurements")]
@@ -40,9 +43,14 @@ pub(crate) fn init(config: &Config) -> Result<(TracingFlameGuard, Logging)> {
 	}
 
 	let cap_layer = capture::Layer::new(&cap_state);
-	let subscriber = Registry::default()
-		.with(console_layer(config, &reload_handles)?)
-		.with(cap_layer);
+	let console = (!journald_enabled(config))
+		.then(|| console_layer(config, &reload_handles))
+		.transpose()?;
+
+	let subscriber = Registry::default().with(console).with(cap_layer);
+
+	#[cfg(all(feature = "systemd", target_os = "linux"))]
+	let subscriber = subscriber.with(journald_layer(config, &reload_handles)?);
 
 	#[cfg(feature = "sentry_telemetry")]
 	let subscriber = subscriber.with(sentry_layer(config, &reload_handles)?);
@@ -109,6 +117,40 @@ where
 
 	reload_handles.add("console", Box::new(reload_handle));
 	Ok(layer.with_filter(reload_filter))
+}
+
+/// Whether logging is redirected from the console to the journald socket.
+/// The console output remains captured by journald in systemd mode, but a
+/// single fixed priority is assigned to every line; native submission
+/// preserves each entry's actual severity.
+fn journald_enabled(config: &Config) -> bool {
+	cfg!(all(feature = "systemd", target_os = "linux"))
+		&& config.log_journald
+		&& is_systemd_mode()
+}
+
+#[cfg(all(feature = "systemd", target_os = "linux"))]
+fn journald_layer<S>(
+	config: &Config,
+	reload_handles: &LogLevelReloadHandles,
+) -> Result<Option<impl Layer<S>>>
+where
+	S: Subscriber + for<'a> LookupSpan<'a> + 'static,
+{
+	if !journald_enabled(config) {
+		return Ok(None);
+	}
+
+	let filter = EnvFilter::builder()
+		.with_regex(config.log_filter_regex)
+		.parse(&config.log)
+		.map_err(|e| err!(Config("log", "{e}.")))?;
+
+	let layer = tracing_journald::layer().map_err(|e| err!(Config("log_journald", "{e}.")))?;
+	let (reload_filter, reload_handle) = reload::Layer::new(filter);
+
+	reload_handles.add("journald", Box::new(reload_handle));
+	Ok(Some(layer.with_filter(reload_filter)))
 }
 
 #[cfg(feature = "sentry_telemetry")]

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1207,6 +1207,17 @@
 #
 #log_to_stderr = false
 
+# Submits log output directly to the journald socket instead of the
+# console when running under systemd on Linux. Each entry carries its
+# actual severity as the journal priority, so tools such as `journalctl
+# --priority warning` catch Tuwunel's warnings and errors; console output
+# is captured by journald at a single fixed priority instead. Metadata
+# like the target and source location is attached as journal fields.
+# This option has no effect when not running under systemd or on builds
+# without the 'systemd' feature.
+#
+#log_journald = true
+
 # Setting to false disables the logging/tracing system at a lower level.
 # In contrast to configuring an empty `log` string where the system is
 # still operating but muted, when this option is false the system was not


### PR DESCRIPTION
### What does this PR do?

#### Problem

When Tuwunel runs as a systemd service, every log line lands in the journal at priority 6 (info) regardless of its actual severity. The unit's `SyslogLevelPrefix=yes` expects a numeric `<N>` prefix on stdout lines, which the `tracing_subscriber::fmt` console formatter never emits — so everything falls through to the default priority. As a result, `journalctl --priority warning` sweeps (and any monitoring built on them) are completely blind to Tuwunel's warnings and errors.

<details>
<summary>Before — live production server (stock v1.8.2 under systemd)</summary>

A 24-hour priority sweep finds nothing:

```console
$ journalctl -u tuwunel -p warning --since -24h
-- No entries --
```

…while the same journal demonstrably contains warnings (ordinary federation noise; IDs truncated):

```console
$ journalctl -u tuwunel -n 6
Aug 01 01:10:22 chiba tuwunel[19325]: 2026-08-01T01:10:22Z  WARN tuwunel_service::rooms::event_handler::handle_outlier_pdu: Missing auth_event $eI73…: M_NOT_FOUND: Not found in database
Aug 01 01:10:22 chiba tuwunel[19325]: 2026-08-01T01:10:22Z  WARN tuwunel_service::rooms::event_handler::fetch_auth: Authentication of event $Sksy… failed: Auth check failed …
Aug 01 05:53:48 chiba tuwunel[19325]: 2026-08-01T05:53:48Z  WARN tuwunel_service::rooms::event_handler::handle_incoming_pdu: Prev event processing failed: M_NOT_FOUND: event not found on any of 3 servers …
```

Priority distribution of the newest 200 journal entries: `{"6": 199, "5": 1}` — the WARN lines above are all priority 6. Their `MESSAGE` fields in `journalctl -o json` are raw byte arrays rather than strings (ANSI color bytes), so text-based scans miss them twice over.

</details>

#### Fix

When systemd is detected (the existing `is_systemd_mode()` check: `SYSTEMD_EXEC_PID` + `JOURNAL_STREAM`), the console layer is replaced by [`tracing-journald`](https://crates.io/crates/tracing-journald) (official `tokio-rs/tracing` crate), which submits events over the journald socket with severity preserved: ERROR→3, WARN→4, INFO→5, DEBUG→6, TRACE→7. The target and source location travel as structured journal fields. Replacing rather than stacking avoids every line being logged twice.

- Gated behind the existing default-on `systemd` cargo feature and `target_os = "linux"`, matching the router's systemd code.
- New `log_journald` config option (default `true`) restores plain console output if disabled; `tuwunel-example.toml` regenerated.
- The layer registers its own `journald` reload handle so `!admin debug change-log-level` works in both modes. `Suppress` intentionally still targets only the console handle — muting the persistent journal while using the REPL would punch holes in the journal.
- Side benefit: native submission carries no ANSI codes, so `journalctl -o json` MESSAGE fields become proper strings regardless of the `log_colors` setting.

#### Testing

Validated on a live production deployment — the same server as the "before" capture above, running this branch (`a9c0cf3`) built with the default feature set:

<details>
<summary>After — same production server, this branch deployed</summary>

The previously-blind sweep now catches a deliberately provoked WARN (service restart → `Received SIGTERM`):

```console
$ journalctl -u tuwunel -p warning --since -10min
Aug 01 06:38:57 chiba tuwunel[54253]: Received SIGTERM
```

`journalctl -o json` confirms real priorities and structured fields (PRIORITY | MESSAGE | TARGET | CODE_FILE):

```
4 | Received SIGTERM | tuwunel::signals | src/main/signals.rs
```

Startup INFO entries land at priority 5 with proper string MESSAGE fields (priority-6 lines are systemd's own unit messages):

```
6 | Starting Tuwunel Matrix Server...
5 | 1.8.2
5 | Opened database.
5 | Loaded RocksDB database with schema version 17
6 | Started Tuwunel Matrix Server.
5 | Listening on ["tcp:127.0.0.1:6167", "tcp:[::1]:6167"]
```

No console double-logging; the server runs healthy and federates normally.

</details>

<details>
<summary>Local end-to-end test output (debug build, faked systemd env)</summary>

Earlier validation on a workstation: the binary ran with `SYSTEMD_EXEC_PID`/`JOURNAL_STREAM` set so `is_systemd_mode()` engages, logging to the local journald. The startup WARN was provoked with an unknown config key:

```console
$ journalctl SYSLOG_IDENTIFIER=tuwunel -p warning --since <test start>
Aug 01 07:17:08 beatmachine tuwunel[246264]: Note: tuwunel was built without optimisations (i.e. debug build)
Aug 01 07:17:08 beatmachine tuwunel[246264]: Config parameter "this_key_does_not_exist" is unknown to tuwunel, ignoring.
Aug 01 07:17:08 beatmachine tuwunel[246264]: Storage hardware not detected for database directory; assuming defaults.
Aug 01 07:17:23 beatmachine tuwunel[246264]: Received SIGTERM
Aug 01 07:17:23 beatmachine tuwunel[246264]: 3 dangling references to Services after shutdown
```

Per-entry priorities and structured fields from `journalctl -o json` (PRIORITY | MESSAGE | fields):

```
4 | Config parameter "this_key_does_not_exist" is unknown to tuwunel, ignoring. | TARGET= tuwunel_core::config::check | CODE_FILE= src/core/config/check.rs
5 | Opened database. | TARGET= tuwunel_database::engine::open | CODE_FILE= src/database/engine/open.rs
4 | Received SIGTERM | TARGET= tuwunel::signals | CODE_FILE= src/main/signals.rs
3 | 3 dangling references to Services after shutdown | TARGET= tuwunel_router::run | CODE_FILE= src/router/run.rs
5 | Listening on ["tcp:127.0.0.1:18448", "tcp:[::1]:18448"] | TARGET= tuwunel_router::serve | CODE_FILE= src/router/serve.rs
```

With `log_journald = false` the previous console behavior is unchanged (and no native journal entries are submitted). stdout/stderr stayed empty in journald mode (console layer replaced, not stacked).

</details>

Complement results should be unaffected (log transport only).

#### Disclosure

Developed with AI assistance (Claude - Fable 5), reviewed and tested by me — locally end-to-end and on a live production deployment; the AI co-author trailer is on the commit.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [x] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.