### PR TITLE
sys/limits: gate the nix imports and page_size to unix

### DIFF
--- a/src/core/utils/sys/limits.rs
+++ b/src/core/utils/sys/limits.rs
@@ -1,8 +1,11 @@
 #[cfg(unix)]
 use nix::sys::resource::{Resource, getrlimit};
+#[cfg(unix)]
 use nix::unistd::{SysconfVar, sysconf};
 
-use crate::{Result, apply, debug, utils::math::ExpectInto};
+use crate::Result;
+#[cfg(unix)]
+use crate::{apply, debug, utils::math::ExpectInto};
 
 #[cfg(unix)]
 /// Raises the soft file descriptor limit to the current hard limit.
@@ -101,6 +104,7 @@ pub fn max_threads() -> Result<(usize, usize)> {
 #[inline]
 pub fn max_threads() -> Result<(usize, usize)> { Ok((usize::MAX, usize::MAX)) }
 
+#[cfg(unix)]
 /// Get the system's page size in bytes.
 #[inline]
 pub fn page_size() -> Result<usize> {
@@ -109,3 +113,8 @@ pub fn page_size() -> Result<usize> {
 		.try_into()
 		.map_err(Into::into)
 }
+
+#[cfg(not(unix))]
+/// Get the system's page size in bytes.
+#[inline]
+pub fn page_size() -> Result<usize> { Ok(4096) }


### PR DESCRIPTION
### What does this PR do?

`nix` is a unix-only dependency of `tuwunel_core` — `src/core/Cargo.toml` declares it
under `[target.'cfg(unix)'.dependencies]` — but `sys/limits.rs` imports from it
unconditionally, so on a non-unix target the crate does not resolve:

```
error[E0433]: cannot find module or crate `nix` in this scope
 --> src/core/utils/sys/limits.rs:3:5
  |
3 | use nix::unistd::{SysconfVar, sysconf};
  |     ^^^ use of unresolved module or unlinked crate `nix`
```

The `nix::sys::resource` import one line above is already gated, so this only extends
the same condition to the one next to it. `page_size()` follows, being the only user of
`sysconf`, and gains a `#[cfg(not(unix))]` arm in the shape the rest of the file already
uses for its limit getters.

`apply`, `debug` and `ExpectInto` are used only by the `#[cfg(unix)]` getters, so they
warn as unused on a non-unix target; `Result` is used by both arms and stays ungated.

```diff
 #[cfg(unix)]
 use nix::sys::resource::{Resource, getrlimit};
+#[cfg(unix)]
 use nix::unistd::{SysconfVar, sysconf};
 
-use crate::{Result, apply, debug, utils::math::ExpectInto};
+use crate::Result;
+#[cfg(unix)]
+use crate::{apply, debug, utils::math::ExpectInto};
```

```diff
+#[cfg(unix)]
 /// Get the system's page size in bytes.
 #[inline]
 pub fn page_size() -> Result<usize> {
 	sysconf(SysconfVar::PAGE_SIZE)?
 		.unwrap_or(-1)
 		.try_into()
 		.map_err(Into::into)
 }
+
+#[cfg(not(unix))]
+/// Get the system's page size in bytes.
+#[inline]
+pub fn page_size() -> Result<usize> { Ok(4096) }
```

**On the constant.** 4096 is the page size Windows reports on both architectures it
supports. A constant keeps `tuwunel_core` from taking a platform dependency for the sake
of one number, and it is what the other non-unix arms in this file do. It also keeps
`utils::tests::page_size` — which asserts only that the value is non-zero — passing on a
target where an error return would fail it. If you would rather it returned an error, or
a different value, say so and I will change it.

No behaviour change on unix. Same class of fix as #526, #527 and #528.

**On verification.** CI builds Linux only, where none of this appears, so CI cannot
demonstrate the change: the symptom is absent there both before and after. It was
observed building v1.8.2 for `x86_64-pc-windows-msvc`, and the crate-resolution failure
above is reproducible on any host with a two-file crate that declares `nix` under
`[target.'cfg(unix)'.dependencies]` and imports it ungated. `cargo +nightly fmt --check`,
`cargo check` and `cargo clippy` on the unix path are clean before and after.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; no runtime path is touched
      on unix.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.