### PR TITLE
pusher: Always refresh push badge on read advance.

### DIFF
--- a/src/api/client/read_marker/read_markers.rs
+++ b/src/api/client/read_marker/read_markers.rs
@@ -100,17 +100,20 @@ pub(crate) async fn set_read_marker_route(
 	};
 
 	// Route through the dispatcher so per-thread counts are also cleared;
-	// `/read_markers` predates MSC3771 and carries no thread field.
-	if (private_advanced || public_advanced)
-		&& services
+	// `/read_markers` predates MSC3771 and carries no thread field. Always
+	// push the current account-wide count on a read advance; it must not be
+	// gated on `reset_notification_counts_for_thread` returning `true`, or a
+	// stale (already-zero stored count) badge would never be cleared.
+	if private_advanced || public_advanced {
+		services
 			.pusher
 			.reset_notification_counts_for_thread(
 				sender_user,
 				&body.room_id,
 				&ReceiptThread::Unthreaded,
 			)
-			.await
-	{
+			.await;
+
 		services
 			.sending
 			.refresh_push_badge(sender_user)

--- a/src/api/client/read_marker/receipt.rs
+++ b/src/api/client/read_marker/receipt.rs
@@ -139,12 +139,19 @@ pub(crate) async fn create_receipt_route(
 		},
 	};
 
-	if advanced
-		&& services
+	if advanced {
+		// Always reset the per-room/thread notification counts and then push
+		// the current account-wide count to every pusher. Pushing must not be
+		// gated on `reset_notification_counts_for_thread` returning `true`
+		// (i.e. a nonzero count having been cleared): the previously delivered
+		// badge can be stale (nonzero) while the stored count is already zero,
+		// and in that case no `counts.unread = 0` was ever sent, so the badge
+		// would never clear.
+		services
 			.pusher
 			.reset_notification_counts_for_thread(sender_user, &body.room_id, &body.thread)
-			.await
-	{
+			.await;
+
 		services
 			.sending
 			.refresh_push_badge(sender_user)


### PR DESCRIPTION
<!--
Thanks for contributing to Tuwunel! Please read the contributing guide before
opening a pull request:
https://github.com/matrix-construct/tuwunel/blob/main/CONTRIBUTING.md

Your pull request can target either the `dev` branch or the `main` branch.
If the work is unfinished, open it as a draft so its status is clear.
-->

### What does this PR do?

closes #538 - stuck iOS badge.

Fix a bug where the iOS push badge could get stuck at a stale nonzero value. tuwunel only sent the badge-clearing push (counts.unread = 0) when a read receipt cleared a nonzero stored notification count. If the stored count was already 0 but the previously delivered badge was still stale, reading a message never sent a clear, so the badge never went away.

This makes the read-receipt paths (read_marker/receipt.rs and read_marker/read_markers.rs) always refresh the push badge on a read advance, so the push gateway always receives the current account-wide count (including 0) and stale badges are corrected.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [x] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.

Tested in my local environment.