### PR TITLE
core/config: Document the nine undocumented cache capacity fields.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -82,9 +82,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -134,7 +134,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -146,7 +146,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -158,7 +158,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -192,13 +192,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -378,15 +378,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -409,7 +409,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -484,9 +484,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -508,9 +508,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytesize"
-version = "2.4.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 dependencies = [
  "serde_core",
 ]
@@ -543,9 +543,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -666,14 +666,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ checksum = "1c7e7913ec01ed98b697e62f8d3fd63c86dc6cccaf983c7eebc64d0e563b0ad9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -957,9 +957,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crokey"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+checksum = "074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80"
 dependencies = [
  "crokey-proc_macros",
  "crossterm",
@@ -970,15 +970,15 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+checksum = "b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0"
 dependencies = [
  "crossterm",
  "proc-macro2",
  "quote",
  "strict",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1115,7 +1115,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1126,9 +1126,9 @@ checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "date_header"
@@ -1195,7 +1195,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1223,13 +1223,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1282,20 +1282,20 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "email-encoding"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "memchr",
 ]
 
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -1515,7 +1515,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1614,9 +1614,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1656,14 +1656,14 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "flate2",
- "nom 7.1.3",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -1726,7 +1726,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1748,7 +1748,7 @@ dependencies = [
  "rand 0.10.2",
  "ring",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -1776,7 +1776,7 @@ dependencies = [
  "serde",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -1812,14 +1812,14 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1877,9 +1877,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -2227,7 +2227,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2242,7 +2242,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -2347,14 +2347,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2399,12 +2399,12 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2428,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -2465,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linked-hash-map"
@@ -2477,9 +2477,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2635,9 +2635,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
 
 [[package]]
 name = "minicbor-serde"
@@ -3051,7 +3051,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -3101,7 +3101,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3116,7 +3116,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -3148,7 +3148,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3243,7 +3243,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3317,7 +3317,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3413,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3428,7 +3428,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3453,7 +3453,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3519,7 +3519,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3542,7 +3542,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3685,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3856,7 +3856,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "web-time",
 ]
@@ -3886,7 +3886,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -3912,7 +3912,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "web-time",
  "wildmatch",
@@ -3939,7 +3939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallstr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3949,7 +3949,7 @@ version = "0.12.1"
 source = "git+https://github.com/matrix-construct/ruma?rev=7cf3483a30fa331843531da2c99451d25771176a#7cf3483a30fa331843531da2c99451d25771176a"
 dependencies = [
  "js_int",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3975,8 +3975,8 @@ dependencies = [
  "quote",
  "ruma-identifiers-validation",
  "serde",
- "syn",
- "toml 1.1.3+spec-1.1.0",
+ "syn 2.0.119",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4005,7 +4005,7 @@ dependencies = [
  "ruma-events",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4087,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4115,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4178,7 +4178,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "thingbuf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
 ]
 
@@ -4388,7 +4388,7 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -4396,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4416,22 +4416,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4449,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4637,9 +4637,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
 ]
@@ -4652,7 +4652,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -4762,6 +4762,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synapse-admin-api"
 version = "0.11.0"
 source = "git+https://github.com/matrix-construct/synapse-admin-api?rev=5cb409a3fc10b2dc9d8ed4f0f2ed7a68ca910a6d#5cb409a3fc10b2dc9d8ed4f0f2ed7a68ca910a6d"
@@ -4787,7 +4798,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4824,7 +4835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4853,7 +4864,7 @@ dependencies = [
  "lazy-regex",
  "minimad",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-width",
 ]
 
@@ -4878,11 +4889,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4893,18 +4904,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4918,9 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4938,9 +4949,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4983,9 +4994,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5000,13 +5011,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5033,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5044,13 +5055,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5084,9 +5096,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "serde_core",
  "serde_spanned 1.1.1",
@@ -5150,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -5294,7 +5306,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5391,7 +5403,7 @@ dependencies = [
  "sentry-tower",
  "sentry-tracing",
  "serde_json",
- "similar 3.1.1",
+ "similar 3.1.2",
  "tokio",
  "tokio-metrics",
  "tracing",
@@ -5526,13 +5538,13 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "serde_yaml",
- "similar 3.1.1",
+ "similar 3.1.2",
  "smallstr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-metrics",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -5568,7 +5580,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5646,7 +5658,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "similar 3.1.1",
+ "similar 3.1.2",
  "subtle",
  "termimad",
  "tokio",
@@ -5902,7 +5914,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6048,7 +6060,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6059,7 +6071,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6222,7 +6234,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -6262,28 +6274,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6303,7 +6315,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6324,7 +6336,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6357,7 +6369,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,7 +3459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5465,7 +5474,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "ipnet",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "rand 0.10.2",
  "reqwest 0.13.4",
@@ -5514,7 +5523,7 @@ dependencies = [
  "insta",
  "ipaddress",
  "ipnet",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jevmalloc",
  "jsonwebtoken",
  "libc",
@@ -5577,7 +5586,7 @@ dependencies = [
 name = "tuwunel_macros"
 version = "1.8.3"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,9 +2650,9 @@ checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
 
 [[package]]
 name = "minicbor-serde"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80047f75e28e3b38f6ab2ec3c2c7669f6b411fa6f8424e1a90a3fd784b19a3f4"
+checksum = "b7abdec9761edcb452764c68564ae4b77ec62f6c1a361aa68f5de15fd788c679"
 dependencies = [
  "minicbor",
  "serde",
@@ -3459,7 +3459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "minimad"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
+checksum = "de632ee829aec3a874d18a4192eae64a0460b3a45c54ed556b334f6fe5a1d62f"
 dependencies = [
  "once_cell",
 ]
@@ -4863,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.34.1"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
+checksum = "d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb"
 dependencies = [
  "coolor",
  "crokey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,7 @@ version = "2.2"
 features = ["std"]
 
 [workspace.dependencies.minicbor-serde]
-version = "0.6"
+version = "0.7"
 features = ["std"]
 
 [workspace.dependencies.nix]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ features = [
 ]
 
 [workspace.dependencies.itertools]
-version = "0.14"
+version = "0.15"
 
 [workspace.dependencies.jevmalloc]
 git = "https://github.com/matrix-construct/jevmalloc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,7 +543,7 @@ features = [
 ]
 
 [workspace.dependencies.termimad]
-version = "0.34"
+version = "0.35"
 default-features = false
 
 [workspace.dependencies.thiserror]

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1782483289,
-        "narHash": "sha256-//gQFVLVFhwHyI9yrpPqX0MQJGYqS6nE/iLV872K+PU=",
+        "lastModified": 1783346450,
+        "narHash": "sha256-AyXLhsc2drC+lunm+TB6Xs6XMMJ/m4B1YjMM1N8JXhU=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "b7c905657cb81b8ec9c26b0d9f53aa2e4f231810",
+        "rev": "7a19204df10d606c5070e6bb72615c3461900c05",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1782407683,
-        "narHash": "sha256-JXS7BhBZ9ElHgel4ssTdyxxs07C+uxRheLCLRlgAUCk=",
+        "lastModified": 1785845883,
+        "narHash": "sha256-PH0sZZFRa99rQfd343DQL1yNb1y9XaYfHFvrUplOwrE=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "683ee9e164e22e596320a8b492918f8084e22cd5",
+        "rev": "a699a8d3ada903ef8fb56af64d5fc8c8963c4382",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760971495,
-        "narHash": "sha256-IwnNtbNVrlZIHh7h4Wz6VP0Furxg9Hh0ycighvL5cZc=",
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "c5bfd933d1033672f51a863c47303fc0e093c2d2",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1781825982,
-        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
         "type": "github"
       },
       "original": {
@@ -131,14 +131,33 @@
         "type": "github"
       }
     },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
     "devenv": {
       "inputs": {
         "cachix": "cachix_2",
+        "crate2nix": "crate2nix",
         "flake-compat": [
           "cachix",
           "flake-compat"
         ],
         "flake-parts": "flake-parts_2",
+        "ghostty": "ghostty",
         "git-hooks": [
           "cachix",
           "git-hooks"
@@ -148,14 +167,15 @@
         "nixpkgs": [
           "cachix",
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772738982,
-        "narHash": "sha256-9MN0FV0XeYJV7kFtUxY6uQMxbZmlrPQLUm3yLbEEJ7Q=",
+        "lastModified": 1785176754,
+        "narHash": "sha256-Fzagdd/VsmWSwGHMNEWkSLV2v54BvgSTmVP12SdITWA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "22ec127af85396b04af045ec20d004d11a0675af",
+        "rev": "0215a960671f25094d35bd1e7d79a4705f28984d",
         "type": "github"
       },
       "original": {
@@ -172,11 +192,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1782732035,
-        "narHash": "sha256-oREqdReAdtbMW5WFcVFDg7NM4b6rmJQglZ+sxC+CwDs=",
+        "lastModified": 1785919363,
+        "narHash": "sha256-4FDhl7ybhL5qhJw1X2IviFJ2MERnzV7X1HlJhFeSBXU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1748a8592edbdcbe8a2317ddc237b47a27932578",
+        "rev": "d17fa5c004217ac6e51da9a8c2d2b79b0ed37109",
         "type": "github"
       },
       "original": {
@@ -265,31 +285,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1760948891,
-        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1723604017,
-        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
         "type": "github"
       }
     },
@@ -312,62 +317,55 @@
         "type": "github"
       }
     },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784602798,
+        "narHash": "sha256-298x90knBUWX5GHGXh2SKsAKvStjU2ri9UgOGoF79/8=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "88b4cd047fa627cdca6781bc7e7dc8b75a2cecb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": [
           "cachix",
           "flake-compat"
         ],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "cachix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1772665116,
-        "narHash": "sha256-XmjUDG/J8Z8lY5DVNVUf5aoZGc400FxcjsNCqHKiKtc=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "cachix",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "liburing": {
       "flake": false,
       "locked": {
-        "lastModified": 1782603678,
-        "narHash": "sha256-oBNu5DI2RMk0BPm6NT8qaYuyhk7+KIpFSsBsVwI7BO8=",
+        "lastModified": 1785277588,
+        "narHash": "sha256-CnODrFX1TSnHajJTNe68q/wMyh8RtT61KiIjIMUS8cQ=",
         "owner": "axboe",
         "repo": "liburing",
-        "rev": "d41bf9220ec39277ff235379e9089d9e0fd6c2a5",
+        "rev": "5cdb10f1a1334e8c7a3604ddfbaed4e4ff8ec30a",
         "type": "github"
       },
       "original": {
@@ -409,16 +407,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1771532737,
-        "narHash": "sha256-H26FQmOyvIGnedfAioparJQD8Oe+/byD6OpUpnI/hkE=",
+        "lastModified": 1782407171,
+        "narHash": "sha256-xem+4ncdQCTFJsQ4PrVuyVmi3j4w/Yqg298hBUzVejA=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "7eb6c427c7a86fdc3ebf9e6cbf2a84e80e8974fd",
+        "rev": "782ac1b155679b065ec945ae50d0fa1d495883b7",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.32",
+        "ref": "devenv-2.34",
         "repo": "nix",
         "type": "github"
       }
@@ -467,7 +465,6 @@
           "devenv",
           "flake-parts"
         ],
-        "flake-root": "flake-root",
         "nixpkgs": [
           "cachix",
           "devenv",
@@ -476,11 +473,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1763964548,
-        "narHash": "sha256-JTRoaEWvPsVIMFJWeS4G2isPo15wqXY/otsiHPN0zww=",
+        "lastModified": 1783935112,
+        "narHash": "sha256-IAQ14nteIKXAz4cd75UcZrsHGEVJ7QNrkUwX9rmeZ/Y=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "d4bf15e56540422e2acc7bc26b20b0a0934e3f5e",
+        "rev": "a64cd33e53b316b6b092ea0a966640cd2309bf3d",
         "type": "github"
       },
       "original": {
@@ -523,11 +520,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -539,11 +536,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1782731455,
-        "narHash": "sha256-weCjCyph1saaHwUdjTk6AAFn/w2riVwOimn/qZMFxKY=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c4c05a947a91dc14625265fab505fb695e93218",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {
@@ -588,17 +585,39 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1782691063,
-        "narHash": "sha256-qtAe8z4KKLIe/oKu4tc2bmaB+wEG/jjPrebR34WY0zg=",
+        "lastModified": 1785889825,
+        "narHash": "sha256-U98Y5RADVCkMCbrKCFXppe6MSAi0tUTLxi3cB/SMcZI=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "972c4e7bee140acd27e26b3e04673bfd05302f89",
+        "rev": "6817dd3094203c8bc4911f5799baf897623003de",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     },
@@ -627,11 +646,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/src/api/client/sync/mod.rs
+++ b/src/api/client/sync/mod.rs
@@ -1,15 +1,12 @@
 mod v3;
 mod v5;
 
-use futures::{FutureExt, StreamExt, pin_mut};
+use futures::{StreamExt, pin_mut};
 use ruma::{RoomId, UserId, events::TimelineEventType::RoomMember};
 use tuwunel_core::{
 	Error, PduCount, Result,
 	matrix::{Event, pdu::PduEvent},
-	utils::{
-		result::LogErr,
-		stream::{BroadbandExt, ReadyExt},
-	},
+	utils::{ReadyExt, result::LogErr, stream::BroadbandExt},
 };
 use tuwunel_service::Services;
 
@@ -17,6 +14,12 @@ pub(crate) use self::{
 	v3::{calculate_heroes, sync_events_route},
 	v5::sync_events_v5_route,
 };
+
+#[derive(Clone, Copy)]
+enum TimelineErrors {
+	Ignore,
+	Propagate,
+}
 
 async fn load_timeline(
 	services: &Services,
@@ -26,37 +29,88 @@ async fn load_timeline(
 	next_batch: Option<PduCount>,
 	limit: usize,
 ) -> Result<(Vec<(PduCount, PduEvent)>, bool, PduCount), Error> {
-	let last_timeline_count = services
-		.timeline
-		.last_timeline_count(Some(sender_user), room_id, next_batch)
-		.await?;
+	load_timeline_with_errors(
+		services,
+		sender_user,
+		room_id,
+		roomsincecount,
+		next_batch,
+		limit,
+		TimelineErrors::Ignore,
+	)
+	.await
+}
 
-	if last_timeline_count <= roomsincecount {
-		return Ok((Vec::new(), false, last_timeline_count));
+async fn load_timeline_fallible(
+	services: &Services,
+	sender_user: &UserId,
+	room_id: &RoomId,
+	roomsincecount: PduCount,
+	next_batch: Option<PduCount>,
+	limit: usize,
+) -> Result<(Vec<(PduCount, PduEvent)>, bool, PduCount), Error> {
+	load_timeline_with_errors(
+		services,
+		sender_user,
+		room_id,
+		roomsincecount,
+		next_batch,
+		limit,
+		TimelineErrors::Propagate,
+	)
+	.await
+}
+
+async fn load_timeline_with_errors(
+	services: &Services,
+	sender_user: &UserId,
+	room_id: &RoomId,
+	roomsincecount: PduCount,
+	next_batch: Option<PduCount>,
+	limit: usize,
+	errors: TimelineErrors,
+) -> Result<(Vec<(PduCount, PduEvent)>, bool, PduCount), Error> {
+	let until = next_batch.map(|count| count.saturating_add(1));
+	let pdus = services
+		.timeline
+		.pdus_rev(Some(sender_user), room_id, until);
+
+	// Take the last events for the timeline.
+	pin_mut!(pdus);
+	let mut timeline_pdus = Vec::new();
+	let mut last_timeline_count = PduCount::max();
+	let mut first = true;
+	let mut limited = false;
+
+	while let Some(pdu) = pdus.next().await {
+		let (pducount, pdu) = match pdu {
+			| Ok(pdu) => pdu,
+			| Err(error) if first || matches!(errors, TimelineErrors::Propagate) => {
+				return Err(error);
+			},
+			| Err(_) => continue,
+		};
+
+		if first {
+			first = false;
+			last_timeline_count = matches!(pducount, PduCount::Normal(_))
+				.then_some(pducount)
+				.unwrap_or_else(PduCount::max);
+		}
+
+		if pducount <= roomsincecount {
+			break;
+		}
+
+		if timeline_pdus.len() == limit {
+			limited = true;
+			break;
+		}
+
+		timeline_pdus.push((pducount, pdu));
 	}
 
-	let non_timeline_pdus = services
-		.timeline
-		.pdus_rev(Some(sender_user), room_id, None)
-		.ready_filter_map(Result::ok)
-		.ready_skip_while(|&(pducount, _)| pducount > next_batch.unwrap_or_else(PduCount::max))
-		.ready_take_while(|&(pducount, _)| pducount > roomsincecount);
-
-	// Take the last events for the timeline
-	pin_mut!(non_timeline_pdus);
-	let timeline_pdus: Vec<_> = non_timeline_pdus
-		.by_ref()
-		.take(limit)
-		.collect()
-		.map(|mut pdus: Vec<_>| {
-			pdus.reverse();
-			pdus
-		})
-		.await;
-
-	// They /sync response doesn't always return all messages, so we say the output
-	// is limited unless there are events in non_timeline_pdus
-	let limited = non_timeline_pdus.next().await.is_some();
+	timeline_pdus.reverse();
 
 	Ok((timeline_pdus, limited, last_timeline_count))
 }

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -52,8 +52,15 @@ struct WindowRoom {
 	room_id: OwnedRoomId,
 	membership: Option<MembershipState>,
 	lists: ListIds,
-	ranked: usize,
-	last_count: u64,
+	event_count: u64,
+	payload_count: u64,
+}
+
+impl WindowRoom {
+	#[inline]
+	fn payload_is_fresh(&self, roomsince: u64) -> bool {
+		roomsince == 0 || self.payload_count > roomsince
+	}
 }
 
 type Window = BTreeMap<OwnedRoomId, WindowRoom>;
@@ -196,10 +203,12 @@ pub(crate) async fn sync_events_v5_route(
 			let extensions = handle_extensions(sync_info, &conn, &window);
 			let (mut ranges, extensions) = join(ranges, extensions).boxed().await;
 
-			response.extensions = extensions?;
-			apply_ranges(&conn, &window, &mut ranges, &mut response.extensions);
+			let mut extensions = extensions?;
+
+			apply_ranges(&conn, &window, &mut ranges, &mut extensions);
 			conn.update_rooms_epilogue(ranges.keys());
 			response.rooms = ranges.into_payloads();
+			response.extensions = extensions.into_response(&response.rooms);
 
 			if !is_empty_response(&response) {
 				response.pos = conn.next_batch.to_string().into();

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -42,6 +42,7 @@ struct SyncInfo<'a> {
 	services: &'a Services,
 	sender_user: &'a UserId,
 	sender_device: Option<&'a DeviceId>,
+	previous_connection_pos: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -165,7 +166,12 @@ pub(crate) async fn sync_events_v5_route(
 		.checked_add(Duration::from_millis(timeout))
 		.expect("configuration must limit maximum timeout");
 
-	let sync_info = SyncInfo { services, sender_user, sender_device };
+	let sync_info = SyncInfo {
+		services,
+		sender_user,
+		sender_device,
+		previous_connection_pos: since.ne(&0).then_some(since),
+	};
 	loop {
 		debug_assert!(
 			conn.globalsince <= conn.next_batch,

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -198,7 +198,7 @@ pub(crate) async fn sync_events_v5_route(
 
 			try_join(rooms, extensions).boxed().await?;
 
-			conn.update_rooms_epilogue(window.keys().map(AsRef::as_ref));
+			conn.update_rooms_epilogue(response.rooms.keys().map(AsRef::as_ref));
 
 			if !is_empty_response(&response) {
 				response.pos = conn.next_batch.to_string().into();

--- a/src/api/client/sync/v5.rs
+++ b/src/api/client/sync/v5.rs
@@ -1,15 +1,13 @@
 mod extensions;
 mod filter;
+mod range;
 mod rooms;
 mod selector;
 
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc, time::Duration};
 
 use axum::extract::{Extension, State};
-use futures::{
-	FutureExt, TryFutureExt,
-	future::{join, try_join},
-};
+use futures::{FutureExt, TryFutureExt, future::join};
 use ruma::{
 	DeviceId, OwnedRoomId, UserId,
 	api::client::sync::sync_events::v5::{ListId, Request, Response, response},
@@ -34,6 +32,10 @@ use tuwunel_service::{
 	sync::{Connection, into_connection_key},
 };
 
+use self::{
+	extensions::{apply_ranges, handle as handle_extensions},
+	range::collect as collect_ranges,
+};
 use super::share_encrypted_room;
 use crate::{ClientIp, Ruma};
 
@@ -190,15 +192,14 @@ pub(crate) async fn sync_events_v5_route(
 			.await;
 
 		if conn.globalsince < conn.next_batch {
-			let rooms = rooms::handle(sync_info, &conn, &window)
-				.map_ok(|response_rooms| response.rooms = response_rooms);
+			let ranges = collect_ranges(sync_info, &conn, &window);
+			let extensions = handle_extensions(sync_info, &conn, &window);
+			let (mut ranges, extensions) = join(ranges, extensions).boxed().await;
 
-			let extensions = extensions::handle(sync_info, &conn, &window)
-				.map_ok(|response_extensions| response.extensions = response_extensions);
-
-			try_join(rooms, extensions).boxed().await?;
-
-			conn.update_rooms_epilogue(response.rooms.keys().map(AsRef::as_ref));
+			response.extensions = extensions?;
+			apply_ranges(&conn, &window, &mut ranges, &mut response.extensions);
+			conn.update_rooms_epilogue(ranges.keys());
+			response.rooms = ranges.into_payloads();
 
 			if !is_empty_response(&response) {
 				response.pos = conn.next_batch.to_string().into();

--- a/src/api/client/sync/v5/extensions.rs
+++ b/src/api/client/sync/v5/extensions.rs
@@ -14,7 +14,11 @@ use ruma::{
 use tuwunel_core::{Result, apply, at, extract_variant, utils::BoolExt};
 use tuwunel_service::sync::Connection;
 
-use super::{SyncInfo, Window, share_encrypted_room};
+use self::{
+	account_data::collect_ranges as collect_account_data_ranges,
+	receipts::collect_ranges as collect_receipt_ranges,
+};
+use super::{SyncInfo, Window, range::Results, share_encrypted_room};
 
 #[tracing::instrument(
 	name = "extensions",
@@ -83,6 +87,34 @@ pub(super) async fn handle(
 	})
 }
 
+pub(super) fn apply_ranges(
+	conn: &Connection,
+	window: &Window,
+	ranges: &mut Results,
+	extensions: &mut response::Extensions,
+) {
+	ranges.retain_complete(&mut extensions.typing.rooms, |room_id| window.contains_key(room_id));
+
+	if conn.extensions.receipts.enabled.unwrap_or(false) {
+		extensions
+			.receipts
+			.rooms
+			.extend(collect_receipt_ranges(conn, window, ranges).rooms);
+	}
+
+	if conn
+		.extensions
+		.account_data
+		.enabled
+		.unwrap_or(false)
+	{
+		extensions
+			.account_data
+			.rooms
+			.extend(collect_account_data_ranges(conn, window, ranges));
+	}
+}
+
 #[tracing::instrument(
 	name = "selector",
 	level = "trace",
@@ -90,7 +122,6 @@ pub(super) async fn handle(
 	fields(?implicit, ?explicit),
 )]
 fn selector<'a, ListIter, SubsIter>(
-	SyncInfo { .. }: SyncInfo<'a>,
 	conn: &'a Connection,
 	window: &'a Window,
 	implicit: Option<ListIter>,

--- a/src/api/client/sync/v5/extensions.rs
+++ b/src/api/client/sync/v5/extensions.rs
@@ -4,21 +4,42 @@ mod receipts;
 mod to_device;
 mod typing;
 
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 
-use futures::{FutureExt, future::join5};
+use futures::{FutureExt, future::join4};
 use ruma::{
-	RoomId,
-	api::client::sync::sync_events::v5::{ListId, request::ExtensionRoomConfig, response},
+	OwnedRoomId, RoomId,
+	api::client::sync::sync_events::v5::{
+		ListId,
+		request::ExtensionRoomConfig,
+		response::{Extensions, Room as ResponseRoom},
+	},
 };
 use tuwunel_core::{Result, apply, at, extract_variant, utils::BoolExt};
 use tuwunel_service::sync::Connection;
 
 use self::{
-	account_data::collect_ranges as collect_account_data_ranges,
+	account_data::{
+		collect as collect_account_data, collect_ranges as collect_account_data_ranges,
+	},
 	receipts::collect_ranges as collect_receipt_ranges,
 };
-use super::{SyncInfo, Window, range::Results, share_encrypted_room};
+use super::{SyncInfo, Window, WindowRoom, range::Results, share_encrypted_room};
+
+pub(super) struct Collected {
+	response: Extensions,
+	typing: typing::Collected,
+}
+
+impl Collected {
+	pub(super) fn into_response(
+		mut self,
+		payloads: &BTreeMap<OwnedRoomId, ResponseRoom>,
+	) -> Extensions {
+		self.response.typing = self.typing.into_response(payloads);
+		self.response
+	}
+}
 
 #[tracing::instrument(
 	name = "extensions",
@@ -35,22 +56,13 @@ pub(super) async fn handle(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window: &Window,
-) -> Result<response::Extensions> {
-	let SyncInfo { .. } = sync_info;
-
+) -> Result<Collected> {
 	let account_data = conn
 		.extensions
 		.account_data
 		.enabled
 		.unwrap_or(false)
-		.then_async(|| account_data::collect(sync_info, conn, window));
-
-	let receipts = conn
-		.extensions
-		.receipts
-		.enabled
-		.unwrap_or(false)
-		.then_async(|| receipts::collect(sync_info, conn, window));
+		.then_async(|| collect_account_data(sync_info, conn));
 
 	let typing = conn
 		.extensions
@@ -73,33 +85,31 @@ pub(super) async fn handle(
 		.unwrap_or(false)
 		.then_async(|| e2ee::collect(sync_info, conn));
 
-	let (account_data, receipts, typing, to_device, e2ee) =
-		join5(account_data, receipts, typing, to_device, e2ee)
-			.map(apply!(5, |t: Option<_>| t.unwrap_or(Ok(Default::default()))))
-			.await;
+	let (account_data, typing, to_device, e2ee) = join4(account_data, typing, to_device, e2ee)
+		.map(apply!(4, |t: Option<_>| t.unwrap_or(Ok(Default::default()))))
+		.await;
 
-	Ok(response::Extensions {
+	// Receipt and room account-data payloads only exist as bounded room-range
+	// outputs, applied by `apply_ranges` after the ranges resolve.
+	let response = Extensions {
 		account_data: account_data?,
-		receipts: receipts?,
-		typing: typing?,
+		receipts: Default::default(),
+		typing: Default::default(),
 		to_device: to_device?,
 		e2ee: e2ee?,
-	})
+	};
+
+	Ok(Collected { response, typing: typing? })
 }
 
 pub(super) fn apply_ranges(
 	conn: &Connection,
 	window: &Window,
 	ranges: &mut Results,
-	extensions: &mut response::Extensions,
+	extensions: &mut Collected,
 ) {
-	ranges.retain_complete(&mut extensions.typing.rooms, |room_id| window.contains_key(room_id));
-
 	if conn.extensions.receipts.enabled.unwrap_or(false) {
-		extensions
-			.receipts
-			.rooms
-			.extend(collect_receipt_ranges(conn, window, ranges).rooms);
+		extensions.response.receipts = collect_receipt_ranges(conn, window, ranges);
 	}
 
 	if conn
@@ -108,10 +118,8 @@ pub(super) fn apply_ranges(
 		.enabled
 		.unwrap_or(false)
 	{
-		extensions
-			.account_data
-			.rooms
-			.extend(collect_account_data_ranges(conn, window, ranges));
+		extensions.response.account_data.rooms =
+			collect_account_data_ranges(conn, window, ranges);
 	}
 }
 
@@ -136,9 +144,20 @@ where
 		.into_iter()
 		.flatten()
 		.any(|erc| matches!(erc, ExtensionRoomConfig::AllSubscribed));
+	let implicit_subscribed = implicit.clone();
+	let implicit_explicit = implicit.clone();
 
 	let all_subscribed = has_all_subscribed
-		.then(|| conn.subscriptions.keys())
+		.then(|| {
+			window
+				.keys()
+				.filter(|room_id| conn.subscriptions.contains_key(*room_id))
+				.filter(move |room_id| {
+					window
+						.get(*room_id)
+						.is_some_and(|room| !implicit_match(room, implicit_subscribed.as_ref()))
+				})
+		})
 		.into_iter()
 		.flatten()
 		.map(AsRef::as_ref);
@@ -150,6 +169,11 @@ where
 				.into_iter()
 				.flatten()
 				.filter_map(|erc| extract_variant!(erc, ExtensionRoomConfig::Room))
+				.filter(move |room_id| {
+					window
+						.get::<RoomId>(room_id.as_ref())
+						.is_some_and(|room| !implicit_match(room, implicit_explicit.as_ref()))
+				})
 				.map(AsRef::as_ref)
 		})
 		.into_iter()
@@ -157,17 +181,143 @@ where
 
 	let rooms_selected = window
 		.iter()
-		.filter(move |(_, room)| {
-			implicit.as_ref().is_none_or(|lists| {
-				lists
-					.clone()
-					.any(|list| room.lists.contains(list))
-			})
-		})
+		.filter(move |(_, room)| implicit_match(room, implicit.as_ref()))
 		.map(at!(0))
 		.map(AsRef::as_ref);
 
 	all_subscribed
 		.chain(rooms_explicit)
 		.chain(rooms_selected)
+}
+
+fn implicit_match<'a, ListIter>(room: &WindowRoom, implicit: Option<&ListIter>) -> bool
+where
+	ListIter: Iterator<Item = &'a ListId> + Clone,
+{
+	implicit.is_none_or(|lists| {
+		lists
+			.clone()
+			.any(|list| room.lists.contains(list))
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::slice::Iter;
+
+	use ruma::room_id;
+
+	use super::*;
+	use crate::client::sync::v5::ListIds;
+
+	#[test]
+	fn explicit_room_outside_the_window_is_rejected() {
+		let selected = room_id!("!selected:example.com");
+		let foreign = room_id!("!foreign:example.com");
+		let window = window(selected, 0);
+		let conn = Connection::default();
+		let list = ListId::from("unmatched");
+		let lists = [list];
+		let rooms = [ExtensionRoomConfig::Room(foreign.to_owned())];
+
+		assert!(
+			selector(&conn, &window, Some(lists.iter()), Some(rooms.iter()))
+				.next()
+				.is_none()
+		);
+	}
+
+	#[test]
+	fn all_subscribed_room_outside_the_window_is_rejected() {
+		let selected = room_id!("!selected:example.com");
+		let foreign = room_id!("!foreign:example.com");
+		let window = window(selected, 0);
+		let mut conn = Connection::default();
+		conn.subscriptions
+			.insert(foreign.to_owned(), Default::default());
+		let list = ListId::from("unmatched");
+		let lists = [list];
+		let rooms = [ExtensionRoomConfig::AllSubscribed];
+
+		assert!(
+			selector(&conn, &window, Some(lists.iter()), Some(rooms.iter()))
+				.next()
+				.is_none()
+		);
+	}
+
+	#[test]
+	fn stale_payload_room_in_the_window_remains_extension_eligible() {
+		let room_id = room_id!("!stale:example.com");
+		let window = window(room_id, 1);
+		let mut conn = Connection::default();
+		conn.rooms
+			.entry(room_id.to_owned())
+			.or_default()
+			.roomsince = 9;
+
+		let lists: Option<Iter<'_, ListId>> = None;
+		let rooms: Option<Iter<'_, ExtensionRoomConfig>> = None;
+
+		let selected = selector(&conn, &window, lists, rooms).collect::<Vec<_>>();
+
+		assert_eq!(selected, [room_id]);
+	}
+
+	#[test]
+	fn explicit_room_already_selected_by_list_is_not_duplicated() {
+		let room_id = room_id!("!explicit-overlap:example.com");
+		let list = ListId::from("main");
+		let mut window = window(room_id, 0);
+
+		window
+			.get_mut(room_id)
+			.expect("test room should be present")
+			.lists
+			.push(list.clone());
+
+		let conn = Connection::default();
+		let lists = [list];
+		let rooms = [ExtensionRoomConfig::Room(room_id.to_owned())];
+		let selected =
+			selector(&conn, &window, Some(lists.iter()), Some(rooms.iter())).collect::<Vec<_>>();
+
+		assert_eq!(selected, [room_id]);
+	}
+
+	#[test]
+	fn subscribed_room_already_selected_by_list_is_not_duplicated() {
+		let room_id = room_id!("!subscribed-overlap:example.com");
+		let list = ListId::from("main");
+		let mut window = window(room_id, 0);
+
+		window
+			.get_mut(room_id)
+			.expect("test room should be present")
+			.lists
+			.push(list.clone());
+
+		let mut conn = Connection::default();
+		conn.subscriptions
+			.insert(room_id.to_owned(), Default::default());
+
+		let lists = [list];
+		let rooms = [ExtensionRoomConfig::AllSubscribed];
+		let selected =
+			selector(&conn, &window, Some(lists.iter()), Some(rooms.iter())).collect::<Vec<_>>();
+
+		assert_eq!(selected, [room_id]);
+	}
+
+	fn window(room_id: &RoomId, payload_count: u64) -> Window {
+		let room = WindowRoom {
+			room_id: room_id.to_owned(),
+			membership: None,
+			lists: ListIds::new(),
+			event_count: 0,
+			payload_count,
+		};
+
+		[(room_id.to_owned(), room)].into()
+	}
 }

--- a/src/api/client/sync/v5/extensions/account_data.rs
+++ b/src/api/client/sync/v5/extensions/account_data.rs
@@ -1,22 +1,58 @@
-use futures::{StreamExt, future::join};
-use ruma::{api::client::sync::sync_events::v5::response, events::AnyRawAccountDataEvent};
+use std::collections::BTreeMap;
+
+use futures::{StreamExt, TryStreamExt, future::join};
+use ruma::{
+	OwnedRoomId,
+	api::client::sync::sync_events::v5::response::AccountData,
+	events::{AnyRawAccountDataEvent, AnyRoomAccountDataEvent},
+	serde::Raw,
+};
 use tuwunel_core::{
 	Result, extract_variant,
-	utils::{IterStream, ReadyExt, stream::BroadbandExt},
+	utils::{IterStream, ReadyExt, TryReadyExt, stream::BroadbandExt},
 };
 use tuwunel_service::sync::Room;
 
 use super::{Connection, SyncInfo, Window, selector};
-use crate::client::is_empty_account_data_event;
+use crate::client::{is_empty_account_data_event, sync::v5::range::Results};
 
 #[tracing::instrument(name = "account_data", level = "trace", skip_all)]
 pub(super) async fn collect(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window: &Window,
-) -> Result<response::AccountData> {
-	let SyncInfo { services, sender_user, .. } = sync_info;
+) -> Result<AccountData> {
+	let global = collect_global(sync_info, conn);
+	let rooms = collect_unattempted(sync_info, conn, window);
+	let (global, rooms) = join(global, rooms).await;
+	let mut account_data = global?;
 
+	account_data.rooms = rooms;
+
+	Ok(account_data)
+}
+
+async fn collect_global(
+	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
+	conn: &Connection,
+) -> Result<AccountData> {
+	let globalsince = conn.globalsince;
+	let global = services
+		.account_data
+		.changes_since_fallible(None, sender_user, globalsince, Some(conn.next_batch))
+		.ready_try_filter_map(|event| Ok(extract_variant!(event, AnyRawAccountDataEvent::Global)))
+		.ready_try_filter(move |event| globalsince != 0 || !is_empty_account_data_event(event))
+		.try_collect()
+		.await?;
+
+	Ok(AccountData { global, rooms: Default::default() })
+}
+
+async fn collect_unattempted(
+	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
+	conn: &Connection,
+	window: &Window,
+) -> BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>> {
 	let implicit = conn
 		.extensions
 		.account_data
@@ -31,34 +67,49 @@ pub(super) async fn collect(
 		.as_deref()
 		.map(<[_]>::iter);
 
-	let rooms = selector(sync_info, conn, window, implicit, explicit)
+	selector(conn, window, implicit, explicit)
+		.filter(|&room_id| !window.contains_key(room_id))
 		.stream()
 		.broad_filter_map(async |room_id| {
 			let &Room { roomsince, .. } = conn.rooms.get(room_id)?;
 			let changes: Vec<_> = services
 				.account_data
 				.changes_since(Some(room_id), sender_user, roomsince, Some(conn.next_batch))
-				.ready_filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Room))
-				.ready_filter(move |e| roomsince != 0 || !is_empty_account_data_event(e))
+				.ready_filter_map(|event| extract_variant!(event, AnyRawAccountDataEvent::Room))
+				.ready_filter(move |event| roomsince != 0 || !is_empty_account_data_event(event))
 				.collect()
 				.await;
 
-			changes
-				.is_empty()
-				.eq(&false)
-				.then(move || (room_id.to_owned(), changes))
+			(!changes.is_empty()).then(|| (room_id.to_owned(), changes))
 		})
-		.collect();
+		.collect()
+		.await
+}
 
-	let globalsince = conn.globalsince;
-	let global = services
+pub(super) fn collect_ranges(
+	conn: &Connection,
+	window: &Window,
+	ranges: &mut Results,
+) -> BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>> {
+	let implicit = conn
+		.extensions
 		.account_data
-		.changes_since(None, sender_user, globalsince, Some(conn.next_batch))
-		.ready_filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Global))
-		.ready_filter(move |e| globalsince != 0 || !is_empty_account_data_event(e))
-		.collect();
+		.lists
+		.as_deref()
+		.map(<[_]>::iter);
 
-	let (global, rooms) = join(global, rooms).await;
+	let explicit = conn
+		.extensions
+		.account_data
+		.rooms
+		.as_deref()
+		.map(<[_]>::iter);
 
-	Ok(response::AccountData { global, rooms })
+	selector(conn, window, implicit, explicit)
+		.filter_map(|room_id| {
+			ranges
+				.take_account_data(room_id)
+				.map(|events| (room_id.to_owned(), events))
+		})
+		.collect()
 }

--- a/src/api/client/sync/v5/extensions/account_data.rs
+++ b/src/api/client/sync/v5/extensions/account_data.rs
@@ -1,38 +1,19 @@
 use std::collections::BTreeMap;
 
-use futures::{StreamExt, TryStreamExt, future::join};
+use futures::TryStreamExt;
 use ruma::{
 	OwnedRoomId,
 	api::client::sync::sync_events::v5::response::AccountData,
 	events::{AnyRawAccountDataEvent, AnyRoomAccountDataEvent},
 	serde::Raw,
 };
-use tuwunel_core::{
-	Result, extract_variant,
-	utils::{IterStream, ReadyExt, TryReadyExt, stream::BroadbandExt},
-};
-use tuwunel_service::sync::Room;
+use tuwunel_core::{Result, extract_variant, utils::TryReadyExt};
 
 use super::{Connection, SyncInfo, Window, selector};
 use crate::client::{is_empty_account_data_event, sync::v5::range::Results};
 
 #[tracing::instrument(name = "account_data", level = "trace", skip_all)]
 pub(super) async fn collect(
-	sync_info: SyncInfo<'_>,
-	conn: &Connection,
-	window: &Window,
-) -> Result<AccountData> {
-	let global = collect_global(sync_info, conn);
-	let rooms = collect_unattempted(sync_info, conn, window);
-	let (global, rooms) = join(global, rooms).await;
-	let mut account_data = global?;
-
-	account_data.rooms = rooms;
-
-	Ok(account_data)
-}
-
-async fn collect_global(
 	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
 	conn: &Connection,
 ) -> Result<AccountData> {
@@ -46,44 +27,6 @@ async fn collect_global(
 		.await?;
 
 	Ok(AccountData { global, rooms: Default::default() })
-}
-
-async fn collect_unattempted(
-	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
-	conn: &Connection,
-	window: &Window,
-) -> BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>> {
-	let implicit = conn
-		.extensions
-		.account_data
-		.lists
-		.as_deref()
-		.map(<[_]>::iter);
-
-	let explicit = conn
-		.extensions
-		.account_data
-		.rooms
-		.as_deref()
-		.map(<[_]>::iter);
-
-	selector(conn, window, implicit, explicit)
-		.filter(|&room_id| !window.contains_key(room_id))
-		.stream()
-		.broad_filter_map(async |room_id| {
-			let &Room { roomsince, .. } = conn.rooms.get(room_id)?;
-			let changes: Vec<_> = services
-				.account_data
-				.changes_since(Some(room_id), sender_user, roomsince, Some(conn.next_batch))
-				.ready_filter_map(|event| extract_variant!(event, AnyRawAccountDataEvent::Room))
-				.ready_filter(move |event| roomsince != 0 || !is_empty_account_data_event(event))
-				.collect()
-				.await;
-
-			(!changes.is_empty()).then(|| (room_id.to_owned(), changes))
-		})
-		.collect()
-		.await
 }
 
 pub(super) fn collect_ranges(

--- a/src/api/client/sync/v5/extensions/receipts.rs
+++ b/src/api/client/sync/v5/extensions/receipts.rs
@@ -1,51 +1,7 @@
-use futures::{FutureExt, StreamExt};
-use ruma::{
-	OwnedRoomId, RoomId,
-	api::client::sync::sync_events::v5::response::Receipts,
-	events::{AnySyncEphemeralRoomEvent, receipt::SyncReceiptEvent},
-	serde::Raw,
-};
-use tuwunel_core::{
-	Result,
-	utils::{BoolExt, IterStream, stream::BroadbandExt},
-};
-use tuwunel_service::{
-	rooms::read_receipt::{PrivateReadEvents, pack_receipts},
-	sync::Room,
-};
+use ruma::api::client::sync::sync_events::v5::response::Receipts;
 
-use super::{Connection, SyncInfo, Window, selector};
+use super::{Connection, Window, selector};
 use crate::client::sync::v5::range::Results;
-
-#[tracing::instrument(name = "receipts", level = "trace", skip_all)]
-pub(super) async fn collect(
-	sync_info: SyncInfo<'_>,
-	conn: &Connection,
-	window: &Window,
-) -> Result<Receipts> {
-	let implicit = conn
-		.extensions
-		.receipts
-		.lists
-		.as_deref()
-		.map(<[_]>::iter);
-
-	let explicit = conn
-		.extensions
-		.receipts
-		.rooms
-		.as_deref()
-		.map(<[_]>::iter);
-
-	let rooms = selector(conn, window, implicit, explicit)
-		.filter(|&room_id| !window.contains_key(room_id))
-		.stream()
-		.broad_filter_map(|room_id| collect_room(sync_info, conn, room_id))
-		.collect()
-		.await;
-
-	Ok(Receipts { rooms })
-}
 
 pub(super) fn collect_ranges(
 	conn: &Connection,
@@ -75,46 +31,4 @@ pub(super) fn collect_ranges(
 		.collect();
 
 	Receipts { rooms }
-}
-
-#[tracing::instrument(level = "trace", skip_all, fields(room_id), ret)]
-async fn collect_room(
-	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
-	conn: &Connection,
-	room_id: &RoomId,
-) -> Option<(OwnedRoomId, Raw<SyncReceiptEvent>)> {
-	let &Room { roomsince, .. } = conn.rooms.get(room_id)?;
-	let private_receipt = services
-		.read_receipt
-		.last_privateread_update(sender_user, room_id)
-		.then(async |last_private_update| {
-			if last_private_update <= roomsince || last_private_update > conn.next_batch {
-				return PrivateReadEvents::new();
-			}
-
-			services
-				.read_receipt
-				.private_read_get(room_id, sender_user)
-				.await
-				.unwrap_or_default()
-		})
-		.map(IterStream::stream)
-		.flatten_stream();
-
-	let receipts: Vec<Raw<AnySyncEphemeralRoomEvent>> = services
-		.read_receipt
-		.readreceipts_since(room_id, roomsince, Some(conn.next_batch))
-		.filter_map(async |(read_user, _ts, event)| {
-			services
-				.users
-				.user_is_ignored(read_user, sender_user)
-				.await
-				.or_some(event)
-		})
-		.chain(private_receipt)
-		.collect()
-		.boxed()
-		.await;
-
-	(!receipts.is_empty()).then(|| (room_id.to_owned(), pack_receipts(receipts.into_iter())))
 }

--- a/src/api/client/sync/v5/extensions/receipts.rs
+++ b/src/api/client/sync/v5/extensions/receipts.rs
@@ -1,7 +1,7 @@
 use futures::{FutureExt, StreamExt};
 use ruma::{
 	OwnedRoomId, RoomId,
-	api::client::sync::sync_events::v5::response,
+	api::client::sync::sync_events::v5::response::Receipts,
 	events::{AnySyncEphemeralRoomEvent, receipt::SyncReceiptEvent},
 	serde::Raw,
 };
@@ -15,15 +15,14 @@ use tuwunel_service::{
 };
 
 use super::{Connection, SyncInfo, Window, selector};
+use crate::client::sync::v5::range::Results;
 
 #[tracing::instrument(name = "receipts", level = "trace", skip_all)]
 pub(super) async fn collect(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window: &Window,
-) -> Result<response::Receipts> {
-	let SyncInfo { .. } = sync_info;
-
+) -> Result<Receipts> {
 	let implicit = conn
 		.extensions
 		.receipts
@@ -38,20 +37,50 @@ pub(super) async fn collect(
 		.as_deref()
 		.map(<[_]>::iter);
 
-	let rooms = selector(sync_info, conn, window, implicit, explicit)
+	let rooms = selector(conn, window, implicit, explicit)
+		.filter(|&room_id| !window.contains_key(room_id))
 		.stream()
-		.broad_filter_map(|room_id| collect_room(sync_info, conn, window, room_id))
+		.broad_filter_map(|room_id| collect_room(sync_info, conn, room_id))
 		.collect()
 		.await;
 
-	Ok(response::Receipts { rooms })
+	Ok(Receipts { rooms })
+}
+
+pub(super) fn collect_ranges(
+	conn: &Connection,
+	window: &Window,
+	ranges: &mut Results,
+) -> Receipts {
+	let implicit = conn
+		.extensions
+		.receipts
+		.lists
+		.as_deref()
+		.map(<[_]>::iter);
+
+	let explicit = conn
+		.extensions
+		.receipts
+		.rooms
+		.as_deref()
+		.map(<[_]>::iter);
+
+	let rooms = selector(conn, window, implicit, explicit)
+		.filter_map(|room_id| {
+			ranges
+				.take_receipts(room_id)
+				.map(|event| (room_id.to_owned(), event))
+		})
+		.collect();
+
+	Receipts { rooms }
 }
 
 #[tracing::instrument(level = "trace", skip_all, fields(room_id), ret)]
 async fn collect_room(
 	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
 	conn: &Connection,
-	_window: &Window,
 	room_id: &RoomId,
 ) -> Option<(OwnedRoomId, Raw<SyncReceiptEvent>)> {
 	let &Room { roomsince, .. } = conn.rooms.get(room_id)?;
@@ -75,20 +104,17 @@ async fn collect_room(
 	let receipts: Vec<Raw<AnySyncEphemeralRoomEvent>> = services
 		.read_receipt
 		.readreceipts_since(room_id, roomsince, Some(conn.next_batch))
-		.filter_map(async |(read_user, _ts, v)| {
+		.filter_map(async |(read_user, _ts, event)| {
 			services
 				.users
 				.user_is_ignored(read_user, sender_user)
 				.await
-				.or_some(v)
+				.or_some(event)
 		})
 		.chain(private_receipt)
 		.collect()
 		.boxed()
 		.await;
 
-	receipts
-		.is_empty()
-		.is_false()
-		.then(|| (room_id.to_owned(), pack_receipts(receipts.into_iter())))
+	(!receipts.is_empty()).then(|| (room_id.to_owned(), pack_receipts(receipts.into_iter())))
 }

--- a/src/api/client/sync/v5/extensions/typing.rs
+++ b/src/api/client/sync/v5/extensions/typing.rs
@@ -8,7 +8,7 @@ use ruma::{
 };
 use tuwunel_core::{
 	Result, debug_error,
-	utils::{IterStream, ReadyExt},
+	utils::{IterStream, stream::BroadbandExt},
 };
 
 use super::{Connection, SyncInfo, Window, selector};
@@ -37,24 +37,24 @@ pub(super) async fn collect(
 		.as_deref()
 		.map(<[_]>::iter);
 
-	selector(sync_info, conn, window, implicit, explicit)
+	selector(conn, window, implicit, explicit)
 		.stream()
-		.filter_map(async |room_id| {
-			services
+		.broad_filter_map(async |room_id| {
+			let users = services
 				.typing
 				.typing_users_for_user(room_id, sender_user)
 				.inspect_err(|e| debug_error!(%room_id, "Failed to get typing events: {e}"))
 				.await
 				.ok()
-				.filter(|users| !users.is_empty())
-				.map(|users| (room_id, users))
-		})
-		.ready_filter_map(|(room_id, users)| {
+				.filter(|users| !users.is_empty())?;
+
 			let content = TypingEventContent::new(users);
 			let event = SyncTypingEvent { content };
 			let event = Raw::new(&event);
 
-			Some((room_id.to_owned(), event.ok()?))
+			event
+				.ok()
+				.map(|event| (room_id.to_owned(), event))
 		})
 		.collect::<BTreeMap<_, _>>()
 		.map(|rooms| Typing { rooms })

--- a/src/api/client/sync/v5/extensions/typing.rs
+++ b/src/api/client/sync/v5/extensions/typing.rs
@@ -2,25 +2,63 @@ use std::collections::BTreeMap;
 
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use ruma::{
-	api::client::sync::sync_events::v5::response,
+	OwnedRoomId,
+	api::client::sync::sync_events::v5::response::{self, Typing},
 	events::typing::{SyncTypingEvent, TypingEventContent},
 	serde::Raw,
 };
 use tuwunel_core::{
 	Result, debug_error,
+	smallvec::SmallVec,
 	utils::{IterStream, stream::BroadbandExt},
 };
 
 use super::{Connection, SyncInfo, Window, selector};
+
+type CollectedRooms = SmallVec<[(OwnedRoomId, CollectedRoom); 1]>;
+
+#[derive(Debug, Default)]
+pub(super) struct Collected {
+	rooms: CollectedRooms,
+}
+
+#[derive(Debug)]
+pub(super) struct CollectedRoom {
+	event: Raw<SyncTypingEvent>,
+	initial_only: bool,
+}
+
+impl Collected {
+	pub(super) fn into_response(
+		self,
+		payloads: &BTreeMap<OwnedRoomId, response::Room>,
+	) -> Typing {
+		let rooms = self
+			.rooms
+			.into_iter()
+			.filter_map(|(room_id, room)| {
+				if room.initial_only
+					&& payloads
+						.get(&room_id)
+						.is_none_or(|payload| payload.initial != Some(true))
+				{
+					return None;
+				}
+
+				Some((room_id, room.event))
+			})
+			.collect();
+
+		Typing { rooms }
+	}
+}
 
 #[tracing::instrument(name = "typing", level = "trace", skip_all, ret)]
 pub(super) async fn collect(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window: &Window,
-) -> Result<response::Typing> {
-	use response::Typing;
-
+) -> Result<Collected> {
 	let SyncInfo { services, sender_user, .. } = sync_info;
 
 	let implicit = conn
@@ -40,13 +78,26 @@ pub(super) async fn collect(
 	selector(conn, window, implicit, explicit)
 		.stream()
 		.broad_filter_map(async |room_id| {
-			let users = services
+			let roomsince = conn
+				.rooms
+				.get(room_id)
+				.map(|room| room.roomsince)
+				.unwrap_or_default();
+
+			let eligible = move |update_token, has_users| {
+				eligibility(update_token, conn.globalsince, conn.next_batch, roomsince, has_users)
+			};
+
+			let (update_token, users) = services
 				.typing
-				.typing_users_for_user(room_id, sender_user)
+				.typing_snapshot_for_user(room_id, sender_user, |update_token| {
+					eligible(update_token, true).is_some()
+				})
 				.inspect_err(|e| debug_error!(%room_id, "Failed to get typing events: {e}"))
 				.await
-				.ok()
-				.filter(|users| !users.is_empty())?;
+				.ok()??;
+
+			let initial_only = eligible(update_token, !users.is_empty())?;
 
 			let content = TypingEventContent::new(users);
 			let event = SyncTypingEvent { content };
@@ -54,10 +105,114 @@ pub(super) async fn collect(
 
 			event
 				.ok()
-				.map(|event| (room_id.to_owned(), event))
+				.map(|event| (room_id.to_owned(), CollectedRoom { event, initial_only }))
 		})
-		.collect::<BTreeMap<_, _>>()
-		.map(|rooms| Typing { rooms })
+		.collect::<CollectedRooms>()
+		.map(|rooms| Collected { rooms })
 		.map(Ok)
 		.await
+}
+
+/// Whether a typing update publishes, and if so whether only alongside an
+/// initial room payload.
+///
+/// `None` skips the room; `Some(false)` is a live update, empty clears
+/// included; `Some(true)` is an initial candidate gated later on an actual
+/// initial payload.
+fn eligibility(
+	update_token: u64,
+	globalsince: u64,
+	next_batch: u64,
+	roomsince: u64,
+	has_users: bool,
+) -> Option<bool> {
+	if update_token > next_batch {
+		return None;
+	}
+
+	if globalsince < update_token {
+		return Some(false);
+	}
+
+	(roomsince == 0 && has_users).then_some(true)
+}
+
+#[cfg(test)]
+mod tests {
+	use ruma::{
+		OwnedUserId, RoomId, api::client::sync::sync_events::v5::response::Room as ResponseRoom,
+		room_id, user_id,
+	};
+
+	use super::*;
+
+	#[test]
+	fn typing_update_gate_is_live_once_and_replays() {
+		let live = eligibility(5, 4, 6, 6, true);
+		let advanced = eligibility(5, 5, 7, 6, true);
+		let replayed = eligibility(5, 4, 6, 6, true);
+
+		assert_eq!(live, Some(false));
+		assert_eq!(advanced, None);
+		assert_eq!(replayed, Some(false));
+	}
+
+	#[test]
+	fn future_and_unchanged_typing_updates_are_omitted() {
+		assert_eq!(eligibility(7, 0, 6, 0, true), None);
+		assert_eq!(eligibility(4, 5, 6, 3, true), None);
+		assert_eq!(eligibility(0, 0, 6, 0, false), None);
+	}
+
+	#[test]
+	fn empty_live_typing_is_preserved() {
+		let room_id = room_id!("!typing-clear:example.com");
+		let initial_only =
+			eligibility(5, 4, 6, 6, false).expect("live empty typing should be eligible");
+
+		let typing = collected(room_id, Vec::new(), initial_only).into_response(&BTreeMap::new());
+		let event = typing.rooms[room_id]
+			.deserialize()
+			.expect("typing event should deserialize");
+
+		assert!(event.content.user_ids.is_empty());
+	}
+
+	#[test]
+	fn initial_typing_requires_an_actual_initial_payload() {
+		let room_id = room_id!("!typing-initial:example.com");
+		let users = vec![user_id!("@typing:example.com").to_owned()];
+		let initial_only =
+			eligibility(0, 0, 6, 0, true).expect("nonempty initial typing should be eligible");
+
+		let missing =
+			collected(room_id, users.clone(), initial_only).into_response(&BTreeMap::new());
+
+		assert!(missing.rooms.is_empty());
+
+		let payloads = [(room_id.to_owned(), ResponseRoom::default())].into();
+		let noninitial = collected(room_id, users.clone(), initial_only).into_response(&payloads);
+		assert!(noninitial.rooms.is_empty());
+
+		let payload = ResponseRoom {
+			initial: Some(true),
+			..Default::default()
+		};
+		let payloads = [(room_id.to_owned(), payload)].into();
+		let initial = collected(room_id, users.clone(), initial_only).into_response(&payloads);
+
+		assert!(initial.rooms.contains_key(room_id));
+
+		let live = collected(room_id, users, false).into_response(&BTreeMap::new());
+		assert!(live.rooms.contains_key(room_id));
+	}
+
+	fn collected(room_id: &RoomId, users: Vec<OwnedUserId>, initial_only: bool) -> Collected {
+		let content = TypingEventContent::new(users);
+		let event = SyncTypingEvent { content };
+		let event = Raw::new(&event).expect("typing event should serialize");
+		let rooms = [(room_id.to_owned(), CollectedRoom { event, initial_only })].into();
+
+		Collected { rooms }
+	}
 }

--- a/src/api/client/sync/v5/range.rs
+++ b/src/api/client/sync/v5/range.rs
@@ -1,0 +1,431 @@
+use std::{collections::BTreeMap, mem::take};
+
+use futures::{StreamExt, TryFutureExt, TryStreamExt, future::try_join4};
+use ruma::{
+	OwnedRoomId, OwnedUserId, RoomId,
+	api::client::sync::sync_events::v5::response,
+	events::{
+		AnyRawAccountDataEvent, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent,
+		GlobalAccountDataEventType, ignored_user_list::IgnoredUserListEvent,
+		receipt::SyncReceiptEvent,
+	},
+	serde::Raw,
+};
+use tokio::sync::OnceCell;
+use tuwunel_core::{
+	Error, Result, at, err, error, extract_variant, implement,
+	utils::{IterStream, TryReadyExt, stream::BroadbandExt},
+};
+use tuwunel_service::{
+	rooms::read_receipt::{PrivateReadEvents, pack_receipts_fallible},
+	sync::Connection,
+};
+
+use super::{
+	SyncInfo, Window, WindowRoom,
+	rooms::{
+		Failure as RoomFailure,
+		Failure::{Payload as PayloadFailure, Timeline as TimelineFailure},
+		handle_room,
+	},
+};
+use crate::client::is_empty_account_data_event;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Domain {
+	Timeline,
+	Payload,
+	PublicReceipt,
+	PrivateRead,
+	RoomAccountData,
+	ReceiptSerialization,
+}
+
+#[derive(Debug)]
+struct Failure {
+	domain: Domain,
+	error: Error,
+}
+
+impl Failure {
+	fn new(domain: Domain, error: Error) -> Self { Self { domain, error } }
+}
+
+impl From<RoomFailure> for Failure {
+	fn from(failure: RoomFailure) -> Self {
+		match failure {
+			| TimelineFailure(error) => Self::new(Domain::Timeline, error),
+			| PayloadFailure(error) => Self::new(Domain::Payload, error),
+		}
+	}
+}
+
+#[derive(Debug)]
+struct CompleteRange {
+	payload: Option<response::Room>,
+	receipts: Option<Raw<SyncReceiptEvent>>,
+	account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+}
+
+#[derive(Default)]
+pub(super) struct Results {
+	ranges: BTreeMap<OwnedRoomId, CompleteRange>,
+}
+
+#[implement(Results)]
+#[inline]
+pub(super) fn contains(&self, room_id: &RoomId) -> bool { self.ranges.contains_key(room_id) }
+
+#[implement(Results)]
+pub(super) fn retain_complete<T>(
+	&self,
+	rooms: &mut BTreeMap<OwnedRoomId, T>,
+	attempted: impl Fn(&RoomId) -> bool,
+) {
+	rooms.retain(|room_id, _| !attempted(room_id) || self.contains(room_id));
+}
+
+#[implement(Results)]
+pub(super) fn keys(&self) -> impl Iterator<Item = &RoomId> {
+	self.ranges.keys().map(AsRef::as_ref)
+}
+
+#[implement(Results)]
+pub(super) fn into_payloads(self) -> BTreeMap<OwnedRoomId, response::Room> {
+	self.ranges
+		.into_iter()
+		.filter_map(|(room_id, range)| range.payload.map(|payload| (room_id, payload)))
+		.collect()
+}
+
+#[implement(Results)]
+pub(super) fn take_receipts(&mut self, room_id: &RoomId) -> Option<Raw<SyncReceiptEvent>> {
+	self.ranges
+		.get_mut(room_id)
+		.and_then(|range| range.receipts.take())
+}
+
+#[implement(Results)]
+pub(super) fn take_account_data(
+	&mut self,
+	room_id: &RoomId,
+) -> Option<Vec<Raw<AnyRoomAccountDataEvent>>> {
+	self.ranges
+		.get_mut(room_id)
+		.map(|range| take(&mut range.account_data))
+		.filter(|events| !events.is_empty())
+}
+
+#[tracing::instrument(
+	name = "ranges",
+	level = "debug",
+	skip_all,
+	fields(
+		next_batch = conn.next_batch,
+		window = window.len(),
+	),
+)]
+pub(super) async fn collect(
+	sync_info: SyncInfo<'_>,
+	conn: &Connection,
+	window: &Window,
+) -> Results {
+	let ignored = OnceCell::new();
+	let ranges = window
+		.iter()
+		.stream()
+		.broad_filter_map(async |(room_id, window_room)| {
+			let roomsince = conn
+				.rooms
+				.get(room_id)
+				.map(|room| room.roomsince)
+				.unwrap_or_default();
+
+			match collect_room(sync_info, conn, window_room, roomsince, &ignored).await {
+				| Ok(range) => Some((room_id.clone(), range)),
+				| Err(Failure { domain, error }) => {
+					error!(
+						%room_id,
+						?domain,
+						roomsince,
+						next_batch = conn.next_batch,
+						%error,
+						"sliding sync range failed"
+					);
+					None
+				},
+			}
+		})
+		.collect()
+		.await;
+
+	Results { ranges }
+}
+
+async fn collect_room(
+	sync_info: SyncInfo<'_>,
+	conn: &Connection,
+	window_room: &WindowRoom,
+	roomsince: u64,
+	ignored: &OnceCell<Option<IgnoredUserListEvent>>,
+) -> Result<CompleteRange, Failure> {
+	let room_id = &window_room.room_id;
+
+	let payload = handle_room(sync_info, conn, window_room, roomsince).map_err(Failure::from);
+	let public_receipts = public_receipts(sync_info, conn, room_id, roomsince, ignored)
+		.map_err(|error| Failure::new(Domain::PublicReceipt, error));
+	let private_receipts = private_receipts(sync_info, conn, room_id, roomsince)
+		.map_err(|error| Failure::new(Domain::PrivateRead, error));
+	let account_data = room_account_data(sync_info, conn, room_id, roomsince)
+		.map_err(|error| Failure::new(Domain::RoomAccountData, error));
+
+	let (payload, public_receipts, private_receipts, account_data) =
+		try_join4(payload, public_receipts, private_receipts, account_data).await?;
+
+	assemble(Ok(payload), Ok(public_receipts), Ok(private_receipts), Ok(account_data))
+}
+async fn public_receipts(
+	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
+	conn: &Connection,
+	room_id: &RoomId,
+	roomsince: u64,
+	ignored: &OnceCell<Option<IgnoredUserListEvent>>,
+) -> Result<impl Iterator<Item = Raw<AnySyncEphemeralRoomEvent>>> {
+	let mut receipts: Vec<(OwnedUserId, Raw<AnySyncEphemeralRoomEvent>)> = services
+		.read_receipt
+		.readreceipts_since_fallible(room_id, roomsince, Some(conn.next_batch))
+		.map_ok(|(user_id, _ts, event)| (user_id.to_owned(), event))
+		.try_collect()
+		.await?;
+
+	if !receipts.is_empty() {
+		let ignored = ignored
+			.get_or_try_init(async || {
+				services
+					.account_data
+					.get_global(sender_user, GlobalAccountDataEventType::IgnoredUserList)
+					.await
+					.map(Some)
+					.or_else(|error| error.is_not_found().then_some(None).ok_or(error))
+			})
+			.await?;
+
+		if let Some(ignored) = ignored {
+			receipts.retain(|(user_id, _)| {
+				!ignored
+					.content
+					.ignored_users
+					.contains_key(user_id)
+			});
+		}
+	}
+
+	Ok(receipts.into_iter().map(at!(1)))
+}
+
+async fn private_receipts(
+	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
+	conn: &Connection,
+	room_id: &RoomId,
+	roomsince: u64,
+) -> Result<PrivateReadEvents> {
+	let update = services
+		.read_receipt
+		.last_privateread_update_fallible(sender_user, room_id)
+		.await?;
+
+	if update <= roomsince {
+		return Ok(PrivateReadEvents::new());
+	}
+
+	if update > conn.next_batch {
+		return Err(err!(Database("Private read advanced beyond the bounded sync range.")));
+	}
+
+	let receipts = services
+		.read_receipt
+		.private_read_get_fallible(room_id, sender_user, update)
+		.await?;
+
+	let confirmed = services
+		.read_receipt
+		.last_privateread_update_fallible(sender_user, room_id)
+		.await?;
+
+	if confirmed != update {
+		return Err(err!(Database(
+			"Private read changed while assembling a bounded sync range."
+		)));
+	}
+
+	Ok(receipts)
+}
+
+async fn room_account_data(
+	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
+	conn: &Connection,
+	room_id: &RoomId,
+	roomsince: u64,
+) -> Result<Vec<Raw<AnyRoomAccountDataEvent>>> {
+	services
+		.account_data
+		.changes_since_fallible(Some(room_id), sender_user, roomsince, Some(conn.next_batch))
+		.ready_try_filter_map(|event| Ok(extract_variant!(event, AnyRawAccountDataEvent::Room)))
+		.ready_try_filter(move |event| roomsince != 0 || !is_empty_account_data_event(event))
+		.try_collect()
+		.await
+}
+
+fn assemble<PublicReceipts>(
+	payload: Result<response::Room, Failure>,
+	public_receipts: Result<PublicReceipts, Failure>,
+	private_receipts: Result<PrivateReadEvents, Failure>,
+	account_data: Result<Vec<Raw<AnyRoomAccountDataEvent>>, Failure>,
+) -> Result<CompleteRange, Failure>
+where
+	PublicReceipts: Iterator<Item = Raw<AnySyncEphemeralRoomEvent>>,
+{
+	let payload = payload?;
+	let public_receipts = public_receipts?;
+	let private_receipts = private_receipts?;
+	let account_data = account_data?;
+
+	let mut receipts = public_receipts.chain(private_receipts).peekable();
+
+	let receipts = receipts
+		.peek()
+		.is_some()
+		.then(|| pack_receipts_fallible(receipts))
+		.transpose()
+		.map_err(|error| Failure::new(Domain::ReceiptSerialization, error))?;
+
+	Ok(CompleteRange {
+		payload: Some(payload),
+		receipts,
+		account_data,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::vec::IntoIter;
+
+	use ruma::{api::client::sync::sync_events::v5::response::Room as ResponseRoom, room_id};
+	use serde_json::{json, value::to_raw_value};
+
+	use super::*;
+
+	#[test]
+	fn failures_withhold_all_range_output_until_retry_succeeds() {
+		let room_id = room_id!("!range:example.com");
+
+		for domain in [
+			Domain::Timeline,
+			Domain::Payload,
+			Domain::PublicReceipt,
+			Domain::PrivateRead,
+			Domain::RoomAccountData,
+		] {
+			let mut failed = publish(room_id, assemble_with_failure(domain));
+			let mut typing = [(room_id.to_owned(), ())].into();
+			failed.retain_complete(&mut typing, |_| true);
+
+			assert!(!failed.contains(room_id));
+			assert!(typing.is_empty());
+			assert!(failed.take_receipts(room_id).is_none());
+			assert!(failed.take_account_data(room_id).is_none());
+			assert!(failed.into_payloads().is_empty());
+
+			let retried = publish(room_id, successful_range());
+			let mut typing = [(room_id.to_owned(), ())].into();
+			retried.retain_complete(&mut typing, |_| true);
+
+			assert!(retried.contains(room_id));
+			assert_eq!(typing.len(), 1);
+			assert_eq!(retried.into_payloads().len(), 1);
+		}
+	}
+
+	#[test]
+	fn unattempted_extension_rooms_are_preserved() {
+		let attempted = room_id!("!attempted:example.com");
+		let unattempted = room_id!("!unattempted:example.com");
+		let failed = publish(attempted, assemble_with_failure(Domain::Timeline));
+		let mut typing = [(attempted.to_owned(), ()), (unattempted.to_owned(), ())].into();
+
+		failed.retain_complete(&mut typing, |room_id| room_id == attempted);
+
+		assert!(!typing.contains_key(attempted));
+		assert!(typing.contains_key(unattempted));
+	}
+
+	#[test]
+	fn malformed_receipt_withholds_the_complete_range() {
+		let room_id = room_id!("!receipt:example.com");
+		let malformed = Raw::from_json(
+			to_raw_value(&json!({"content": 5})).expect("test JSON should serialize"),
+		);
+
+		let range = assemble(
+			Ok(ResponseRoom::default()),
+			Ok(vec![malformed].into_iter()),
+			Ok(PrivateReadEvents::new()),
+			Ok(Vec::new()),
+		);
+		let error = range.expect_err("malformed receipt must fail the complete range");
+
+		assert_eq!(error.domain, Domain::ReceiptSerialization);
+		assert!(!publish(room_id, Err(error)).contains(room_id));
+	}
+
+	fn publish(room_id: &RoomId, range: Result<CompleteRange, Failure>) -> Results {
+		let ranges = range
+			.ok()
+			.map(|range| (room_id.to_owned(), range))
+			.into_iter()
+			.collect();
+
+		Results { ranges }
+	}
+
+	fn assemble_with_failure(domain: Domain) -> Result<CompleteRange, Failure> {
+		let failure = || Failure::new(domain, Error::Err("injected failure".into()));
+
+		match domain {
+			| Domain::Timeline | Domain::Payload => assemble(
+				Err(failure()),
+				Ok(Vec::new().into_iter()),
+				Ok(PrivateReadEvents::new()),
+				Ok(Vec::new()),
+			),
+			| Domain::PublicReceipt => assemble(
+				Ok(ResponseRoom::default()),
+				Err::<IntoIter<Raw<AnySyncEphemeralRoomEvent>>, _>(failure()),
+				Ok(PrivateReadEvents::new()),
+				Ok(Vec::new()),
+			),
+			| Domain::PrivateRead => assemble(
+				Ok(ResponseRoom::default()),
+				Ok(Vec::new().into_iter()),
+				Err(failure()),
+				Ok(Vec::new()),
+			),
+			| Domain::RoomAccountData => assemble(
+				Ok(ResponseRoom::default()),
+				Ok(Vec::new().into_iter()),
+				Ok(PrivateReadEvents::new()),
+				Err(failure()),
+			),
+			| Domain::ReceiptSerialization => unreachable!("injected through malformed input"),
+		}
+	}
+
+	fn successful_range() -> Result<CompleteRange, Failure> {
+		assemble(
+			Ok(ResponseRoom::default()),
+			Ok(Vec::new().into_iter()),
+			Ok(PrivateReadEvents::new()),
+			Ok(Vec::new()),
+		)
+	}
+}

--- a/src/api/client/sync/v5/range.rs
+++ b/src/api/client/sync/v5/range.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, mem::take};
 
-use futures::{StreamExt, TryFutureExt, TryStreamExt, future::try_join4};
+use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, future::try_join4};
 use ruma::{
 	OwnedRoomId, OwnedUserId, RoomId,
 	api::client::sync::sync_events::v5::response,
@@ -14,7 +14,7 @@ use ruma::{
 use tokio::sync::OnceCell;
 use tuwunel_core::{
 	Error, Result, at, err, error, extract_variant, implement,
-	utils::{IterStream, TryReadyExt, stream::BroadbandExt},
+	utils::{BoolExt, IterStream, TryReadyExt, stream::BroadbandExt},
 };
 use tuwunel_service::{
 	rooms::read_receipt::{PrivateReadEvents, pack_receipts_fallible},
@@ -70,19 +70,6 @@ struct CompleteRange {
 #[derive(Default)]
 pub(super) struct Results {
 	ranges: BTreeMap<OwnedRoomId, CompleteRange>,
-}
-
-#[implement(Results)]
-#[inline]
-pub(super) fn contains(&self, room_id: &RoomId) -> bool { self.ranges.contains_key(room_id) }
-
-#[implement(Results)]
-pub(super) fn retain_complete<T>(
-	&self,
-	rooms: &mut BTreeMap<OwnedRoomId, T>,
-	attempted: impl Fn(&RoomId) -> bool,
-) {
-	rooms.retain(|room_id, _| !attempted(room_id) || self.contains(room_id));
 }
 
 #[implement(Results)]
@@ -171,19 +158,27 @@ async fn collect_room(
 ) -> Result<CompleteRange, Failure> {
 	let room_id = &window_room.room_id;
 
-	let payload = handle_room(sync_info, conn, window_room, roomsince).map_err(Failure::from);
+	let payload = window_room
+		.payload_is_fresh(roomsince)
+		.then_async(|| handle_room(sync_info, conn, window_room, roomsince))
+		.map(Option::transpose)
+		.map_err(Failure::from);
+
 	let public_receipts = public_receipts(sync_info, conn, room_id, roomsince, ignored)
 		.map_err(|error| Failure::new(Domain::PublicReceipt, error));
+
 	let private_receipts = private_receipts(sync_info, conn, room_id, roomsince)
 		.map_err(|error| Failure::new(Domain::PrivateRead, error));
+
 	let account_data = room_account_data(sync_info, conn, room_id, roomsince)
 		.map_err(|error| Failure::new(Domain::RoomAccountData, error));
 
 	let (payload, public_receipts, private_receipts, account_data) =
 		try_join4(payload, public_receipts, private_receipts, account_data).await?;
 
-	assemble(Ok(payload), Ok(public_receipts), Ok(private_receipts), Ok(account_data))
+	assemble(payload, public_receipts, private_receipts, account_data)
 }
+
 async fn public_receipts(
 	SyncInfo { services, sender_user, .. }: SyncInfo<'_>,
 	conn: &Connection,
@@ -234,31 +229,16 @@ async fn private_receipts(
 		.last_privateread_update_fallible(sender_user, room_id)
 		.await?;
 
-	if update <= roomsince {
-		return Ok(PrivateReadEvents::new());
+	match update {
+		| _ if update <= roomsince => Ok(PrivateReadEvents::new()),
+		| _ if update > conn.next_batch =>
+			Err(err!(Database("Private read advanced beyond the bounded sync range."))),
+		| _ =>
+			services
+				.read_receipt
+				.private_read_get_fallible(room_id, sender_user, update)
+				.await,
 	}
-
-	if update > conn.next_batch {
-		return Err(err!(Database("Private read advanced beyond the bounded sync range.")));
-	}
-
-	let receipts = services
-		.read_receipt
-		.private_read_get_fallible(room_id, sender_user, update)
-		.await?;
-
-	let confirmed = services
-		.read_receipt
-		.last_privateread_update_fallible(sender_user, room_id)
-		.await?;
-
-	if confirmed != update {
-		return Err(err!(Database(
-			"Private read changed while assembling a bounded sync range."
-		)));
-	}
-
-	Ok(receipts)
 }
 
 async fn room_account_data(
@@ -277,21 +257,15 @@ async fn room_account_data(
 }
 
 fn assemble<PublicReceipts>(
-	payload: Result<response::Room, Failure>,
-	public_receipts: Result<PublicReceipts, Failure>,
-	private_receipts: Result<PrivateReadEvents, Failure>,
-	account_data: Result<Vec<Raw<AnyRoomAccountDataEvent>>, Failure>,
+	payload: Option<response::Room>,
+	public_receipts: PublicReceipts,
+	private_receipts: PrivateReadEvents,
+	account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
 ) -> Result<CompleteRange, Failure>
 where
 	PublicReceipts: Iterator<Item = Raw<AnySyncEphemeralRoomEvent>>,
 {
-	let payload = payload?;
-	let public_receipts = public_receipts?;
-	let private_receipts = private_receipts?;
-	let account_data = account_data?;
-
 	let mut receipts = public_receipts.chain(private_receipts).peekable();
-
 	let receipts = receipts
 		.peek()
 		.is_some()
@@ -299,65 +273,15 @@ where
 		.transpose()
 		.map_err(|error| Failure::new(Domain::ReceiptSerialization, error))?;
 
-	Ok(CompleteRange {
-		payload: Some(payload),
-		receipts,
-		account_data,
-	})
+	Ok(CompleteRange { payload, receipts, account_data })
 }
 
 #[cfg(test)]
 mod tests {
-	use std::vec::IntoIter;
-
 	use ruma::{api::client::sync::sync_events::v5::response::Room as ResponseRoom, room_id};
 	use serde_json::{json, value::to_raw_value};
 
 	use super::*;
-
-	#[test]
-	fn failures_withhold_all_range_output_until_retry_succeeds() {
-		let room_id = room_id!("!range:example.com");
-
-		for domain in [
-			Domain::Timeline,
-			Domain::Payload,
-			Domain::PublicReceipt,
-			Domain::PrivateRead,
-			Domain::RoomAccountData,
-		] {
-			let mut failed = publish(room_id, assemble_with_failure(domain));
-			let mut typing = [(room_id.to_owned(), ())].into();
-			failed.retain_complete(&mut typing, |_| true);
-
-			assert!(!failed.contains(room_id));
-			assert!(typing.is_empty());
-			assert!(failed.take_receipts(room_id).is_none());
-			assert!(failed.take_account_data(room_id).is_none());
-			assert!(failed.into_payloads().is_empty());
-
-			let retried = publish(room_id, successful_range());
-			let mut typing = [(room_id.to_owned(), ())].into();
-			retried.retain_complete(&mut typing, |_| true);
-
-			assert!(retried.contains(room_id));
-			assert_eq!(typing.len(), 1);
-			assert_eq!(retried.into_payloads().len(), 1);
-		}
-	}
-
-	#[test]
-	fn unattempted_extension_rooms_are_preserved() {
-		let attempted = room_id!("!attempted:example.com");
-		let unattempted = room_id!("!unattempted:example.com");
-		let failed = publish(attempted, assemble_with_failure(Domain::Timeline));
-		let mut typing = [(attempted.to_owned(), ()), (unattempted.to_owned(), ())].into();
-
-		failed.retain_complete(&mut typing, |room_id| room_id == attempted);
-
-		assert!(!typing.contains_key(attempted));
-		assert!(typing.contains_key(unattempted));
-	}
 
 	#[test]
 	fn malformed_receipt_withholds_the_complete_range() {
@@ -367,15 +291,64 @@ mod tests {
 		);
 
 		let range = assemble(
-			Ok(ResponseRoom::default()),
-			Ok(vec![malformed].into_iter()),
-			Ok(PrivateReadEvents::new()),
-			Ok(Vec::new()),
+			Some(ResponseRoom::default()),
+			vec![malformed].into_iter(),
+			PrivateReadEvents::new(),
+			Vec::new(),
 		);
+
 		let error = range.expect_err("malformed receipt must fail the complete range");
 
 		assert_eq!(error.domain, Domain::ReceiptSerialization);
-		assert!(!publish(room_id, Err(error)).contains(room_id));
+		assert!(
+			!publish(room_id, Err(error))
+				.ranges
+				.contains_key(room_id)
+		);
+	}
+
+	#[test]
+	fn extension_only_range_commits_without_a_room_payload() {
+		let room_id = room_id!("!extension-only:example.com");
+		let range = assemble(None, Vec::new().into_iter(), PrivateReadEvents::new(), Vec::new());
+
+		let range = publish(room_id, range);
+
+		assert_eq!(range.keys().collect::<Vec<_>>(), [room_id]);
+		assert!(range.into_payloads().is_empty());
+	}
+
+	#[test]
+	fn extension_outputs_are_taken_once_without_removing_the_complete_range() {
+		let room_id = room_id!("!extension-output:example.com");
+		let receipt = Raw::from_json(
+			to_raw_value(&json!({"content": {}})).expect("test receipt should serialize"),
+		);
+
+		let account_data = Raw::from_json(
+			to_raw_value(&json!({"type": "m.tag", "content": {"tags": {}}}))
+				.expect("test account data should serialize"),
+		);
+
+		let range = CompleteRange {
+			payload: None,
+			receipts: Some(receipt),
+			account_data: vec![account_data],
+		};
+
+		let ranges = [(room_id.to_owned(), range)].into();
+		let mut results = Results { ranges };
+
+		assert!(results.take_receipts(room_id).is_some());
+		assert!(results.take_receipts(room_id).is_none());
+
+		let count = results
+			.take_account_data(room_id)
+			.map(|events| events.len());
+
+		assert_eq!(Some(1), count);
+		assert!(results.take_account_data(room_id).is_none());
+		assert!(results.ranges.contains_key(room_id));
 	}
 
 	fn publish(room_id: &RoomId, range: Result<CompleteRange, Failure>) -> Results {
@@ -386,46 +359,5 @@ mod tests {
 			.collect();
 
 		Results { ranges }
-	}
-
-	fn assemble_with_failure(domain: Domain) -> Result<CompleteRange, Failure> {
-		let failure = || Failure::new(domain, Error::Err("injected failure".into()));
-
-		match domain {
-			| Domain::Timeline | Domain::Payload => assemble(
-				Err(failure()),
-				Ok(Vec::new().into_iter()),
-				Ok(PrivateReadEvents::new()),
-				Ok(Vec::new()),
-			),
-			| Domain::PublicReceipt => assemble(
-				Ok(ResponseRoom::default()),
-				Err::<IntoIter<Raw<AnySyncEphemeralRoomEvent>>, _>(failure()),
-				Ok(PrivateReadEvents::new()),
-				Ok(Vec::new()),
-			),
-			| Domain::PrivateRead => assemble(
-				Ok(ResponseRoom::default()),
-				Ok(Vec::new().into_iter()),
-				Err(failure()),
-				Ok(Vec::new()),
-			),
-			| Domain::RoomAccountData => assemble(
-				Ok(ResponseRoom::default()),
-				Ok(Vec::new().into_iter()),
-				Ok(PrivateReadEvents::new()),
-				Err(failure()),
-			),
-			| Domain::ReceiptSerialization => unreachable!("injected through malformed input"),
-		}
-	}
-
-	fn successful_range() -> Result<CompleteRange, Failure> {
-		assemble(
-			Ok(ResponseRoom::default()),
-			Ok(Vec::new().into_iter()),
-			Ok(PrivateReadEvents::new()),
-			Ok(Vec::new()),
-		)
 	}
 }

--- a/src/api/client/sync/v5/rooms.rs
+++ b/src/api/client/sync/v5/rooms.rs
@@ -8,7 +8,7 @@ use futures::{
 	future::{join, join3, join4},
 };
 use ruma::{
-	JsOption, MxcUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, RoomId, UInt, UserId,
+	JsOption, MxcUri, OwnedEventId, OwnedMxcUri, RoomId, UInt, UserId,
 	api::client::sync::sync_events::{
 		UnreadNotificationsCount,
 		v5::{DisplayName, response, response::Heroes},
@@ -19,7 +19,7 @@ use ruma::{
 	serde::Raw,
 };
 use tuwunel_core::{
-	Result, at, error, is_equal_to,
+	Error, Result, at, is_equal_to,
 	itertools::Itertools,
 	matrix::{
 		Event, StateKey,
@@ -37,41 +37,18 @@ use tuwunel_service::Services;
 
 use self::{bump_stamp::room_bump_stamp, heroes::calculate_heroes};
 use super::{
-	super::{load_timeline, strip_prev_state},
-	Connection, ListIds, SyncInfo, Window, WindowRoom,
+	super::{load_timeline_fallible, strip_prev_state},
+	Connection, ListIds, SyncInfo, WindowRoom,
 };
 use crate::client::{annotate_membership, ignored_filter, with_membership};
 
-type ThreadCounts = BTreeMap<OwnedEventId, (u64, u64)>;
-
-#[tracing::instrument(
-    name = "rooms",
-    level = "debug",
-    skip_all,
-    fields(
-        next_batch = conn.next_batch,
-        window = window.len(),
-    )
-)]
-pub(super) async fn handle(
-	sync_info: SyncInfo<'_>,
-	conn: &Connection,
-	window: &Window,
-) -> Result<BTreeMap<OwnedRoomId, response::Room>> {
-	window
-		.iter()
-		.stream()
-		.broad_filter_map(async |(room_id, room)| {
-			handle_room(sync_info, conn, room)
-				.map_ok(move |room| (room_id.clone(), room))
-				.inspect_err(|e| error!(?room_id, %e, "sync handler failed"))
-				.await
-				.ok()
-		})
-		.collect()
-		.map(Ok)
-		.await
+#[derive(Debug)]
+pub(super) enum Failure {
+	Timeline(Error),
+	Payload(Error),
 }
+
+type ThreadCounts = BTreeMap<OwnedEventId, (u64, u64)>;
 
 #[tracing::instrument(
 	name = "room",
@@ -79,11 +56,12 @@ pub(super) async fn handle(
 	skip_all,
 	fields(room_id, roomsince)
 )]
-async fn handle_room(
+pub(super) async fn handle_room(
 	sync_info: SyncInfo<'_>,
 	conn: &Connection,
 	window_room: &WindowRoom,
-) -> Result<response::Room> {
+	roomsince: u64,
+) -> Result<response::Room, Failure> {
 	let SyncInfo {
 		services,
 		sender_user,
@@ -94,33 +72,25 @@ async fn handle_room(
 		lists, membership, room_id, last_count, ..
 	} = window_room;
 
-	// Absent connection state is first contact, e.g. a new subscription.
-	let roomsince = conn
-		.rooms
-		.get(room_id)
-		.map(|room| room.roomsince)
-		.unwrap_or_default();
-
 	debug_assert!(
 		*last_count > roomsince || *last_count == 0 || roomsince == 0,
 		"Stale room shouldn't be in the window"
 	);
 
 	if matches!(*membership, Some(MembershipState::Leave | MembershipState::Ban)) {
-		return leave_or_ban_response(sync_info, conn, window_room, roomsince).await;
+		return leave_or_ban_response(sync_info, conn, window_room, roomsince)
+			.map_err(Failure::Payload)
+			.await;
 	}
 
 	let is_invite = *membership == Some(MembershipState::Invite);
 
-	let encrypted = services
-		.state_accessor
-		.is_encrypted_room(room_id)
-		.await;
+	let encrypted = services.state_accessor.is_encrypted_room(room_id);
 
 	let (timeline_limit, required_state) = merged_room_details(conn, lists, room_id);
 
 	let timeline = is_invite.is_false().then_async(|| {
-		load_timeline(
+		load_timeline_fallible(
 			services,
 			sender_user,
 			room_id,
@@ -130,11 +100,15 @@ async fn handle_room(
 		)
 	});
 
-	// A failed load must fail the room, else roomsince advances past unsent events.
-	let (timeline_pdus, limited, last_timeline_count) = timeline
+	let timeline = timeline
 		.map(Option::transpose)
-		.await?
-		.unwrap_or_else(|| (Vec::new(), true, PduCount::default()));
+		.map_err(Failure::Timeline);
+
+	let (encrypted, timeline) = join(encrypted, timeline).await;
+
+	// A failed load must fail the room, else roomsince advances past unsent events.
+	let (timeline_pdus, limited, last_timeline_count) =
+		timeline?.unwrap_or_else(|| (Vec::new(), true, PduCount::default()));
 
 	let required_state = required_state
 		.into_iter()
@@ -156,7 +130,8 @@ async fn handle_room(
 		PduCount::from(conn.next_batch),
 		last_timeline_count,
 	)
-	.await;
+	.map_err(Failure::Timeline)
+	.await?;
 
 	let required_state = collect_required_state(
 		services,

--- a/src/api/client/sync/v5/rooms.rs
+++ b/src/api/client/sync/v5/rooms.rs
@@ -84,7 +84,12 @@ async fn handle_room(
 	conn: &Connection,
 	window_room: &WindowRoom,
 ) -> Result<response::Room> {
-	let SyncInfo { services, sender_user, .. } = sync_info;
+	let SyncInfo {
+		services,
+		sender_user,
+		previous_connection_pos,
+		..
+	} = sync_info;
 	let WindowRoom {
 		lists, membership, room_id, last_count, ..
 	} = window_room;
@@ -150,18 +155,6 @@ async fn handle_room(
 	)
 	.await;
 
-	let num_live = roomsince
-		.ne(&0)
-		.and_is(limited || timeline_pdus.len() >= timeline_limit)
-		.then_async(|| {
-			services
-				.timeline
-				.pdus(None, room_id, Some(roomsince.into()))
-				.count()
-				.map(TryInto::try_into)
-				.map(Result::ok)
-		});
-
 	let required_state = collect_required_state(
 		services,
 		sender_user,
@@ -183,23 +176,25 @@ async fn handle_room(
 		.iter()
 		.stream()
 		.filter_map(|item| ignored_filter(services, item.clone(), sender_user))
-		.map(at!(1))
-		.wide_then(|pdu| with_membership(services, pdu, sender_user, encrypted))
-		.wide_then(|pdu| {
+		.wide_then(|(position, pdu)| {
+			with_membership(services, pdu, sender_user, encrypted).map(move |pdu| (position, pdu))
+		})
+		.wide_then(|(position, pdu)| {
 			services
 				.pdu_metadata
 				.bundle_aggregations(sender_user, pdu)
+				.map(move |pdu| (position, pdu))
 		})
-		.map(Event::into_format)
-		.collect();
+		.map(|(position, pdu)| (position, Event::into_format(pdu)))
+		.collect::<Vec<_>>();
 
 	let meta = room_meta_future(services, sender_user, room_id);
-	let events = join4(timeline, num_live, required_state, invite_state);
+	let events = join3(timeline, required_state, invite_state);
 	let member_counts = member_counts_future(services, room_id);
 	let notification_counts = notification_counts_future(services, sender_user, room_id);
 	let (
 		(room_name, room_avatar, is_dm),
-		(timeline, num_live, required_state, invite_state),
+		(timeline, required_state, invite_state),
 		(joined_count, invited_count),
 		(highlight_count, notification_count, _last_notification_read, thread_counts),
 	) = join4(meta, events, member_counts, notification_counts)
@@ -215,8 +210,14 @@ async fn handle_room(
 	)
 	.await;
 
+	let previous_connection_pos = previous_connection_pos.filter(|_| !is_invite);
+	let (initial, num_live) =
+		room_timeline_metadata(roomsince, previous_connection_pos, &timeline);
+
+	let timeline = timeline.into_iter().map(at!(1)).collect();
+
 	Ok(response::Room {
-		initial: roomsince.eq(&0).then_some(true),
+		initial,
 		lists: lists.clone(),
 		membership: membership.clone(),
 		name: room_name.or(heroes_name),
@@ -226,7 +227,7 @@ async fn handle_room(
 		required_state,
 		invite_state: invite_state.flatten(),
 		prev_batch: prev_batch.as_deref().map(Into::into),
-		num_live: num_live.flatten(),
+		num_live,
 		limited,
 		timeline,
 		bump_stamp,
@@ -277,6 +278,28 @@ fn merged_room_details(
 			required_state.extend(config.required_state.clone());
 			(timeline_limit.max(usize_from_ruma(config.timeline_limit)), required_state)
 		})
+}
+
+fn room_timeline_metadata<Event>(
+	roomsince: u64,
+	previous_connection_pos: Option<u64>,
+	timeline_pdus: &[(PduCount, Event)],
+) -> (Option<bool>, Option<UInt>) {
+	let initial = roomsince.eq(&0).then_some(true);
+	let num_live = previous_connection_pos
+		.map(PduCount::from)
+		.and_then(|previous_connection_pos| {
+			timeline_pdus
+				.iter()
+				.rev()
+				.map(|(position, _)| *position)
+				.take_while(|position| *position > previous_connection_pos)
+				.count()
+				.try_into()
+				.ok()
+		});
+
+	(initial, num_live)
 }
 
 async fn resolve_heroes(
@@ -487,4 +510,65 @@ async fn wildcard_state_keys(
 		.map(|state_key| (event_type.clone(), state_key))
 		.collect()
 		.await
+}
+
+#[cfg(test)]
+mod tests {
+	use ruma::{UInt, uint};
+	use tuwunel_core::matrix::pdu::PduCount;
+
+	use super::room_timeline_metadata;
+
+	fn timeline(positions: &[u64]) -> Vec<(PduCount, ())> {
+		positions
+			.iter()
+			.copied()
+			.map(|position| (PduCount::Normal(position), ()))
+			.collect()
+	}
+
+	#[test]
+	fn first_connection_timeline_is_initial_and_historical() {
+		let (initial, num_live) = room_timeline_metadata(0, None, &timeline(&[8, 9, 10]));
+
+		assert_eq!(initial, Some(true));
+		assert_eq!(num_live, None);
+	}
+
+	#[test]
+	fn incremental_new_room_has_one_live_event() {
+		let (initial, num_live) = room_timeline_metadata(0, Some(10), &timeline(&[8, 9, 11]));
+
+		assert_eq!(initial, Some(true));
+		assert_eq!(num_live, Some(uint!(1)));
+	}
+
+	#[test]
+	fn incremental_range_expansion_has_no_live_events() {
+		let (initial, num_live) = room_timeline_metadata(0, Some(10), &timeline(&[7, 8, 9]));
+
+		assert_eq!(initial, Some(true));
+		assert_eq!(num_live, Some(uint!(0)));
+	}
+
+	#[test]
+	fn incremental_timeline_counts_only_live_suffix() {
+		let (initial, num_live) = room_timeline_metadata(5, Some(10), &timeline(&[8, 9, 11, 12]));
+
+		assert_eq!(initial, None);
+		assert_eq!(num_live, Some(uint!(2)));
+	}
+
+	#[test]
+	fn limited_timeline_counts_only_returned_live_events() {
+		// Earlier live events at positions 11 through 13 were truncated.
+		let returned_timeline = timeline(&[14, 15]);
+		let (_, num_live) = room_timeline_metadata(5, Some(10), &returned_timeline);
+
+		assert_eq!(num_live, Some(uint!(2)));
+		let timeline_len =
+			UInt::try_from(returned_timeline.len()).expect("timeline length fits UInt");
+
+		assert!(num_live.expect("incremental response") <= timeline_len);
+	}
 }

--- a/src/api/client/sync/v5/rooms.rs
+++ b/src/api/client/sync/v5/rooms.rs
@@ -68,14 +68,9 @@ pub(super) async fn handle_room(
 		previous_connection_pos,
 		..
 	} = sync_info;
-	let WindowRoom {
-		lists, membership, room_id, last_count, ..
-	} = window_room;
+	let WindowRoom { lists, membership, room_id, .. } = window_room;
 
-	debug_assert!(
-		*last_count > roomsince || *last_count == 0 || roomsince == 0,
-		"Stale room shouldn't be in the window"
-	);
+	debug_assert!(window_room.payload_is_fresh(roomsince), "Room payload should be fresh");
 
 	if matches!(*membership, Some(MembershipState::Leave | MembershipState::Ban)) {
 		return leave_or_ban_response(sync_info, conn, window_room, roomsince)

--- a/src/api/client/sync/v5/rooms.rs
+++ b/src/api/client/sync/v5/rooms.rs
@@ -19,7 +19,7 @@ use ruma::{
 	serde::Raw,
 };
 use tuwunel_core::{
-	Result, at, err, error, is_equal_to,
+	Result, at, error, is_equal_to,
 	itertools::Itertools,
 	matrix::{
 		Event, StateKey,
@@ -33,7 +33,7 @@ use tuwunel_core::{
 		stream::{BroadbandExt, WidebandExt},
 	},
 };
-use tuwunel_service::{Services, sync::Room};
+use tuwunel_service::Services;
 
 use self::{bump_stamp::room_bump_stamp, heroes::calculate_heroes};
 use super::{
@@ -64,7 +64,7 @@ pub(super) async fn handle(
 		.broad_filter_map(async |(room_id, room)| {
 			handle_room(sync_info, conn, room)
 				.map_ok(move |room| (room_id.clone(), room))
-				.inspect_err(|e| error!(?room_id, "sync handler: {e:?}"))
+				.inspect_err(|e| error!(?room_id, %e, "sync handler failed"))
 				.await
 				.ok()
 		})
@@ -94,10 +94,12 @@ async fn handle_room(
 		lists, membership, room_id, last_count, ..
 	} = window_room;
 
-	let &Room { roomsince, .. } = conn
+	// Absent connection state is first contact, e.g. a new subscription.
+	let roomsince = conn
 		.rooms
 		.get(room_id)
-		.ok_or_else(|| err!("Missing connection state for {room_id}"))?;
+		.map(|room| room.roomsince)
+		.unwrap_or_default();
 
 	debug_assert!(
 		*last_count > roomsince || *last_count == 0 || roomsince == 0,
@@ -128,9 +130,10 @@ async fn handle_room(
 		)
 	});
 
+	// A failed load must fail the room, else roomsince advances past unsent events.
 	let (timeline_pdus, limited, last_timeline_count) = timeline
-		.await
-		.flat_ok()
+		.map(Option::transpose)
+		.await?
 		.unwrap_or_else(|| (Vec::new(), true, PduCount::default()));
 
 	let required_state = required_state
@@ -247,11 +250,14 @@ async fn leave_or_ban_response(
 	WindowRoom { lists, membership, room_id, .. }: &WindowRoom,
 	roomsince: u64,
 ) -> Result<response::Room> {
+	// A rejected federated invite has no resolved state; the retraction still
+	// delivers on the membership alone.
 	let member_event = services
 		.state_accessor
 		.room_state_get(room_id, &StateEventType::RoomMember, sender_user.as_str())
 		.map_ok(Event::into_format)
-		.await?;
+		.await
+		.ok();
 
 	Ok(response::Room {
 		initial: roomsince.eq(&0).then_some(true),
@@ -259,7 +265,7 @@ async fn leave_or_ban_response(
 		membership: membership.clone(),
 		prev_batch: Some(conn.next_batch.to_string().into()),
 		limited: true,
-		required_state: vec![member_event],
+		required_state: member_event.into_iter().collect(),
 		..Default::default()
 	})
 }

--- a/src/api/client/sync/v5/rooms/bump_stamp.rs
+++ b/src/api/client/sync/v5/rooms/bump_stamp.rs
@@ -1,4 +1,4 @@
-use futures::{StreamExt, pin_mut};
+use futures::{TryStreamExt, pin_mut};
 use ruma::{
 	RoomId, UInt, UserId,
 	events::TimelineEventType::{
@@ -6,12 +6,12 @@ use ruma::{
 	},
 };
 use tuwunel_core::{
-	is_equal_to,
+	Result, is_equal_to,
 	matrix::{
 		Event,
 		pdu::{PduCount, PduEvent},
 	},
-	utils::stream::ReadyExt,
+	utils::TryReadyExt,
 };
 use tuwunel_service::Services;
 
@@ -32,25 +32,23 @@ pub(super) async fn room_bump_stamp(
 	roomsince: PduCount,
 	next_batch: PduCount,
 	last_timeline_count: PduCount,
-) -> Option<UInt> {
+) -> Result<Option<UInt>> {
 	if last_timeline_count <= roomsince {
-		return None;
+		return Ok(None);
 	}
 
 	let bumpable_pdus = services
 		.timeline
-		.pdus_rev(Some(sender_user), room_id, None)
-		.ready_filter_map(Result::ok)
-		.ready_skip_while(|&(pdu_count, _)| pdu_count > next_batch)
-		.ready_take_while(|&(pdu_count, _)| pdu_count > roomsince)
-		.ready_filter_map(|(pdu_count, pdu)| {
-			is_bumpable_pdu(&pdu, sender_user)
+		.pdus_rev(Some(sender_user), room_id, Some(next_batch.saturating_add(1)))
+		.ready_try_take_while(|&(pdu_count, _)| Ok(pdu_count > roomsince))
+		.ready_try_filter_map(|(pdu_count, pdu)| {
+			Ok(is_bumpable_pdu(&pdu, sender_user)
 				.then(|| pdu_count.into_signed().try_into().ok())
-				.flatten()
+				.flatten())
 		});
 
 	pin_mut!(bumpable_pdus);
-	bumpable_pdus.next().await
+	bumpable_pdus.try_next().await
 }
 
 fn is_bumpable_pdu(pdu: &PduEvent, sender_user: &UserId) -> bool {

--- a/src/api/client/sync/v5/selector.rs
+++ b/src/api/client/sync/v5/selector.rs
@@ -128,13 +128,6 @@ async fn matcher(
 			.last_privateread_update(sender_user, &room_id)
 	});
 
-	let last_receipt = matched.then_async(|| {
-		services
-			.read_receipt
-			.last_receipt_count(&room_id, sender_user.into(), None)
-			.unwrap_or_default()
-	});
-
 	let last_account = matched.then_async(|| {
 		services
 			.account_data
@@ -164,35 +157,20 @@ async fn matcher(
 		| _ => 0,
 	});
 
-	let (
-		(last_timeline, last_notification, last_account),
-		(last_receipt, last_privateread, last_membership),
-	) = join(
-		join3(last_timeline, last_notification, last_account),
-		join3(last_receipt, last_privateread, last_membership),
-	)
-	.await;
+	let ((last_timeline, last_notification, last_account), (last_privateread, last_membership)) =
+		join(
+			join3(last_timeline, last_notification, last_account),
+			join(last_privateread, last_membership),
+		)
+		.await;
 
-	// A departed room surfaces only on its own leave count, never on room-global
-	// timeline activity the user no longer receives, so the retraction is one-shot.
-	let last_count = match &membership {
-		| Some(MembershipState::Leave | MembershipState::Ban) => last_membership
-			.filter(|count| conn.next_batch.ge(count))
-			.unwrap_or_default(),
-		| _ => [
-			last_timeline,
-			last_notification,
-			last_account,
-			last_receipt,
-			last_privateread,
-			last_membership,
-		]
-		.into_iter()
-		.map(Option::unwrap_or_default)
-		.filter(|count| conn.next_batch.ge(count))
-		.max()
-		.unwrap_or_default(),
-	};
+	let last_count = last_count(membership.as_ref(), conn.next_batch, ActivityCounts {
+		timeline: last_timeline,
+		notification: last_notification,
+		account: last_account,
+		private_read: last_privateread,
+		membership: last_membership,
+	});
 
 	Some(WindowRoom {
 		room_id: room_id.clone(),
@@ -201,6 +179,42 @@ async fn matcher(
 		ranked: 0,
 		last_count,
 	})
+}
+
+#[derive(Copy, Clone)]
+struct ActivityCounts {
+	timeline: Option<u64>,
+	notification: Option<u64>,
+	account: Option<u64>,
+	private_read: Option<u64>,
+	membership: Option<u64>,
+}
+
+fn last_count(
+	membership: Option<&MembershipState>,
+	next_batch: u64,
+	counts: ActivityCounts,
+) -> u64 {
+	// A departed room surfaces only on its own leave count, never on room-global
+	// timeline activity the user no longer receives, so the retraction is one-shot.
+	match membership {
+		| Some(MembershipState::Leave | MembershipState::Ban) => counts
+			.membership
+			.filter(|count| next_batch.ge(count))
+			.unwrap_or_default(),
+		| _ => [
+			counts.timeline,
+			counts.notification,
+			counts.account,
+			counts.private_read,
+			counts.membership,
+		]
+		.into_iter()
+		.map(Option::unwrap_or_default)
+		.filter(|count| next_batch.ge(count))
+		.max()
+		.unwrap_or_default(),
+	}
 }
 
 #[tracing::instrument(
@@ -307,3 +321,50 @@ where
 }
 
 fn room_sort(a: &WindowRoom, b: &WindowRoom) -> Ordering { b.last_count.cmp(&a.last_count) }
+
+#[cfg(test)]
+mod tests {
+	use ruma::{OwnedRoomId, room_id};
+
+	use super::{ActivityCounts, ListIds, WindowRoom, last_count, room_sort};
+
+	#[test]
+	fn receipt_activity_does_not_reorder_room_but_timeline_activity_does() {
+		const NEXT_BATCH: u64 = 10;
+
+		let receipt_only = last_count(None, NEXT_BATCH, ActivityCounts {
+			timeline: None,
+			notification: None,
+			account: None,
+			private_read: None,
+			membership: None,
+		});
+		let mut rooms = [
+			room(room_id!("!current:example.com").to_owned(), 1),
+			room(room_id!("!updated:example.com").to_owned(), receipt_only),
+		];
+
+		rooms.sort_by(room_sort);
+		assert_eq!(rooms[0].room_id, room_id!("!current:example.com"));
+
+		rooms[1].last_count = last_count(None, NEXT_BATCH, ActivityCounts {
+			timeline: Some(2),
+			notification: None,
+			account: None,
+			private_read: None,
+			membership: None,
+		});
+		rooms.sort_by(room_sort);
+		assert_eq!(rooms[0].room_id, room_id!("!updated:example.com"));
+	}
+
+	fn room(room_id: OwnedRoomId, last_count: u64) -> WindowRoom {
+		WindowRoom {
+			room_id,
+			membership: None,
+			lists: ListIds::new(),
+			ranked: 0,
+			last_count,
+		}
+	}
+}

--- a/src/api/client/sync/v5/selector.rs
+++ b/src/api/client/sync/v5/selector.rs
@@ -1,16 +1,19 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, collections::BTreeMap};
 
 use futures::{
-	FutureExt, StreamExt, TryFutureExt,
+	FutureExt, StreamExt,
 	future::{join, join3},
 };
-use ruma::{OwnedRoomId, UInt, events::room::member::MembershipState, uint};
+use ruma::{
+	OwnedRoomId, RoomId, UInt, api::client::sync::sync_events::v5::ListId,
+	events::room::member::MembershipState, uint,
+};
 use tuwunel_core::{
-	apply, is_true,
+	Result, apply, debug_error, is_true,
 	matrix::PduCount,
 	trace,
 	utils::{
-		BoolExt, ReadyExt, TryFutureExtExt,
+		BoolExt, ReadyExt,
 		math::usize_from_ruma,
 		option::OptionExt,
 		stream::{BroadbandExt, IterStream},
@@ -61,17 +64,12 @@ pub(super) async fn selector(
 		.collect::<Vec<_>>()
 		.await;
 
-	rooms.sort_by(room_sort);
-	rooms
-		.iter_mut()
-		.enumerate()
-		.for_each(|(i, room)| {
-			room.ranked = i;
-
-			conn.rooms
-				.entry(room.room_id.clone())
-				.or_default();
-		});
+	rooms.sort_unstable_by(room_sort);
+	for room in &rooms {
+		conn.rooms
+			.entry(room.room_id.clone())
+			.or_default();
+	}
 
 	trace!(?rooms);
 	let lists = response_lists(rooms.iter());
@@ -115,106 +113,174 @@ async fn matcher(
 		.map(|lists| (lists.is_empty().is_false(), lists))
 		.await;
 
-	let last_notification = matched.then_async(|| {
-		services
+	let selected = matched
+		|| conn.subscriptions.contains_key(&room_id)
+		|| matches!(membership, Some(MembershipState::Leave | MembershipState::Ban));
+
+	if !selected {
+		return None;
+	}
+
+	let membership_only = membership_only(membership.as_ref());
+
+	let last_notification = async {
+		if membership_only {
+			return ActivityProbe::default();
+		}
+
+		let result = services
 			.pusher
 			.last_notification_read(sender_user, &room_id)
-			.unwrap_or_default()
-	});
+			.await;
 
-	let last_privateread = matched.then_async(|| {
-		services
-			.read_receipt
-			.last_privateread_update(sender_user, &room_id)
-	});
+		activity_probe(result, &room_id, "notification read", true)
+	};
 
-	let last_account = matched.then_async(|| {
-		services
-			.account_data
-			.last_count(Some(room_id.as_ref()), sender_user, Some(conn.next_batch))
-			.unwrap_or_default()
-	});
+	let last_timeline = async {
+		if membership_only {
+			return ActivityProbe::default();
+		}
 
-	let last_timeline = matched.then_async(|| {
-		services
+		let result = services
 			.timeline
 			.last_timeline_count(None, &room_id, Some(conn.next_batch.into()))
-			.map_ok(PduCount::into_unsigned)
-			.unwrap_or_default()
-	});
-
-	let last_membership = matched.then_async(async || match &membership {
-		| Some(MembershipState::Invite) => services
-			.state_cache
-			.get_invite_count(&room_id, sender_user)
 			.await
-			.unwrap_or_default(),
-		| Some(MembershipState::Leave | MembershipState::Ban) => services
-			.state_cache
-			.get_left_count(&room_id, sender_user)
-			.await
-			.unwrap_or_default(),
-		| _ => 0,
-	});
+			.map(PduCount::into_unsigned);
 
-	let ((last_timeline, last_notification, last_account), (last_privateread, last_membership)) =
-		join(
-			join3(last_timeline, last_notification, last_account),
-			join(last_privateread, last_membership),
-		)
-		.await;
+		activity_probe(result, &room_id, "timeline", false)
+	};
 
-	let last_count = last_count(membership.as_ref(), conn.next_batch, ActivityCounts {
-		timeline: last_timeline,
-		notification: last_notification,
-		account: last_account,
-		private_read: last_privateread,
-		membership: last_membership,
-	});
+	let last_membership = async {
+		let result = match &membership {
+			| Some(MembershipState::Join) => Some(
+				services
+					.state_cache
+					.get_joined_count(&room_id, sender_user)
+					.await,
+			),
+			| Some(MembershipState::Invite) => Some(
+				services
+					.state_cache
+					.get_invite_count(&room_id, sender_user)
+					.await,
+			),
+			| Some(MembershipState::Knock) => Some(
+				services
+					.state_cache
+					.get_knock_count(&room_id, sender_user)
+					.await,
+			),
+			| Some(MembershipState::Leave | MembershipState::Ban) => Some(
+				services
+					.state_cache
+					.get_left_count(&room_id, sender_user)
+					.await,
+			),
+			| _ => None,
+		};
+
+		result.map_or_else(ActivityProbe::default, |result| {
+			activity_probe(result, &room_id, "membership", false)
+		})
+	};
+
+	let (last_timeline, last_notification, last_membership) =
+		join3(last_timeline, last_notification, last_membership).await;
+
+	let (event_count, payload_count) =
+		activity_counts(membership.as_ref(), conn.next_batch, ActivityCounts {
+			timeline: last_timeline.count,
+			notification: last_notification.count,
+			membership: last_membership.count,
+			payload_probe_failed: last_timeline.failed
+				|| last_notification.failed
+				|| last_membership.failed,
+		});
 
 	Some(WindowRoom {
-		room_id: room_id.clone(),
+		room_id,
 		membership,
 		lists,
-		ranked: 0,
-		last_count,
+		event_count,
+		payload_count,
 	})
+}
+
+#[derive(Copy, Clone, Default)]
+struct ActivityProbe {
+	count: Option<u64>,
+	failed: bool,
 }
 
 #[derive(Copy, Clone)]
 struct ActivityCounts {
 	timeline: Option<u64>,
 	notification: Option<u64>,
-	account: Option<u64>,
-	private_read: Option<u64>,
 	membership: Option<u64>,
+	payload_probe_failed: bool,
 }
 
-fn last_count(
+fn activity_counts(
 	membership: Option<&MembershipState>,
 	next_batch: u64,
 	counts: ActivityCounts,
-) -> u64 {
-	// A departed room surfaces only on its own leave count, never on room-global
-	// timeline activity the user no longer receives, so the retraction is one-shot.
-	match membership {
-		| Some(MembershipState::Leave | MembershipState::Ban) => counts
-			.membership
-			.filter(|count| next_batch.ge(count))
-			.unwrap_or_default(),
-		| _ => [
-			counts.timeline,
-			counts.notification,
-			counts.account,
-			counts.private_read,
-			counts.membership,
-		]
-		.into_iter()
-		.map(Option::unwrap_or_default)
-		.filter(|count| next_batch.ge(count))
-		.max()
-		.unwrap_or_default(),
+) -> (u64, u64) {
+	let timeline = bounded_count(next_batch, counts.timeline);
+	let notification = bounded_count(next_batch, counts.notification);
+	let membership_count = bounded_count(next_batch, counts.membership);
+	let membership_only = membership_only(membership);
+	let event_count = if membership_only {
+		membership_count
+	} else {
+		timeline.max(membership_count)
+	};
+	let fresh_count = if membership_only {
+		membership_count
+	} else {
+		timeline.max(notification).max(membership_count)
+	};
+	let payload_count = if counts.payload_probe_failed {
+		next_batch
+	} else {
+		fresh_count
+	};
+
+	(event_count, payload_count)
+}
+
+fn activity_probe(
+	result: Result<u64>,
+	room_id: &RoomId,
+	source: &'static str,
+	missing_is_zero: bool,
+) -> ActivityProbe {
+	match result {
+		| Ok(count) => ActivityProbe { count: Some(count), failed: false },
+		| Err(error) if missing_is_zero && error.is_not_found() => ActivityProbe::default(),
+		| Err(error) => {
+			debug_error!(%room_id, %source, "Failed to read sliding sync activity: {error}");
+			ActivityProbe { count: None, failed: true }
+		},
 	}
+}
+
+#[inline]
+fn membership_only(membership: Option<&MembershipState>) -> bool {
+	matches!(
+		membership,
+		Some(
+			MembershipState::Invite
+				| MembershipState::Knock
+				| MembershipState::Leave
+				| MembershipState::Ban
+		)
+	)
+}
+
+fn bounded_count(next_batch: u64, count: Option<u64>) -> u64 {
+	count
+		.filter(|count| next_batch.ge(count))
+		.unwrap_or_default()
 }
 
 #[tracing::instrument(
@@ -238,8 +304,7 @@ where
 
 	let selections = lists
 		.keys()
-		.cloned()
-		.filter_map(|id| conn.lists.get(&id).map(|list| (id, list)))
+		.filter_map(|id| conn.lists.get(id).map(|list| (id, list)))
 		.flat_map(|(id, list)| {
 			let full_range = list
 				.ranges
@@ -251,24 +316,34 @@ where
 				.iter()
 				.chain(full_range)
 				.map(apply!(2, usize_from_ruma))
-				.map(move |range| (id.clone(), range))
+				.map(move |range| (id, range))
 		})
 		.flat_map(|(id, (start, end))| {
-			rooms
-				.clone()
-				.filter(move |&room| room.lists.contains(&id))
-				.filter(|&room| {
-					conn.rooms
-						.get(&room.room_id)
-						.is_some_and(|conn_room| {
-							conn_room.roomsince == 0 || room.last_count > conn_room.roomsince
-						})
-				})
-				.enumerate()
-				.skip_while(move |&(i, _)| i < start)
-				.take(end.saturating_add(1).saturating_sub(start))
-				.map(|(_, room)| (room.room_id.clone(), room.clone()))
+			select_list_range(rooms.clone(), id, start, end)
+				.map(|room| (room.room_id.clone(), room.clone()))
 		})
+		.stream();
+
+	let indexed_subscriptions = (conn.subscriptions.len() > 1).then(|| {
+		rooms
+			.clone()
+			.filter(|room| conn.subscriptions.contains_key(&room.room_id))
+			.map(|room| (&room.room_id, room))
+			.collect::<BTreeMap<_, _>>()
+	});
+
+	let retractions = rooms
+		.clone()
+		.filter(|room| {
+			matches!(room.membership, Some(MembershipState::Leave | MembershipState::Ban))
+				&& conn
+					.rooms
+					.get(&room.room_id)
+					.is_some_and(|conn_room| {
+						conn_room.roomsince != 0 && room.payload_count > conn_room.roomsince
+					})
+		})
+		.map(|room| (room.room_id.clone(), detached_room(room.clone())))
 		.stream();
 
 	let subscriptions = conn
@@ -276,28 +351,72 @@ where
 		.iter()
 		.stream()
 		.broad_filter_map(async |(room_id, _)| {
-			let membership = services
-				.state_cache
-				.user_membership(sender_user, room_id);
+			let room = indexed_subscriptions
+				.as_ref()
+				.map_or_else(
+					|| {
+						rooms
+							.clone()
+							.find(|room| room.room_id == *room_id)
+					},
+					|indexed| indexed.get(&room_id).copied(),
+				)
+				.cloned();
 
-			let filter = filter_room_meta(sync_info, room_id);
-
-			let (membership, filter) = join(membership, filter).await;
+			let (membership, filter) = if let Some(room) = &room {
+				(room.membership.clone(), filter_room_meta(sync_info, room_id).await)
+			} else {
+				join(
+					services
+						.state_cache
+						.user_membership(sender_user, room_id),
+					filter_room_meta(sync_info, room_id),
+				)
+				.await
+			};
 
 			// MSC4380: suppress invited-room subscriptions when invites are blocked.
 			let suppress = invites_blocked && matches!(membership, Some(MembershipState::Invite));
 
-			(filter && !suppress).then(|| WindowRoom {
-				room_id: room_id.clone(),
-				lists: Default::default(),
-				ranked: usize::MAX,
-				last_count: 0,
-				membership,
-			})
+			if !filter || suppress {
+				return None;
+			}
+
+			if let Some(room) = room {
+				return Some(detached_room(room));
+			}
+
+			matcher(sync_info, conn, room_id.clone(), membership)
+				.await
+				.map(detached_room)
 		})
 		.map(|room| (room.room_id.clone(), room));
 
-	subscriptions.chain(selections).collect().await
+	retractions
+		.chain(subscriptions)
+		.chain(selections)
+		.collect()
+		.await
+}
+
+fn detached_room(room: WindowRoom) -> WindowRoom { WindowRoom { lists: ListIds::new(), ..room } }
+
+fn select_list_range<'a, Rooms>(
+	rooms: Rooms,
+	id: &ListId,
+	start: usize,
+	end: usize,
+) -> impl Iterator<Item = &'a WindowRoom>
+where
+	Rooms: Iterator<Item = &'a WindowRoom>,
+{
+	rooms
+		.filter(move |room| room.lists.contains(id))
+		.filter(|room| {
+			!matches!(room.membership, Some(MembershipState::Leave | MembershipState::Ban))
+		})
+		.skip(start)
+		.take(end.saturating_add(1).saturating_sub(start))
 }
 
 fn response_lists<'a, Rooms>(rooms: Rooms) -> ResponseLists
@@ -320,51 +439,168 @@ where
 		})
 }
 
-fn room_sort(a: &WindowRoom, b: &WindowRoom) -> Ordering { b.last_count.cmp(&a.last_count) }
+fn room_sort(a: &WindowRoom, b: &WindowRoom) -> Ordering {
+	b.event_count
+		.cmp(&a.event_count)
+		.then_with(|| a.room_id.cmp(&b.room_id))
+}
 
 #[cfg(test)]
 mod tests {
-	use ruma::{OwnedRoomId, room_id};
+	use ruma::{
+		OwnedRoomId, api::client::sync::sync_events::v5::ListId,
+		events::room::member::MembershipState, room_id,
+	};
 
-	use super::{ActivityCounts, ListIds, WindowRoom, last_count, room_sort};
+	use super::{
+		ActivityCounts, ListIds, WindowRoom, activity_counts, detached_room, room_sort,
+		select_list_range,
+	};
+
+	const NEXT_BATCH: u64 = 10;
 
 	#[test]
-	fn receipt_activity_does_not_reorder_room_but_timeline_activity_does() {
-		const NEXT_BATCH: u64 = 10;
+	fn notification_activity_refreshes_payload_without_reordering() {
+		let (event_count, payload_count) =
+			activity_counts(Some(&MembershipState::Join), NEXT_BATCH, ActivityCounts {
+				timeline: Some(2),
+				notification: Some(8),
+				membership: Some(1),
+				payload_probe_failed: false,
+			});
 
-		let receipt_only = last_count(None, NEXT_BATCH, ActivityCounts {
-			timeline: None,
-			notification: None,
-			account: None,
-			private_read: None,
-			membership: None,
-		});
+		assert_eq!((event_count, payload_count), (2, 8));
+
 		let mut rooms = [
-			room(room_id!("!current:example.com").to_owned(), 1),
-			room(room_id!("!updated:example.com").to_owned(), receipt_only),
+			room(room_id!("!current:example.com").to_owned(), 3, 3, None),
+			room(
+				room_id!("!notification:example.com").to_owned(),
+				event_count,
+				payload_count,
+				None,
+			),
 		];
 
 		rooms.sort_by(room_sort);
 		assert_eq!(rooms[0].room_id, room_id!("!current:example.com"));
-
-		rooms[1].last_count = last_count(None, NEXT_BATCH, ActivityCounts {
-			timeline: Some(2),
-			notification: None,
-			account: None,
-			private_read: None,
-			membership: None,
-		});
-		rooms.sort_by(room_sort);
-		assert_eq!(rooms[0].room_id, room_id!("!updated:example.com"));
 	}
 
-	fn room(room_id: OwnedRoomId, last_count: u64) -> WindowRoom {
+	#[test]
+	fn stripped_membership_rooms_use_only_membership_activity() {
+		for membership in [
+			MembershipState::Invite,
+			MembershipState::Knock,
+			MembershipState::Leave,
+			MembershipState::Ban,
+		] {
+			let counts = activity_counts(Some(&membership), NEXT_BATCH, ActivityCounts {
+				timeline: Some(9),
+				notification: Some(8),
+				membership: Some(4),
+				payload_probe_failed: false,
+			});
+
+			assert_eq!(counts, (4, 4));
+		}
+	}
+
+	#[test]
+	fn activity_probe_failure_forces_payload_without_reordering() {
+		let counts = activity_counts(Some(&MembershipState::Join), NEXT_BATCH, ActivityCounts {
+			timeline: Some(2),
+			notification: None,
+			membership: Some(1),
+			payload_probe_failed: true,
+		});
+
+		assert_eq!(counts, (2, NEXT_BATCH));
+	}
+
+	#[test]
+	fn full_list_range_ignores_payload_freshness_and_departed_rooms() {
+		let list = ListId::from("main");
+		let mut rooms = [
+			room(
+				room_id!("!departed:example.com").to_owned(),
+				40,
+				40,
+				Some(MembershipState::Leave),
+			),
+			room(room_id!("!stale:example.com").to_owned(), 30, 1, None),
+			room(room_id!("!fresh:example.com").to_owned(), 20, 20, None),
+			room(room_id!("!tail:example.com").to_owned(), 10, 10, None),
+		];
+
+		for room in &mut rooms {
+			room.lists.push(list.clone());
+		}
+
+		let selected = select_list_range(rooms.iter(), &list, 0, 1)
+			.map(|room| room.room_id.clone())
+			.collect::<Vec<_>>();
+
+		assert_eq!(selected, [
+			room_id!("!stale:example.com").to_owned(),
+			room_id!("!fresh:example.com").to_owned(),
+		]);
+	}
+
+	#[test]
+	fn equal_activity_rooms_have_deterministic_order() {
+		let mut rooms = [
+			room(room_id!("!z:example.com").to_owned(), 5, 5, None),
+			room(room_id!("!a:example.com").to_owned(), 5, 5, None),
+		];
+
+		rooms.sort_by(room_sort);
+
+		assert_eq!(rooms.map(|room| room.room_id), [
+			room_id!("!a:example.com").to_owned(),
+			room_id!("!z:example.com").to_owned(),
+		]);
+	}
+
+	#[test]
+	fn subscription_keeps_computed_payload_freshness() {
+		let mut room = room(room_id!("!subscribed:example.com").to_owned(), 7, 9, None);
+		room.lists.push(ListId::from("outside-range"));
+
+		let room = detached_room(room);
+
+		assert_eq!(room.payload_count, 9);
+		assert!(room.lists.is_empty());
+	}
+
+	#[test]
+	fn retraction_has_no_list_provenance() {
+		let mut room = room(
+			room_id!("!departed:example.com").to_owned(),
+			7,
+			9,
+			Some(MembershipState::Leave),
+		);
+
+		room.lists
+			.push(ListId::from("matched-before-leave"));
+
+		let room = detached_room(room);
+
+		assert!(room.lists.is_empty());
+		assert_eq!(room.membership, Some(MembershipState::Leave));
+	}
+
+	fn room(
+		room_id: OwnedRoomId,
+		event_count: u64,
+		payload_count: u64,
+		membership: Option<MembershipState>,
+	) -> WindowRoom {
 		WindowRoom {
 			room_id,
-			membership: None,
+			membership,
 			lists: ListIds::new(),
-			ranked: 0,
-			last_count,
+			event_count,
+			payload_count,
 		}
 	}
 }

--- a/src/api/server/invite.rs
+++ b/src/api/server/invite.rs
@@ -30,6 +30,7 @@ use tuwunel_service::{
 	membership::{
 		StrippedCreateVerdict, enforce_stripped_create, into_client_stripped, v12_room_ids,
 	},
+	rooms::state_cache::MembershipUpdate,
 };
 
 use crate::{ClientIp, Ruma};
@@ -330,16 +331,16 @@ async fn record_local_invite(
 	let count = services.globals.next_count();
 	services
 		.state_cache
-		.update_membership(
-			&body.room_id,
-			invited_user,
-			RoomMemberEventContent::new(MembershipState::Invite),
+		.update_membership(MembershipUpdate {
+			room_id: &body.room_id,
+			user_id: invited_user,
+			membership_event: RoomMemberEventContent::new(MembershipState::Invite),
 			sender,
-			Some(invite_state),
-			body.via.clone(),
-			true,
-			PduCount::Normal(*count),
-		)
+			last_state: Some(invite_state),
+			invite_via: body.via.clone(),
+			update_joined_count: true,
+			count: PduCount::Normal(*count),
+		})
 		.await?;
 	drop(count);
 

--- a/src/core/alloc/je.rs
+++ b/src/core/alloc/je.rs
@@ -26,6 +26,12 @@ use crate::{
 	utils::{BoolExt, math, math::Tried},
 };
 
+/// Provides the process-wide jemalloc startup configuration.
+///
+/// Jemalloc reads this unmangled symbol during allocator initialization, which
+/// can occur before `main`. The NUL-terminated options enable CPU-affine
+/// arenas, background purging, metadata huge pages, and tuned cache and decay
+/// thresholds.
 #[cfg(feature = "jemalloc_conf")]
 #[used]
 #[unsafe(no_mangle)]
@@ -70,6 +76,10 @@ static GLOBAL_ALLOCS: AtomicU64 = AtomicU64::new(0);
 static COUNT_GLOBAL_ALLOCS: AtomicBool = AtomicBool::new(false);
 static TRACE_GLOBAL_ALLOCS: AtomicBool = AtomicBool::new(false);
 
+/// Registers the allocation-observer callbacks during process startup.
+///
+/// Normal and zeroed allocations made after registration feed the same counting
+/// and tracing instrumentation.
 #[crate::ctor(unsafe)]
 fn _static_initialization() {
 	// SAFETY: Mutable static globals in jemalloc crate; must be initialized
@@ -80,6 +90,11 @@ fn _static_initialization() {
 	unsafe { ALLOC_ZEROED = Some(global_alloc_zeroed_hook) };
 }
 
+/// Returns a human-readable snapshot of allocator memory usage.
+///
+/// After refreshing the statistics epoch, the report lists allocated, active,
+/// mapped, metadata, resident, and retained memory in MiB. It returns `None`
+/// when the epoch cannot be refreshed.
 #[must_use]
 #[cfg(disable)]
 //#[cfg(feature = "jemalloc_stats")]
@@ -110,10 +125,24 @@ pub fn memory_usage() -> Option<String> {
 	))
 }
 
+/// Returns a human-readable snapshot of allocator memory usage when available.
+///
+/// Detailed summary reporting is currently disabled for this build, so this
+/// implementation returns `None`. Raw allocator output remains available
+/// through [`memory_stats`].
 #[must_use]
 //#[cfg(not(feature = "jemalloc_stats"))]
 pub fn memory_usage() -> Option<String> { None }
 
+/// Collects jemalloc's raw statistics report with the supplied print options.
+///
+/// The allocator statistics epoch is refreshed before invoking
+/// `malloc_stats_print`. Refresh failure returns `None`, and output is
+/// truncated to 1 MiB.
+///
+/// # Panics
+///
+/// Panics if `opts` contains an interior NUL byte.
 pub fn memory_stats(opts: &str) -> Option<String> {
 	const MAX_LENGTH: usize = 1_048_576;
 
@@ -136,6 +165,16 @@ pub fn memory_stats(opts: &str) -> Option<String> {
 	Some(str)
 }
 
+/// Appends a jemalloc statistics fragment through the C callback boundary.
+///
+/// Panics are caught and converted into process aborts before control returns
+/// to jemalloc.
+///
+/// # Safety
+///
+/// `opaque` must point to the live `String` supplied by [`memory_stats`], and
+/// `msg` must point to a NUL-terminated string valid for the duration of the
+/// call.
 unsafe extern "C" fn malloc_stats_cb(opaque: *mut c_void, msg: *const c_char) {
 	catch_unwind(move || handle_malloc_stats(opaque, msg))
 		.map_err(|_| abort())
@@ -191,6 +230,11 @@ fn handle_global_alloc(layout: Layout) {
 	}
 }
 
+/// Returns the process allocation count observed by the allocator hook.
+///
+/// The counter uses relaxed ordering and advances only when internal allocation
+/// counting is enabled. It is intended for allocation measurements rather than
+/// synchronized accounting.
 #[inline]
 #[must_use]
 pub fn global_alloc_count() -> u64 { GLOBAL_ALLOCS.load(Ordering::Relaxed) }
@@ -208,6 +252,11 @@ macro_rules! mallctl {
 	}};
 }
 
+/// Controls jemalloc state associated with the calling thread.
+///
+/// These wrappers expose the thread's arena, cache, profiling state, and
+/// allocation counters through mallctl. Control failures are returned through
+/// the crate's allocator error type.
 pub mod this_thread {
 	use super::{Debug, Key, OnceCell, Result, is_nonzero, key, math};
 
@@ -216,62 +265,146 @@ pub mod this_thread {
 		static DEALLOCATED_BYTES: OnceCell<&'static u64> = const { OnceCell::new() };
 	}
 
+	/// Reclaims unused pages from the calling thread's arena.
+	///
+	/// The operation first applies time-based decay and then purges all
+	/// remaining unused dirty pages.
 	pub fn trim() -> Result { decay().and_then(|()| purge()) }
 
+	/// Purges unused dirty pages from the calling thread's arena.
+	///
+	/// This requests immediate reclamation rather than waiting for the arena's
+	/// decay schedule.
 	pub fn purge() -> Result { notify(mallctl!("arena.0.purge")) }
 
+	/// Applies decay-based purging to the calling thread's arena.
+	///
+	/// Jemalloc selects unused dirty and muzzy pages according to their
+	/// configured decay intervals.
 	pub fn decay() -> Result { notify(mallctl!("arena.0.decay")) }
 
+	/// Notifies jemalloc that the calling thread is entering an extended idle
+	/// period.
+	///
+	/// The hint may flush the thread cache and purge its arena, but does not
+	/// guarantee a specific cleanup operation.
 	pub fn idle() -> Result { super::notify(&mallctl!("thread.idle")) }
 
+	/// Flushes the calling thread's automatic allocation cache.
+	///
+	/// Cached objects and the cache's internal structures are returned to the
+	/// thread's arena.
 	pub fn flush() -> Result { super::notify(&mallctl!("thread.tcache.flush")) }
 
+	/// Sets the calling thread's arena muzzy-page decay interval.
+	///
+	/// A value of `0` requests immediate purging, while `-1` disables purging.
+	/// The previous interval is returned.
 	pub fn set_muzzy_decay(decay_ms: isize) -> Result<isize> {
 		set(mallctl!("arena.0.muzzy_decay_ms"), decay_ms)
 	}
 
+	/// Returns the calling thread's arena muzzy-page decay interval.
+	///
+	/// The value is an approximate delay in milliseconds, with `-1`
+	/// representing disabled purging.
 	pub fn get_muzzy_decay() -> Result<isize> { get(mallctl!("arena.0.muzzy_decay_ms")) }
 
+	/// Sets the calling thread's arena dirty-page decay interval.
+	///
+	/// A value of `0` requests immediate purging, while `-1` disables purging.
+	/// The previous interval is returned.
 	pub fn set_dirty_decay(decay_ms: isize) -> Result<isize> {
 		set(mallctl!("arena.0.dirty_decay_ms"), decay_ms)
 	}
 
+	/// Returns the calling thread's arena dirty-page decay interval.
+	///
+	/// The value is an approximate delay in milliseconds, with `-1`
+	/// representing disabled purging.
 	pub fn get_dirty_decay() -> Result<isize> { get(mallctl!("arena.0.dirty_decay_ms")) }
 
+	/// Enables or disables automatic allocation caching for the calling thread.
+	///
+	/// Disabling the cache flushes its existing contents. The previous enabled
+	/// state is returned.
 	pub fn cache_enable(enable: bool) -> Result<bool> {
 		super::set::<u8>(&mallctl!("thread.tcache.enabled"), enable.into()).map(is_nonzero!())
 	}
 
+	/// Returns whether automatic allocation caching is enabled for the calling
+	/// thread.
+	///
+	/// The value reflects the current thread-specific cache override.
 	pub fn is_cache_enabled() -> Result<bool> {
 		super::get::<u8>(&mallctl!("thread.tcache.enabled")).map(is_nonzero!())
 	}
 
+	/// Associates the calling thread with a jemalloc arena.
+	///
+	/// Jemalloc initializes an uninitialized target arena as needed. The
+	/// previous arena identifier is returned.
 	pub fn set_arena(id: usize) -> Result<usize> {
 		super::set::<u32>(&mallctl!("thread.arena"), id.try_into()?).and_then(math::try_into)
 	}
 
+	/// Returns the jemalloc arena associated with the calling thread.
+	///
+	/// The allocator's unsigned arena identifier is converted to `usize`.
 	pub fn arena_id() -> Result<usize> {
 		super::get::<u32>(&mallctl!("thread.arena")).and_then(math::try_into)
 	}
 
+	/// Enables or disables allocation sampling for the calling thread.
+	///
+	/// Global profiling must also be active before this thread produces
+	/// samples. The previous thread setting is returned.
 	pub fn prof_enable(enable: bool) -> Result<bool> {
 		super::set::<u8>(&mallctl!("thread.prof.active"), enable.into()).map(is_nonzero!())
 	}
 
+	/// Returns whether allocation sampling is active for the calling thread.
+	///
+	/// Global profiling can independently suppress sampling even when this
+	/// value is true.
 	pub fn is_prof_enabled() -> Result<bool> {
 		super::get::<u8>(&mallctl!("thread.prof.active")).map(is_nonzero!())
 	}
 
+	/// Resets the calling thread's peak net-allocation counter.
+	///
+	/// Cumulative allocated and deallocated byte counters are not reset.
 	pub fn reset_peak() -> Result { super::notify(&mallctl!("thread.peak.reset")) }
 
+	/// Returns the calling thread's approximate peak net allocation in bytes.
+	///
+	/// The measurement covers time since thread creation or the most recent
+	/// peak reset.
 	pub fn peak() -> Result<u64> { super::get(&mallctl!("thread.peak.read")) }
 
+	/// Returns the total number of bytes ever allocated by the calling thread.
+	///
+	/// A cached pointer avoids repeated mallctl lookups, and the underlying
+	/// counter can wrap.
+	///
+	/// # Panics
+	///
+	/// Panics if jemalloc does not provide a valid thread allocation counter.
 	#[inline]
 	#[must_use]
 	pub fn allocated() -> u64 {
 		*ALLOCATED_BYTES.with(|once| init_tls_cell(once, "thread.allocatedp"))
 	}
 
+	/// Returns the total number of bytes ever deallocated by the calling
+	/// thread.
+	///
+	/// A cached pointer avoids repeated mallctl lookups, and the underlying
+	/// counter can wrap.
+	///
+	/// # Panics
+	///
+	/// Panics if jemalloc does not provide a valid thread deallocation counter.
 	#[inline]
 	#[must_use]
 	pub fn deallocated() -> u64 {
@@ -294,6 +427,14 @@ pub mod this_thread {
 		super::get_by_arena(Some(arena_id()?), key)
 	}
 
+	/// Caches a pointer to one of jemalloc's thread-local byte counters.
+	///
+	/// The pointer is resolved once per Rust thread and reused by the public
+	/// counter accessors.
+	///
+	/// # Panics
+	///
+	/// Panics if the mallctl lookup fails or returns a null pointer.
 	fn init_tls_cell(cell: &OnceCell<&'static u64>, name: &str) -> &'static u64 {
 		cell.get_or_init(|| {
 			let ptr: *const u64 = super::get(&mallctl!(name)).expect("failed to obtain pointer");
@@ -304,40 +445,82 @@ pub mod this_thread {
 	}
 }
 
+/// Resets jemalloc's mutex profiling statistics.
+///
+/// The reset covers global, arena, and bin mutex counters.
 pub fn stats_reset() -> Result { notify(&mallctl!("stats.mutexes.reset")) }
 
+/// Resets accumulated jemalloc heap-profile statistics.
+///
+/// The control is invoked without specifying a replacement sampling rate.
 pub fn prof_reset() -> Result { notify(&mallctl!("prof.reset")) }
 
+/// Writes a jemalloc heap profile to its default dump path.
+///
+/// Jemalloc derives the filename from the configured profile prefix, process
+/// identifier, and dump sequence.
 pub fn prof_dump() -> Result { notify(&mallctl!("prof.dump")) }
 
+/// Enables or disables profile dumps at new virtual-memory high-water marks.
+///
+/// The previous setting is returned. This control is available when jemalloc
+/// profiling support is built.
 pub fn prof_gdump(enable: bool) -> Result<bool> {
 	set::<u8>(&mallctl!("prof.gdump"), enable.into()).map(is_nonzero!())
 }
 
+/// Enables or disables global jemalloc allocation sampling.
+///
+/// Thread-level profiling must also be active before a thread produces samples.
+/// The previous global setting is returned.
 pub fn prof_enable(enable: bool) -> Result<bool> {
 	set::<u8>(&mallctl!("prof.active"), enable.into()).map(is_nonzero!())
 }
 
+/// Returns whether global jemalloc allocation sampling is active.
+///
+/// Thread-level profiling can independently suppress sampling for individual
+/// threads.
 pub fn is_prof_enabled() -> Result<bool> {
 	get::<u8>(&mallctl!("prof.active")).map(is_nonzero!())
 }
 
+/// Returns the average allocation interval between periodic heap-profile dumps.
+///
+/// The interval is measured in allocated bytes and reflects jemalloc's active
+/// profiling configuration.
 pub fn prof_interval() -> Result<u64> {
 	get::<u64>(&mallctl!("prof.interval")).and_then(math::try_into)
 }
 
+/// Reclaims unused pages from one arena or from all arenas.
+///
+/// The operation applies time-based decay before purging remaining unused dirty
+/// pages. Passing `None` selects every arena.
 pub fn trim<I: Into<Option<usize>> + Copy>(arena: I) -> Result {
 	decay(arena).and_then(|()| purge(arena))
 }
 
+/// Purges unused dirty pages from one arena or from all arenas.
+///
+/// Passing `None` selects every arena and requests immediate reclamation.
 pub fn purge<I: Into<Option<usize>>>(arena: I) -> Result {
 	notify_by_arena(arena.into(), mallctl!("arena.4096.purge"))
 }
 
+/// Triggers decay-based purging for one arena or for all arenas.
+///
+/// Passing `None` selects every arena. Jemalloc chooses unused dirty and muzzy
+/// pages according to the configured decay intervals.
 pub fn decay<I: Into<Option<usize>>>(arena: I) -> Result {
 	notify_by_arena(arena.into(), mallctl!("arena.4096.decay"))
 }
 
+/// Sets an arena's muzzy-page decay interval or the default for future arenas.
+///
+/// Passing `Some` selects an existing arena, while `None` changes the value
+/// used to initialize newly created arenas. The previous interval is returned,
+/// with `0` requesting immediate purging and `-1` disabling it.
 pub fn set_muzzy_decay<I: Into<Option<usize>>>(arena: I, decay_ms: isize) -> Result<isize> {
 	match arena.into() {
 		| Some(arena) =>
@@ -346,6 +529,11 @@ pub fn set_muzzy_decay<I: Into<Option<usize>>>(arena: I, decay_ms: isize) -> Res
 	}
 }
 
+/// Sets an arena's dirty-page decay interval or the default for future arenas.
+///
+/// Passing `Some` selects an existing arena, while `None` changes the value
+/// used to initialize newly created arenas. The previous interval is returned,
+/// with `0` requesting immediate purging and `-1` disabling it.
 pub fn set_dirty_decay<I: Into<Option<usize>>>(arena: I, decay_ms: isize) -> Result<isize> {
 	match arena.into() {
 		| Some(arena) =>
@@ -354,22 +542,40 @@ pub fn set_dirty_decay<I: Into<Option<usize>>>(arena: I, decay_ms: isize) -> Res
 	}
 }
 
+/// Enables or disables jemalloc background purge threads.
+///
+/// Disabling waits for the workers to terminate before returning. The previous
+/// setting is returned.
 pub fn background_thread_enable(enable: bool) -> Result<bool> {
 	set::<u8>(&mallctl!("background_thread"), enable.into()).map(is_nonzero!())
 }
 
+/// Returns whether jemalloc uses a CPU-affine arena mode.
+///
+/// Query failures produce `false` because this convenience predicate treats an
+/// error as no matching affinity mode.
 #[inline]
 #[must_use]
 pub fn is_affine_arena() -> bool { is_percpu_arena() || is_phycpu_arena() }
 
+/// Returns whether jemalloc assigns arenas per logical CPU.
+///
+/// Query failures produce `false` rather than propagating the control error.
 #[inline]
 #[must_use]
 pub fn is_percpu_arena() -> bool { percpu_arenas().is_ok_and(is_equal_to!("percpu")) }
 
+/// Returns whether jemalloc assigns one arena per physical CPU.
+///
+/// Sibling hardware threads share an arena in this mode. Query failures produce
+/// `false` rather than propagating the control error.
 #[inline]
 #[must_use]
 pub fn is_phycpu_arena() -> bool { percpu_arenas().is_ok_and(is_equal_to!("phycpu")) }
 
+/// Returns jemalloc's configured per-CPU arena mode.
+///
+/// The static option string is normally `disabled`, `percpu`, or `phycpu`.
 pub fn percpu_arenas() -> Result<&'static str> {
 	let ptr = get::<*const c_char>(&mallctl!("opt.percpu_arena"))?;
 	//SAFETY: ptr points to a null-terminated string returned for opt.percpu_arena.
@@ -377,12 +583,23 @@ pub fn percpu_arenas() -> Result<&'static str> {
 	cstr.to_str().map_err(Into::into)
 }
 
+/// Returns the current limit on automatically managed jemalloc arenas.
+///
+/// The allocator's unsigned arena count is converted to `usize`.
 pub fn arenas() -> Result<usize> {
 	get::<u32>(&mallctl!("arenas.narenas")).and_then(math::try_into)
 }
 
+/// Refreshes cached allocator statistics by advancing jemalloc's epoch.
+///
+/// Writing `1` triggers a statistics refresh and returns the resulting epoch
+/// value.
 pub fn inc_epoch() -> Result<u64> { xchg(&mallctl!("epoch"), 1_u64) }
 
+/// Acquires a fresh snapshot of cached allocator statistics.
+///
+/// Writing `0` still triggers a statistics refresh, and the resulting epoch
+/// value is returned.
 pub fn acq_epoch() -> Result<u64> { xchg(&mallctl!("epoch"), 0_u64) }
 
 fn notify_by_arena(id: Option<usize>, mut key: Key) -> Result {

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -36,6 +36,11 @@ pub fn reload(old: &Config, new: &Config) -> Result {
 	Ok(())
 }
 
+/// Validates a complete server configuration.
+///
+/// The checks reject incompatible settings and emit warnings for risky or
+/// deprecated choices. Successful validation leaves the configuration
+/// unchanged.
 pub fn check(config: &Config) -> Result {
 	#[cfg(debug_assertions)]
 	warn!("Note: tuwunel was built without optimisations (i.e. debug build)");

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -279,38 +279,109 @@ pub struct Config {
 	#[serde(default = "default_db_write_buffer_capacity_mb")]
 	pub db_write_buffer_capacity_mb: f64,
 
+	/// Maximum number of entries in the RocksDB block cache shared by the
+	/// `pduid_pdu` and `eventid_outlierpdu` column families: a PDU's full
+	/// body, keyed by its PDU ID, and the same body keyed by event ID when
+	/// the PDU is an outlier.
+	///
+	/// This is an entry count, not a byte size. The cache's actual capacity
+	/// in bytes is this value multiplied by an internal per-column-family
+	/// key+value size estimate, then multiplied by `cache_capacity_modifier`.
+	///
+	/// Scaled by your CPU core count by default; see
+	/// `cache_capacity_modifier` to scale this along with the other
+	/// individual LRU caches at once.
+	///
 	/// default: varies by system
 	#[serde(default = "default_pdu_cache_capacity")]
 	pub pdu_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache shared by the
+	/// `shorteventid_authchain` and `authchainkey_authchain` column
+	/// families: a room event's full auth chain, keyed by its short event ID
+	/// or by the auth chain's own key.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity` above; see there
+	/// for how this becomes a byte capacity and how
+	/// `cache_capacity_modifier` applies.
+	///
 	/// default: varies by system
 	#[serde(default = "default_auth_chain_cache_capacity")]
 	pub auth_chain_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `shorteventid_eventid` column family: an event's full event ID,
+	/// looked up from its short event ID.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_shorteventid_cache_capacity")]
 	pub shorteventid_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `eventid_shorteventid` column family: an event's short event ID,
+	/// looked up from its full event ID. The reverse lookup of
+	/// `shorteventid_cache_capacity`.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_eventidshort_cache_capacity")]
 	pub eventidshort_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `eventid_pduid` column family: an event's PDU ID, looked up from its
+	/// full event ID.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_eventid_pdu_cache_capacity")]
 	pub eventid_pdu_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `shortstatekey_statekey` column family: a state event's full state
+	/// key, looked up from its short state key.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_shortstatekey_cache_capacity")]
 	pub shortstatekey_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `statekey_shortstatekey` column family: a state event's short state
+	/// key, looked up from its full state key. The reverse lookup of
+	/// `shortstatekey_cache_capacity`.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_statekeyshort_cache_capacity")]
 	pub statekeyshort_cache_capacity: u32,
 
+	/// Maximum number of entries in the RocksDB block cache for the
+	/// `servernameevent_data` column family: outbound federation events
+	/// (PDUs and EDUs) queued for delivery, keyed by destination server
+	/// name.
+	///
+	/// Same entry-count semantics as `pdu_cache_capacity`.
+	///
 	/// default: varies by system
 	#[serde(default = "default_servernameevent_data_cache_capacity")]
 	pub servernameevent_data_cache_capacity: u32,
 
+	/// Maximum number of entries in the in-memory LRU cache of decompressed
+	/// room state (a list of short state-info entries per state hash), used
+	/// by the state compressor to avoid re-walking
+	/// `shortstatehash_statediff` on every lookup.
+	///
+	/// Unlike the other caches on this page, this one is not backed by
+	/// RocksDB: it is a plain in-process cache sized directly in entries,
+	/// with no per-entry byte-size conversion. `cache_capacity_modifier`
+	/// still applies to it.
+	///
 	/// default: varies by system
 	#[serde(default = "default_stateinfo_cache_capacity")]
 	pub stateinfo_cache_capacity: u32,

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1,13 +1,44 @@
+/// Validates configuration before startup and reload.
+///
+/// Checks reject invalid combinations while emitting warnings for deprecated or
+/// risky values. Reload validation also prevents runtime changes to fixed
+/// identity and network fields.
 pub mod check;
 mod identity_provider_serde;
+/// Defines sources for trusted client IP extraction.
+///
+/// [`IpSource`] enumerates the TCP peer address and supported forwarding
+/// headers. The default uses the TCP peer address without trusting a proxy.
 pub mod ip_source;
+/// Maintains the active reloadable configuration.
+///
+/// [`Manager`] exposes the current [`Config`] through `Deref` and atomically
+/// replaces it on reload. It also manages the lifetime of configurations still
+/// visible to readers.
 pub mod manager;
 mod net;
+/// Defines outbound proxy configuration and domain matching.
+///
+/// The module supports no proxy, one global proxy, or domain-specific include
+/// and exclude rules. URL matching selects the applicable proxy at request
+/// time.
 pub mod proxy;
+/// Defines supported Matrix room-version policy.
+///
+/// Stable, unstable, and experimental version lists are kept here. [`Config`]
+/// helpers apply the opt-in flags and report each enabled version's stability.
 pub mod room_version;
+/// Defines the inputs used to assemble configuration.
+///
+/// [`Sources`] retains file paths and optional overrides so reloads reproduce
+/// startup inputs. Loading layers extra paths before applying those overrides.
 pub mod sources;
 #[cfg(test)]
 mod tests;
+/// Converts discovery configuration into Matrix API values.
+///
+/// Helpers build support contacts, policies, registration terms, and MatrixRTC
+/// transports from config. Endpoint handlers share these conversions.
 pub mod well_known;
 
 use std::{
@@ -138,6 +169,10 @@ pub struct Config {
 	#[serde(default = "default_port")]
 	port: ListeningPort,
 
+	/// Configures direct TLS listeners.
+	///
+	/// Values are read from the separate `[global.tls]` section. Certificate
+	/// and key paths must be supplied together before TLS is enabled.
 	// external structure; separate section
 	#[serde(default)]
 	pub tls: TlsConfig,
@@ -1258,10 +1293,19 @@ pub struct Config {
 	#[serde(default)]
 	pub default_power_level_content_override: Option<serde_json::Value>,
 
+	/// Configures Matrix discovery documents and related endpoints.
+	///
+	/// Values are read from the separate `[global.well_known]` section. Client,
+	/// server, support, and MatrixRTC responses consume these settings.
 	// external structure; separate section
 	#[serde(default)]
 	pub well_known: WellKnownConfig,
 
+	/// Enables OTLP span export for Jaeger-compatible tracing.
+	///
+	/// A build with performance measurements installs an OpenTelemetry layer
+	/// when this is enabled. It defaults to false, and `jaeger_filter` selects
+	/// the exported spans.
 	#[serde(default)]
 	pub allow_jaeger: bool,
 
@@ -1920,6 +1964,10 @@ pub struct Config {
 	#[serde(default = "default_rocksdb_log_level")]
 	pub rocksdb_log_level: String,
 
+	/// Routes RocksDB log messages to standard error.
+	///
+	/// `rocksdb_log_level` still filters the emitted records. When disabled,
+	/// RocksDB uses the application's callback logger instead.
 	#[serde(default)]
 	pub rocksdb_log_stderr: bool,
 
@@ -2115,9 +2163,17 @@ pub struct Config {
 	#[serde(default)]
 	pub rocksdb_repair: bool,
 
+	/// Opens RocksDB in read-only mode.
+	///
+	/// Writes are rejected and missing column families cannot be created. This
+	/// mode is disabled by default.
 	#[serde(default)]
 	pub rocksdb_read_only: bool,
 
+	/// Opens RocksDB as a secondary follower of a primary instance.
+	///
+	/// Writes are rejected while the primary's latest WAL can be replayed into
+	/// this instance's view. Missing column families cannot be created.
 	#[serde(default)]
 	pub rocksdb_secondary: bool,
 
@@ -3503,30 +3559,60 @@ pub struct Config {
 	#[serde(default)]
 	pub device_key_update_encrypted_rooms_only: bool,
 
+	/// Defines named media storage providers.
+	///
+	/// Each map key names a provider, and each value selects a local or
+	/// S3-compatible backend or disables the entry. Provider-specific settings
+	/// live in separate sections.
 	// external structure; separate section
 	#[serde(default)]
 	pub storage_provider: BTreeMap<String, StorageProvider>,
 
+	/// Defines policy documents users must accept during registration.
+	///
+	/// Each map key is the policy identifier exposed in the `m.login.terms` UIA
+	/// stage. An empty map leaves the terms stage disabled.
 	// external structure; separate section
 	#[serde(default)]
 	pub registration_terms: BTreeMap<String, TermsPolicy>,
 
+	/// Configures LDAP login integration.
+	///
+	/// Connection, bind, search, and attribute settings live in the separate
+	/// `[global.ldap]` section. LDAP authentication is disabled by default.
 	// external structure; separate section
 	#[serde(default)]
 	pub ldap: LdapConfig,
 
+	/// Configures JSON Web Token login integration.
+	///
+	/// Key format, algorithm, claim validation, and user provisioning settings
+	/// live in `[global.jwt]`. Token login is disabled by default.
 	// external structure; separate section
 	#[serde(default)]
 	pub jwt: JwtConfig,
 
+	/// Configures outbound SMTP email delivery.
+	///
+	/// Providing a connection URI enables the email subsystem. Registration
+	/// flags determine when a verified address is required.
 	// external structure; separate section
 	#[serde(default)]
 	pub smtp: SmtpConfig,
 
+	/// Defines inline application service registrations.
+	///
+	/// Each map key names one registration and supplies its default identifier.
+	/// The contained settings are converted to Matrix application service data.
 	// external structure; separate section
 	#[serde(default)]
 	pub appservice: BTreeMap<String, AppService>,
 
+	/// Defines OpenID Connect identity provider registrations.
+	///
+	/// Each entry configures client credentials, discovery, and account
+	/// mapping. Its stable `client_id` identifies the provider while `brand`
+	/// selects provider-specific defaults and workarounds.
 	// external structure; separate sections
 	#[serde(default, with = "identity_provider_serde")]
 	pub identity_provider: BTreeMap<String, IdentityProvider>,
@@ -3537,6 +3623,10 @@ pub struct Config {
 	catchall: BTreeMap<String, IgnoredAny>,
 }
 
+/// Configures direct TLS listener behavior.
+///
+/// Certificate and key paths must be supplied together. Optional dual-protocol
+/// mode accepts encrypted and plain connections on the same listeners.
 #[derive(Clone, Debug, Deserialize, Default)]
 #[config_example_generator(filename = "tuwunel-example.toml", section = "global.tls")]
 pub struct TlsConfig {
@@ -3550,11 +3640,19 @@ pub struct TlsConfig {
 	/// example: "/path/to/my/certificate.key"
 	pub key: Option<String>,
 
-	/// Whether to listen and allow for HTTP and HTTPS connections (insecure!)
+	/// Controls whether listeners accept both HTTP and HTTPS.
+	///
+	/// Plain requests are served without redirecting them to HTTPS. This
+	/// weakens transport security and is disabled by default.
 	#[serde(default)]
 	pub dual_protocol: bool,
 }
 
+/// Configures Matrix discovery documents and related response data.
+///
+/// Client and server fields drive the standard well-known responses. Support
+/// contacts, policies, and MatrixRTC transports populate their corresponding
+/// discovery data.
 #[expect(rustdoc::bare_urls)]
 #[derive(Clone, Debug, Deserialize, Default)]
 #[config_example_generator(
@@ -3578,10 +3676,18 @@ pub struct WellKnownConfig {
 	/// example: "matrix.example.com:443"
 	pub server: Option<OwnedServerName>,
 
+	/// Defines contacts published by the support discovery endpoint.
+	///
+	/// Each map value becomes one contact while its key is only a config
+	/// identifier. Legacy scalar support fields are appended separately.
 	// external structure; separate section
 	#[serde(default)]
 	pub support_contact: BTreeMap<String, SupportContact>,
 
+	/// Defines policies published by the support discovery endpoint.
+	///
+	/// Each map key becomes a policy identifier. The value supplies its version
+	/// and localized documents.
 	// external structure; separate section
 	#[serde(default)]
 	pub support_policy: BTreeMap<String, SupportPolicy>,
@@ -3671,6 +3777,10 @@ pub struct WellKnownConfig {
 	pub rtc_transports: Vec<serde_json::Value>,
 }
 
+/// Defines one policy published by the support discovery endpoint.
+///
+/// The enclosing map key supplies the policy identifier. Its version and
+/// localized translations are emitted in the discovery response.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -3684,10 +3794,18 @@ pub struct SupportPolicy {
 	/// reloadable: yes
 	pub version: String,
 
+	/// Maps language identifiers to localized policy documents.
+	///
+	/// Each value supplies the display name and URL for its language. The map
+	/// is converted to the response's localized policy entries.
 	// external structure; separate section
 	pub policy_translation: BTreeMap<String, SupportPolicyTranslation>,
 }
 
+/// Defines one localized support policy document.
+///
+/// `name` is the user-facing title for this language. `url` points clients to
+/// the corresponding policy text.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -3707,6 +3825,10 @@ pub struct SupportPolicyTranslation {
 	pub url: Url,
 }
 
+/// Defines a policy document required during registration.
+///
+/// The enclosing map key becomes the policy identifier presented to clients.
+/// Its version and translations form the `m.login.terms` stage parameters.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -3723,10 +3845,18 @@ pub struct TermsPolicy {
 	/// reloadable: yes
 	pub version: String,
 
+	/// Maps language identifiers to localized registration policy documents.
+	///
+	/// Each value supplies the display name and HTTP or HTTPS URL for its
+	/// language. These translations are presented in the terms stage.
 	// external structure; separate section
 	pub translations: BTreeMap<String, TermsPolicyTranslation>,
 }
 
+/// Defines one localized registration policy document.
+///
+/// `name` is the user-facing title for this language. `url` points clients to
+/// the policy text whose acceptance is recorded.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -3757,6 +3887,10 @@ impl From<SupportPolicyTranslation>
 	}
 }
 
+/// Defines a contact published by the support discovery endpoint.
+///
+/// Every contact has a Matrix support role. Email, Matrix ID, and OpenPGP key
+/// fields provide optional communication channels.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -3803,6 +3937,11 @@ impl From<SupportContact> for ruma::api::client::discovery::discover_support::Co
 	}
 }
 
+/// Configures LDAP authentication and directory-backed administration.
+///
+/// Connection, bind, search, and attribute settings determine how users are
+/// located and authenticated. Optional admin search settings identify directory
+/// entries treated as server administrators.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(filename = "tuwunel-example.toml", section = "global.ldap")]
 pub struct LdapConfig {
@@ -3911,6 +4050,10 @@ pub struct LdapConfig {
 	pub admin_filter: String,
 }
 
+/// Configures authentication using JSON Web Tokens.
+///
+/// Key format, signature algorithm, and claim rules determine token validity.
+/// Optional provisioning creates a local account for an otherwise valid token.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(filename = "tuwunel-example.toml", section = "global.jwt")]
 pub struct JwtConfig {
@@ -4017,6 +4160,10 @@ pub struct JwtConfig {
 	pub validate_signature: bool,
 }
 
+/// Configures outbound email verification through SMTP.
+///
+/// The connection URI and sender identify the relay and source mailbox.
+/// Registration flags control which flows require a verified email address.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(filename = "tuwunel-example.toml", section = "global.smtp")]
 pub struct SmtpConfig {
@@ -4061,6 +4208,11 @@ pub struct SmtpConfig {
 	pub require_email_for_token_registration: bool,
 }
 
+/// Configures one OpenID Connect identity provider.
+///
+/// Client credentials and endpoint discovery establish the upstream
+/// authorization flow. Claim and trust settings control account mapping and
+/// optional registration.
 #[derive(Clone, Debug, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -4340,9 +4492,17 @@ pub struct IdentityProvider {
 }
 
 impl IdentityProvider {
+	/// Returns the provider's stable identifier.
+	///
+	/// The identifier is the OAuth application's client ID. It is borrowed from
+	/// this configuration without allocation.
 	#[must_use]
 	pub fn id(&self) -> &str { self.client_id.as_str() }
 
+	/// Loads the effective client secret.
+	///
+	/// An inline secret takes precedence over a configured secret file. File
+	/// contents are read asynchronously and trimmed before being returned.
 	pub async fn get_client_secret(&self) -> Result<String> {
 		if let Some(client_secret) = &self.client_secret {
 			return Ok(client_secret.clone());
@@ -4358,17 +4518,39 @@ impl IdentityProvider {
 	}
 }
 
+/// Selects the backend for a named media storage provider.
+///
+/// Local providers store objects beneath a filesystem path, while S3 providers
+/// use a compatible object store. The default variant disables the entry.
 #[derive(Clone, Debug, Default, Deserialize)]
 pub enum StorageProvider {
+	/// Selects a local filesystem backend.
+	///
+	/// The contained settings root object paths beneath a configured directory.
+	/// Startup checks can require that directory to be usable.
 	#[expect(non_camel_case_types)]
 	local(StorageProviderLocal),
+
+	/// Selects an S3-compatible object storage backend.
+	///
+	/// The boxed settings configure endpoint, credentials, encryption, and
+	/// multipart uploads. Custom endpoints permit compatible non-AWS services.
 	#[expect(non_camel_case_types)]
 	#[serde(rename = "s3", alias = "S3")]
 	s3(Box<StorageProviderS3>),
+
+	/// Disables this storage provider entry.
+	///
+	/// This is the default when no backend variant is selected. It carries no
+	/// backend settings.
 	#[default]
 	None,
 }
 
+/// Configures local filesystem object storage.
+///
+/// `base_path` prefixes every object path belonging to this provider. Remaining
+/// options control directory creation, cleanup, and startup checks.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -4400,6 +4582,11 @@ pub struct StorageProviderLocal {
 	pub startup_check: bool,
 }
 
+/// Configures an S3-compatible object storage provider.
+///
+/// Bucket, endpoint, and credential fields identify the remote store.
+/// Transport, encryption, multipart, and startup options tune how objects are
+/// accessed.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -4518,6 +4705,11 @@ pub struct StorageProviderS3 {
 	pub startup_check: bool,
 }
 
+/// Defines one inline Matrix application service registration.
+///
+/// Tokens, namespaces, and protocol flags are converted to the Matrix
+/// registration model. The enclosing config map supplies the registration ID
+/// when `id` is empty.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -4525,6 +4717,10 @@ pub struct StorageProviderS3 {
 	ignore = "id users aliases rooms"
 )]
 pub struct AppService {
+	/// Identifies the application service registration.
+	///
+	/// An empty value is replaced with the enclosing config map key. An
+	/// explicit value must match that key.
 	#[serde(default)]
 	pub id: String,
 
@@ -4627,6 +4823,11 @@ impl From<AppService> for ruma::api::appservice::Registration {
 	}
 }
 
+/// Defines one namespace claimed by an application service.
+///
+/// The regular expression selects users, aliases, or rooms according to the
+/// list containing this value. `exclusive` controls whether the service owns
+/// every matching identifier.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[config_example_generator(
 	filename = "tuwunel-example.toml",
@@ -4723,10 +4924,20 @@ impl Config {
 		Ok(config)
 	}
 
+	/// Validates the complete configuration.
+	///
+	/// The startup checks emit warnings for deprecated or risky settings and
+	/// reject invalid combinations. Reload-specific comparisons are performed
+	/// by the configuration manager separately.
 	pub fn check(&self) -> Result { check(self) }
 }
 
 impl TlsConfig {
+	/// Returns the configured TLS certificate and key paths together.
+	///
+	/// A pair is returned only when both options are present. Startup
+	/// validation rejects a configuration containing only one of the two
+	/// paths.
 	#[must_use]
 	pub fn get_tls_cert_key(&self) -> Option<(&Path, &Path)> {
 		let cert = self.certs.as_ref()?;
@@ -4923,6 +5134,10 @@ pub fn default_log() -> String {
 		.to_owned()
 }
 
+/// Returns the default tracing span-event mode.
+///
+/// The value is `none`, which disables span lifecycle event emission. It is
+/// used when `log_span_events` is omitted.
 #[must_use]
 pub fn default_log_span_events() -> String { "none".into() }
 
@@ -4980,6 +5195,10 @@ fn default_rocksdb_bottommost_compression_level() -> i32 { 32767 }
 
 fn default_rocksdb_stats_level() -> u8 { 1 }
 
+/// Returns the default Matrix room version.
+///
+/// Room version 11 is selected when `default_room_version` is omitted. The
+/// value is returned without consulting runtime configuration.
 // I know, it's a great name
 #[must_use]
 #[inline]

--- a/src/core/config/net.rs
+++ b/src/core/config/net.rs
@@ -23,6 +23,10 @@ pub(super) struct ListeningAddr {
 	pub(super) addrs: Either<IpAddr, Vec<IpAddr>>,
 }
 
+/// Interprets the configured Unix socket permission digits as an octal mode.
+///
+/// The returned value is suitable for applying to a newly created socket. An
+/// invalid octal digit produces a configuration error.
 #[implement(super::Config)]
 pub fn get_unix_socket_perms(&self) -> Result<u32> {
 	let octal_perms = self.unix_socket_perms.to_string();
@@ -32,6 +36,11 @@ pub fn get_unix_socket_perms(&self) -> Result<u32> {
 	Ok(socket_perms)
 }
 
+/// Builds every configured TCP listener address.
+///
+/// The result is the Cartesian product of the configured hosts and ports. When
+/// neither TCP addresses nor a Unix socket are configured, loopback hosts
+/// apply.
 #[must_use]
 #[implement(super::Config)]
 pub fn get_bind_addrs(&self) -> Vec<SocketAddr> {
@@ -83,6 +92,10 @@ fn get_bind_ports(&self) -> Vec<u16> {
 #[must_use]
 pub fn is_address_defaulted(&self) -> bool { self.address.is_none() }
 
+/// Determines whether a remote server name is forbidden.
+///
+/// The local server name is always permitted. Otherwise a deny-list match or an
+/// active allow-list miss forbids the destination.
 #[implement(super::Config)]
 #[must_use]
 pub fn is_forbidden_remote_server_name(&self, server_name: &ServerName) -> bool {

--- a/src/core/config/proxy.rs
+++ b/src/core/config/proxy.rs
@@ -32,14 +32,37 @@ use crate::Result;
 #[serde(rename_all = "snake_case")]
 pub enum ProxyConfig {
 	#[default]
+	/// Adds no application-configured proxy.
+	///
+	/// The HTTP client builder remains unchanged, so automatic system proxy
+	/// discovery may still apply. This is the default configuration.
 	None,
+
+	/// Routes every eligible request through one proxy.
+	///
+	/// The same proxy URL applies regardless of the request destination. The
+	/// URL is parsed while the configuration is loaded.
 	Global {
+		/// Identifies the proxy endpoint.
+		///
+		/// The URL may select any proxy scheme supported by the HTTP client. It
+		/// is converted into a request proxy during client construction.
 		#[serde(deserialize_with = "crate::utils::deserialize_from_str")]
 		url: Url,
 	},
+
+	/// Selects proxies using ordered domain rules.
+	///
+	/// Each rule may include or exclude wildcarded domains. The first rule that
+	/// accepts a request supplies its proxy URL.
 	ByDomain(Vec<PartialProxyConfig>),
 }
 impl ProxyConfig {
+	/// Builds the HTTP client's proxy configuration.
+	///
+	/// The default configuration returns no application proxy. Global and
+	/// domain-based configuration produce the corresponding `reqwest` proxy
+	/// selector.
 	pub fn to_proxy(&self) -> Result<Option<Proxy>> {
 		Ok(match self.clone() {
 			| Self::None => None,
@@ -55,6 +78,10 @@ impl ProxyConfig {
 	}
 }
 
+/// Associates one proxy URL with include and exclude patterns.
+///
+/// An empty include list matches every domain. When both lists match, the more
+/// specific wildcard pattern decides whether the proxy applies.
 #[derive(Clone, Debug, Deserialize)]
 pub struct PartialProxyConfig {
 	#[serde(deserialize_with = "crate::utils::deserialize_from_str")]
@@ -66,6 +93,11 @@ pub struct PartialProxyConfig {
 }
 impl PartialProxyConfig {
 	#[must_use]
+	/// Selects this rule's proxy URL for a request URL.
+	///
+	/// A URL without a domain does not match. Otherwise the most specific
+	/// include and exclude patterns compete, with inclusion required for a
+	/// result.
 	pub fn for_url(&self, url: &Url) -> Option<&Url> {
 		let domain = url.domain()?;
 		let mut included_because = None; // most specific reason it was included

--- a/src/core/config/room_version.rs
+++ b/src/core/config/room_version.rs
@@ -23,12 +23,21 @@ pub const EXPERIMENTAL_ROOM_VERSIONS: &[RoomVersionId] = &[];
 impl Config {
 	#[inline]
 	#[must_use]
+	/// Reports whether a room version is enabled by this configuration.
+	///
+	/// Stable versions are always enabled. Unstable and experimental versions
+	/// are included only when their respective configuration flags permit
+	/// them.
 	pub fn supported_room_version(&self, version: &RoomVersionId) -> bool {
 		self.supported_room_versions()
 			.any(|(supported_version, _)| &supported_version == version)
 	}
 
 	#[inline]
+	/// Iterates over the room versions enabled by this configuration.
+	///
+	/// Stable versions appear first, followed by permitted unstable and
+	/// experimental versions. Experimental entries are advertised as unstable.
 	pub fn supported_room_versions(
 		&self,
 	) -> impl Iterator<Item = (RoomVersionId, RoomVersionStability)> + '_ {

--- a/src/core/config/sources.rs
+++ b/src/core/config/sources.rs
@@ -10,11 +10,23 @@ use crate::{Result, implement};
 /// configuration.
 pub type Overrides = dyn Fn(Figment) -> Result<Figment> + Send + Sync;
 
-/// What a configuration is built from besides the environment, retained so a
-/// reload reproduces the sources the server started with.
+/// Retains the inputs used to assemble a server configuration.
+///
+/// Reloads reuse these paths and the optional override to reproduce startup
+/// behavior. Environment providers are added by the configuration loader
+/// itself.
 #[derive(Default)]
 pub struct Sources {
+	/// Lists configuration files in merge order.
+	///
+	/// Later paths overlay values from earlier paths. Reloads begin with this
+	/// same ordered sequence before adding any explicit extra paths.
 	pub paths: Vec<PathBuf>,
+
+	/// Applies an optional transform after the standard providers are merged.
+	///
+	/// The callback can add synthetic overrides after standard loading. Reloads
+	/// retain it so those values are not silently discarded.
 	pub overrides: Option<Box<Overrides>>,
 }
 

--- a/src/core/config/well_known.rs
+++ b/src/core/config/well_known.rs
@@ -12,6 +12,10 @@ use tuwunel_macros::implement;
 
 use crate::{Result, err, error::inspect_log};
 
+/// Builds the support contacts advertised through well-known discovery.
+///
+/// Named contact entries are converted first. Legacy single-contact fields
+/// append one additional contact when a support role is configured.
 #[implement(super::WellKnownConfig)]
 pub fn get_contacts(&self) -> Vec<Contact> {
 	let single_contact = self.support_role.clone().map(|role| Contact {
@@ -30,6 +34,10 @@ pub fn get_contacts(&self) -> Vec<Contact> {
 	contacts.chain(single_contact).collect()
 }
 
+/// Builds the localized support policies advertised through discovery.
+///
+/// Outer map keys remain policy identifiers. Each configured language entry is
+/// converted into the corresponding Matrix policy representation.
 #[implement(super::WellKnownConfig)]
 #[must_use]
 pub fn get_policies(&self) -> BTreeMap<String, Policies> {
@@ -52,6 +60,10 @@ pub fn get_policies(&self) -> BTreeMap<String, Policies> {
 		.collect()
 }
 
+/// Builds registration terms parameters from configured policy documents.
+///
+/// Policy identifiers and language keys are preserved in the Matrix UIA shape.
+/// An empty policy map returns `None` and does not require a terms stage.
 #[implement(super::Config)]
 #[must_use]
 pub fn login_terms_params(&self) -> Option<LoginTermsParams> {

--- a/src/core/error/err.rs
+++ b/src/core/error/err.rs
@@ -32,6 +32,11 @@
 //!    callsite and then returns the error with the same string. Caller has the
 //!    option of replacing `error!` with `debug_error!`.
 
+/// Constructs an error result through `err!`.
+///
+/// The supplied tokens select or format an [`Error`](crate::Error), then wrap
+/// it in [`std::result::Result::Err`]. Every input form accepted by `err!` is
+/// supported.
 #[macro_export]
 #[collapse_debuginfo(yes)]
 macro_rules! Err {
@@ -40,6 +45,11 @@ macro_rules! Err {
 	};
 }
 
+/// Constructs a core error from structured or formatted input.
+///
+/// Variant forms preserve typed Matrix, HTTP, and configuration context.
+/// Forms containing a tracing level also emit the formatted fields before
+/// returning the error.
 #[macro_export]
 #[collapse_debuginfo(yes)]
 macro_rules! err {
@@ -151,6 +161,10 @@ macro_rules! err_log {
 	}}
 }
 
+/// Resolves an error macro level to a tracing level.
+///
+/// Debug-sensitive warning and error levels fall back to `DEBUG` outside debug
+/// logging mode. Fixed warning and error inputs retain their respective levels.
 #[macro_export]
 #[collapse_debuginfo(yes)]
 macro_rules! err_lev {
@@ -202,6 +216,11 @@ impl Visit for Visitor<'_> {
 	}
 }
 
+/// Dispatches structured error fields and records their formatted message.
+///
+/// Enabled tracing subscribers receive an event at the supplied call site, and
+/// the tracing-log bridge receives the same values. The visitor then appends
+/// those values to `out` for construction of the returned error.
 pub fn visit(
 	out: &mut String,
 	level: Level,

--- a/src/core/error/log.rs
+++ b/src/core/error/log.rs
@@ -19,6 +19,11 @@ pub fn error_chain(e: &dyn StdError) -> String {
 		.join("; caused by: ")
 }
 
+/// Logs an error and recovers with a default value in an infallible result.
+///
+/// The input is converted to [`Error`] and emitted through display formatting.
+/// The returned `Ok` contains [`Default::default`] for the requested value
+/// type.
 #[inline]
 pub fn else_log<T, E>(error: E) -> Result<T, Infallible>
 where
@@ -28,6 +33,12 @@ where
 	Ok(default_log(error))
 }
 
+/// Debug-logs an error and recovers with a default value in an infallible
+/// result.
+///
+/// The input is converted to [`Error`] and emitted through the debug-aware
+/// logging path. The returned `Ok` contains [`Default::default`] for the
+/// requested value type.
 #[inline]
 pub fn else_debug_log<T, E>(error: E) -> Result<T, Infallible>
 where
@@ -37,6 +48,10 @@ where
 	Ok(default_debug_log(error))
 }
 
+/// Logs an error and returns a default value.
+///
+/// The input is converted to [`Error`] before display-formatted logging. The
+/// result is independent of the error and comes from [`Default::default`].
 #[inline]
 pub fn default_log<T, E>(error: E) -> T
 where
@@ -48,6 +63,11 @@ where
 	T::default()
 }
 
+/// Debug-logs an error and returns a default value.
+///
+/// The input is converted to [`Error`] before using the debug-aware logging
+/// path. The result is independent of the error and comes from
+/// [`Default::default`].
 #[inline]
 pub fn default_debug_log<T, E>(error: E) -> T
 where
@@ -59,6 +79,10 @@ where
 	T::default()
 }
 
+/// Converts and logs an error while returning the converted value.
+///
+/// Display-formatted logging occurs after conversion to [`Error`]. The same
+/// converted error is returned for propagation by combinator chains.
 #[inline]
 pub fn map_log<E>(error: E) -> Error
 where
@@ -69,6 +93,10 @@ where
 	error
 }
 
+/// Converts and debug-logs an error while returning the converted value.
+///
+/// Debug-aware logging occurs after conversion to [`Error`]. The same converted
+/// error is returned for propagation by combinator chains.
 #[inline]
 pub fn map_debug_log<E>(error: E) -> Error
 where
@@ -79,14 +107,26 @@ where
 	error
 }
 
+/// Logs an error's display representation at error level.
+///
+/// The value is borrowed and otherwise left unchanged. Level dispatch is
+/// delegated to [`inspect_log_level`].
 #[inline]
 pub fn inspect_log<E: fmt::Display>(error: &E) { inspect_log_level(error, Level::ERROR); }
 
+/// Logs an error's debug representation through the debug-aware error path.
+///
+/// The value is borrowed and otherwise left unchanged. Level dispatch is
+/// delegated to [`inspect_debug_log_level`].
 #[inline]
 pub fn inspect_debug_log<E: fmt::Debug>(error: &E) {
 	inspect_debug_log_level(error, Level::ERROR);
 }
 
+/// Logs a display-formatted error at the selected tracing level.
+///
+/// Each tracing level maps to its corresponding project logging macro. The
+/// value is borrowed and otherwise left unchanged.
 #[inline]
 pub fn inspect_log_level<E: fmt::Display>(error: &E, level: Level) {
 	use crate::{debug, error, info, trace, warn};
@@ -100,6 +140,11 @@ pub fn inspect_log_level<E: fmt::Display>(error: &E, level: Level) {
 	}
 }
 
+/// Logs a debug-formatted error at the selected debug-aware tracing level.
+///
+/// Error, warning, and information inputs use their debug-sensitive logging
+/// macros, while debug and trace use fixed levels. The value is borrowed and
+/// otherwise left unchanged.
 #[inline]
 pub fn inspect_debug_log_level<E: fmt::Debug>(error: &E, level: Level) {
 	use crate::{debug, debug_error, debug_info, debug_warn, trace};

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -14,97 +14,310 @@ use std::{
 pub use self::{err::visit, log::*};
 use crate::utils::{assert_ref_unwind_safe, assert_send, assert_sync, assert_unwind_safe};
 
+/// Unifies failures raised by the core crate.
+///
+/// Variants preserve typed causes where available and carry contextual text for
+/// domain-specific failures. Conversion implementations allow callers to
+/// propagate common dependency errors with `?`.
 #[derive(thiserror::Error)]
 pub enum Error {
+	/// Carries an arbitrary panic payload.
+	///
+	/// The payload is protected by a mutex so the error remains shareable
+	/// across unwind boundaries. Use the panic helpers to resume unwinding or
+	/// inspect it.
 	#[error("PANIC!")]
 	PanicAny(Mutex<Box<dyn Any + Send>>),
+
+	/// Carries a panic payload and its extracted static message.
+	///
+	/// The message supports diagnostics without consuming the payload. The
+	/// mutex keeps the payload available across unwind boundaries.
 	#[error("PANIC! {0}")]
 	Panic(&'static str, Mutex<Box<dyn Any + Send + 'static>>),
 
 	// std
+	/// Reports a formatting failure.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	Fmt(#[from] std::fmt::Error),
+
+	/// Reports an invalid UTF-8 byte sequence while constructing a string.
+	///
+	/// Automatic conversion preserves the original bytes and source error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	FromUtf8(#[from] std::string::FromUtf8Error),
+
+	/// Reports an input or output failure.
+	///
+	/// Automatic conversion preserves the original I/O error and its kind. HTTP
+	/// response mapping may use the contained error kind.
 	#[error("I/O error: {0}")]
 	Io(#[from] std::io::Error),
+
+	/// Reports a floating-point parsing failure.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	ParseFloat(#[from] std::num::ParseFloatError),
+
+	/// Reports an integer parsing failure.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	ParseInt(#[from] std::num::ParseIntError),
+
+	/// Carries a dynamically typed standard error.
+	///
+	/// The boxed source must be safe to send and share between threads. Its
+	/// display text and source chain remain available for diagnostics.
 	#[error(transparent)]
 	Std(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+	/// Reports a system clock value earlier than the requested reference time.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	SystemTime(#[from] std::time::SystemTimeError),
+
+	/// Reports failure to access thread-local state.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	ThreadAccessError(#[from] std::thread::AccessError),
+
+	/// Reports an integer conversion outside the destination range.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	TryFromInt(#[from] std::num::TryFromIntError),
+
+	/// Reports conversion from a slice with an incompatible length.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	TryFromSlice(#[from] std::array::TryFromSliceError),
+
+	/// Reports an invalid borrowed UTF-8 byte sequence.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	Utf8(#[from] std::str::Utf8Error),
 
 	// third-party
+	/// Reports that a fixed-capacity collection cannot accept another item.
+	///
+	/// Automatic conversion preserves the original capacity error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	CapacityError(#[from] arrayvec::CapacityError),
+
+	/// Reports failure to parse Cargo manifest data.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	CargoToml(#[from] cargo_toml::Error),
+
+	/// Reports a command-line parsing or presentation failure.
+	///
+	/// Automatic conversion preserves the original Clap error. Its display text
+	/// is forwarded unchanged.
 	#[error(transparent)]
 	Clap(#[from] clap::error::Error),
+
+	/// Reports a Unix system error number.
+	///
+	/// Automatic conversion preserves the original error number. Its display
+	/// text is forwarded unchanged.
 	#[cfg(unix)]
 	#[error(transparent)]
 	Errno(#[from] nix::errno::Errno),
+
+	/// Reports rejection of a required Axum request extension.
+	///
+	/// Automatic conversion preserves the extractor rejection. Its display text
+	/// is forwarded unchanged.
 	#[error(transparent)]
 	Extension(#[from] axum::extract::rejection::ExtensionRejection),
+
+	/// Reports a configuration extraction failure.
+	///
+	/// The boxed Figment error preserves its complete source and diagnostic
+	/// context. A dedicated conversion boxes it for ordinary `?` propagation.
 	#[error(transparent)]
 	Figment(Box<figment::error::Error>),
+
+	/// Reports failure to deserialize an HTML form.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	HtmlFormDe(#[from] serde_html_form::de::Error),
+
+	/// Reports failure to serialize an HTML form.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	HtmlFormSer(#[from] serde_html_form::ser::Error),
+
+	/// Reports failure to construct an HTTP value.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	Http(#[from] http::Error),
+
+	/// Reports an invalid HTTP header value.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	HttpHeader(#[from] http::header::InvalidHeaderValue),
+
+	/// Reports failure of a spawned asynchronous task.
+	///
+	/// The Tokio join error records cancellation and panic state. Panic helpers
+	/// can recover its payload when the task panicked.
 	#[error("Join error: {0}")]
 	JoinError(#[from] tokio::task::JoinError),
+
+	/// Reports failure to serialize or deserialize JSON.
+	///
+	/// Automatic conversion preserves the original source error. Matrix error
+	/// mapping classifies this variant as invalid JSON.
 	#[error(transparent)]
 	Json(#[from] serde_json::Error),
+
+	/// Reports failure to parse a Matrix-compatible JavaScript integer.
+	///
+	/// Automatic conversion preserves the re-exported integer error. Matrix
+	/// response mapping treats it as a bad request.
 	#[error(transparent)]
 	JsParseInt(#[from] ruma::JsParseIntError), // js_int re-export
+
+	/// Reports a value outside the Matrix JavaScript-integer range.
+	///
+	/// Automatic conversion preserves the re-exported conversion error. Matrix
+	/// response mapping treats it as a bad request.
 	#[error(transparent)]
 	JsTryFromInt(#[from] ruma::JsTryFromIntError), // js_int re-export
+
+	/// Reports an object-storage operation failure.
+	///
+	/// Automatic conversion preserves the backend source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	ObjectStore(#[from] object_store::Error),
+
+	/// Reports rejection of an Axum path parameter.
+	///
+	/// Automatic conversion preserves the extractor rejection. Its display text
+	/// is forwarded unchanged.
 	#[error(transparent)]
 	Path(#[from] axum::extract::rejection::PathRejection),
+
+	/// Reports access to a poisoned synchronization primitive.
+	///
+	/// The stored text reports the poisoning without retaining the guard.
+	/// Poison conversion supplies the originating error text.
 	#[error("Mutex poisoned: {0}")]
 	Poison(Cow<'static, str>),
+
+	/// Reports an invalid regular expression.
+	///
+	/// Automatic conversion preserves the original source error. The formatted
+	/// message identifies the regex failure.
 	#[error("Regex error: {0}")]
 	Regex(#[from] regex::Error),
+
+	/// Reports an HTTP client request failure.
+	///
+	/// Automatic conversion preserves status and transport details from
+	/// Reqwest. HTTP response mapping reuses its status when one is available.
 	#[error("Request error: {0}")]
 	Reqwest(#[from] reqwest::Error),
+
+	/// Reports a custom deserialization failure.
+	///
+	/// The message may borrow static text or own formatted context. It is
+	/// exposed directly as the error display.
 	#[error("{0}")]
 	SerdeDe(Cow<'static, str>),
+
+	/// Reports a custom serialization failure.
+	///
+	/// The message may borrow static text or own formatted context. It is
+	/// exposed directly as the error display.
 	#[error("{0}")]
 	SerdeSer(Cow<'static, str>),
+
+	/// Reports failure to deserialize TOML.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	TomlDe(#[from] toml::de::Error),
+
+	/// Reports failure to serialize TOML.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	TomlSer(#[from] toml::ser::Error),
+
+	/// Reports an invalid tracing filter directive.
+	///
+	/// Automatic conversion preserves the filter parser's source error. The
+	/// formatted message identifies the tracing subsystem.
 	#[error("Tracing filter error: {0}")]
 	TracingFilter(#[from] tracing_subscriber::filter::ParseError),
+
+	/// Reports failure to reload a tracing layer.
+	///
+	/// Automatic conversion preserves the reload source error. The formatted
+	/// message identifies the tracing subsystem.
 	#[error("Tracing reload error: {0}")]
 	TracingReload(#[from] tracing_subscriber::reload::Error),
+
+	/// Reports rejection of a typed HTTP header.
+	///
+	/// Automatic conversion preserves the extractor rejection. Its display text
+	/// is forwarded unchanged.
 	#[error(transparent)]
 	TypedHeader(#[from] axum_extra::typed_header::TypedHeaderRejection),
+
+	/// Reports failure to parse a URL.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	UrlParse(#[from] url::ParseError),
+
+	/// Reports failure to serialize or deserialize YAML.
+	///
+	/// Automatic conversion preserves the original source error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	Yaml(#[from] serde_yaml::Error),
 
 	// ruma/tuwunel
+	/// Reports an arithmetic operation that cannot produce a valid result.
+	///
+	/// The message records contextual conversion, range, overflow, and
+	/// underflow failures. It can supplement lower-level typed numeric source
+	/// errors.
 	#[error("Arithmetic operation failed: {0}")]
 	Arithmetic(Cow<'static, str>),
 
@@ -115,52 +328,166 @@ pub enum Error {
 	/// cause without grepping the message text.
 	#[error("Auth check failed: {0}")]
 	AuthCheck(Box<Self>),
+
+	/// Reports a legacy structured Matrix request error.
+	///
+	/// The variant pairs a Matrix error kind with static public text. Response
+	/// mapping derives the appropriate HTTP status from that kind.
 	#[error("{0}: {1}")]
 	BadRequest(ruma::api::error::ErrorKind, &'static str), //TODO: remove
+
+	/// Reports an invalid or unusable response from a remote server.
+	///
+	/// The message carries protocol context suitable for diagnostics. No typed
+	/// remote response is retained.
 	#[error("{0}")]
 	BadServerResponse(Cow<'static, str>),
+
+	/// Reports invalid canonical JSON.
+	///
+	/// Automatic conversion preserves the original canonicalization error.
+	/// Matrix error mapping classifies this variant as invalid JSON.
 	#[error(transparent)]
 	CanonicalJson(#[from] ruma::CanonicalJsonError),
+
+	/// Reports an invalid configuration directive.
+	///
+	/// The static directive name identifies the setting and the accompanying
+	/// message explains why its value cannot be used.
 	#[error("There was a problem with the '{0}' directive in your configuration: {1}")]
 	Config(&'static str, Cow<'static, str>),
+
+	/// Reports a resource conflict.
+	///
+	/// This variant currently represents an already occupied room alias. HTTP
+	/// response mapping emits a conflict status.
 	#[error("{0}")]
 	Conflict(Cow<'static, str>), // This is only needed for when a room alias already exists
+
+	/// Reports an invalid Matrix content-disposition header.
+	///
+	/// Automatic conversion preserves the original parser error. Its display
+	/// text is forwarded unchanged.
 	#[error(transparent)]
 	ContentDisposition(#[from] ruma::http_headers::ContentDispositionParseError),
+
+	/// Reports a database operation or invariant failure.
+	///
+	/// The message carries storage context without exposing it in sanitized
+	/// client-facing output. Database failures default to an internal status.
 	#[error("{0}")]
 	Database(Cow<'static, str>),
+
+	/// Reports use of a feature disabled by server configuration.
+	///
+	/// The stored feature name is included in the public message. Matrix
+	/// response mapping assigns the matching feature-disabled error kind.
 	#[error("Feature '{0}' is not available on this server.")]
 	FeatureDisabled(Cow<'static, str>),
+
+	/// Reports an error response received from a federated server.
+	///
+	/// The variant preserves both the origin and its structured Matrix error.
+	/// Response mapping forwards the remote status and error kind.
 	#[error("Remote server {0} responded with: {1}")]
 	Federation(ruma::OwnedServerName, ruma::api::error::Error),
+
+	/// Carries a preconstructed HTTP status and JSON response body.
+	///
+	/// Response mapping preserves the caller-selected status. The formatted
+	/// JSON becomes the message of a standard Matrix error response.
 	#[error("{0}: {1:#?}")]
 	HttpJson(http::StatusCode, axum::Json<serde_json::Value>),
+
+	/// Reports an invariant violation in a room's persisted state.
+	///
+	/// The static message names the failed invariant and the room identifier
+	/// locates the affected state.
 	#[error("{0} in {1}")]
 	InconsistentRoomState(&'static str, ruma::OwnedRoomId),
+
+	/// Reports failure to convert a Matrix response into HTTP form.
+	///
+	/// Automatic conversion preserves the original Ruma source error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	IntoHttp(#[from] ruma::api::error::IntoHttpError),
+
+	/// Reports an LDAP operation failure.
+	///
+	/// The message records directory-service context not represented by a
+	/// common typed source. Response mapping treats it as an internal error.
 	#[error("{0}")]
 	Ldap(Cow<'static, str>),
+
+	/// Reports an invalid Matrix content URI.
+	///
+	/// Automatic conversion preserves the original URI error. Its display text
+	/// is forwarded unchanged.
 	#[error(transparent)]
 	Mxc(#[from] ruma::MxcUriError),
+
+	/// Reports an invalid Matrix identifier.
+	///
+	/// Automatic conversion preserves the original identifier parser error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	Mxid(#[from] ruma::IdParseError),
+
+	/// Reports invalid room power-level content or arithmetic.
+	///
+	/// Automatic conversion preserves the original Ruma power-level error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	PowerLevels(#[from] ruma::events::room::power_levels::PowerLevelsError),
+
+	/// Reports failure to redact canonical JSON from a remote server.
+	///
+	/// The variant records the origin alongside the invalid canonical field.
+	/// The formatted message keeps both pieces of context.
 	#[error("from {0}: {1}")]
 	Redaction(ruma::OwnedServerName, ruma::canonical_json::CanonicalJsonFieldError),
+
+	/// Carries a structured Matrix client error response.
+	///
+	/// The variant stores the Matrix error kind, public message, and preferred
+	/// HTTP status. Response mapping may refine the status from the kind.
 	#[error("{0}: {1}")]
 	Request(ruma::api::error::ErrorKind, Cow<'static, str>, http::StatusCode),
+
+	/// Reports a structured Matrix API error.
+	///
+	/// Automatic conversion preserves the Ruma status, kind, and message.
+	/// Response mapping forwards those structured fields.
 	#[error(transparent)]
 	Ruma(#[from] ruma::api::error::Error),
+
+	/// Reports a Matrix signature verification failure.
+	///
+	/// Automatic conversion preserves the original verification error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	Signatures(#[from] ruma::signatures::VerificationError),
+
+	/// Reports invalid JSON encountered during signature processing.
+	///
+	/// Automatic conversion preserves the signature library's JSON error. Its
+	/// display text is forwarded unchanged.
 	#[error(transparent)]
 	SignaturesJson(#[from] ruma::signatures::JsonError),
+
+	/// Requests an interactive-authentication challenge response.
+	///
+	/// The contained UIAA information is serialized for the client rather than
+	/// treated as an opaque internal failure.
 	#[error("uiaa")]
 	Uiaa(ruma::api::client::uiaa::UiaaInfo),
 
 	// unique / untyped
+	/// Reports an untyped core failure.
+	///
+	/// The message may borrow static text or own formatted context. This
+	/// fallback is used when no structured variant represents the failure.
 	#[error("{0}")]
 	Err(Cow<'static, str>),
 }
@@ -171,16 +498,30 @@ static _IS_UNWIND_SAFE: () = assert_unwind_safe::<Error>();
 static _IS_REF_UNWIND_SAFE: () = assert_ref_unwind_safe::<Error>();
 
 impl Error {
+	/// Captures the operating system's most recent error for the current
+	/// thread.
+	///
+	/// The error is sampled when this function is called and wrapped as
+	/// [`Error::Io`]. Platform-specific code remains available through the
+	/// source.
 	#[inline]
 	#[must_use]
 	pub fn from_errno() -> Self { Self::Io(std::io::Error::last_os_error()) }
 
+	/// Constructs a database error from static diagnostic text.
+	///
+	/// The error helper records the call site while preserving the supplied
+	/// message. Callers exposing it publicly can use
+	/// [`Error::sanitized_message`].
 	//#[deprecated]
 	pub fn bad_database(message: &'static str) -> Self {
 		crate::err!(Database(error!("{message}")))
 	}
 
-	/// Sanitizes public-facing errors that can leak sensitive information.
+	/// Produces an error message safe for public responses.
+	///
+	/// Database and I/O details are replaced with generic text to avoid leaking
+	/// sensitive context. Other variants retain their normal message.
 	pub fn sanitized_message(&self) -> String {
 		match self {
 			| Self::Database(..) => String::from("Database error occurred."),
@@ -189,7 +530,11 @@ impl Error {
 		}
 	}
 
-	/// Generate the error message string.
+	/// Formats the diagnostic message for this error.
+	///
+	/// Federation errors include their origin and Ruma errors use their Matrix
+	/// response message. Other variants use their
+	/// [`Display`](std::fmt::Display) implementation.
 	pub fn message(&self) -> String {
 		match self {
 			| Self::Federation(origin, error) => format!("Answer from {origin}: {error}"),
@@ -198,7 +543,10 @@ impl Error {
 		}
 	}
 
-	/// Returns the Matrix error code / error kind
+	/// Returns the Matrix error kind represented by this error.
+	///
+	/// Structured request and federation variants preserve their supplied kind.
+	/// Unclassified internal errors map to `M_UNKNOWN`.
 	#[inline]
 	pub fn kind(&self) -> ruma::api::error::ErrorKind {
 		use ruma::api::error::{
@@ -217,8 +565,11 @@ impl Error {
 		}
 	}
 
-	/// Returns the HTTP error code or closest approximation based on error
-	/// variant.
+	/// Returns the HTTP status represented by this error.
+	///
+	/// Structured variants preserve or derive their protocol status, while I/O
+	/// and client errors use their available status metadata. Unclassified
+	/// failures map to an internal-server-error status.
 	pub fn status_code(&self) -> http::StatusCode {
 		use http::StatusCode;
 
@@ -242,10 +593,11 @@ impl Error {
 		}
 	}
 
-	/// Returns true for "not found" errors. This means anything that qualifies
-	/// as a "not found" from any variant's contained error type. This call is
-	/// often used as a special case to eliminate a contained Option with a
-	/// Result where Ok(None) is instead Err(e) if e.is_not_found().
+	/// Tests whether this error maps to an HTTP not-found status.
+	///
+	/// The test includes contained error types whose status mapping yields 404.
+	/// Callers can use it to treat `Err` as the absent case in place of a
+	/// nested `Option`.
 	#[inline]
 	pub fn is_not_found(&self) -> bool { self.status_code() == http::StatusCode::NOT_FOUND }
 }
@@ -277,13 +629,25 @@ impl From<Infallible> for Error {
 	}
 }
 
+/// Marks an impossible [`Infallible`] error path.
+///
+/// The argument cannot be constructed in safe code, so reaching this function
+/// indicates a violated invariant.
+///
+/// # Panics
+///
+/// Always panics because an `Infallible` error cannot legitimately exist.
 #[cold]
 #[inline(never)]
 pub fn infallible(_e: &Infallible) {
 	panic!("infallible error should never exist");
 }
 
-/// Convenience functor for fundamental Error::sanitized_message(); see member.
+/// Produces a public-safe message from an owned error.
+///
+/// Its by-value signature adapts [`Error::sanitized_message`] for iterator and
+/// future combinators that consume their item. Sanitization behavior is
+/// identical to the method.
 #[inline]
 #[must_use]
 #[expect(clippy::needless_pass_by_value)]

--- a/src/core/error/panic.rs
+++ b/src/core/error/panic.rs
@@ -10,15 +10,36 @@ impl UnwindSafe for Error {}
 impl RefUnwindSafe for Error {}
 
 impl Error {
+	/// Starts a panic using the boxed value derived from this error.
+	///
+	/// Explicit panic variants and task joins that ended by panicking supply
+	/// their stored boxed value. Other errors are boxed as typed values.
+	///
+	/// # Panics
+	///
+	/// Always panics by design.
 	#[inline]
 	pub fn panic(self) -> ! { panic_any(self.into_panic()) }
 
+	/// Wraps a caught panic payload as an error.
+	///
+	/// A static string message is extracted when the payload exposes one. The
+	/// original payload remains available for later unwinding.
 	#[must_use]
 	#[inline]
 	pub fn from_panic(e: Box<dyn Any + Send + 'static>) -> Self {
 		Self::Panic(debug::panic_str(&e), e.into())
 	}
 
+	/// Converts this error into a boxed value for panicking.
+	///
+	/// Explicit panic variants and task joins that ended by panicking yield
+	/// their stored boxed value. Other variants are boxed as typed values.
+	///
+	/// # Panics
+	///
+	/// Panics if a stored panic payload's mutex is poisoned or a task join was
+	/// cancelled instead of ending with a panic.
 	#[inline]
 	pub fn into_panic(self) -> Box<dyn Any + Send> {
 		match self {
@@ -29,7 +50,15 @@ impl Error {
 		}
 	}
 
-	/// Get the panic message string.
+	/// Extracts a static message from a carried panic payload.
+	///
+	/// Non-panic errors return `None`. Unsupported payload representations
+	/// produce an empty string, and the error is consumed while inspecting the
+	/// payload.
+	///
+	/// # Panics
+	///
+	/// Panics if a stored panic payload's mutex is poisoned.
 	#[inline]
 	pub fn panic_str(self) -> Option<&'static str> {
 		self.is_panic().then(|| {
@@ -38,7 +67,10 @@ impl Error {
 		})
 	}
 
-	/// Check if the Error is trafficking a panic object.
+	/// Tests whether this error carries a panic payload.
+	///
+	/// Explicit panic variants always match. A task-join error matches only
+	/// when the joined task ended by panicking.
 	#[inline]
 	pub fn is_panic(&self) -> bool {
 		match &self {

--- a/src/core/info/cargo.rs
+++ b/src/core/info/cargo.rs
@@ -42,6 +42,15 @@ static FEATURES: OnceLock<Vec<String>> = OnceLock::new();
 static DEPENDENCIES: OnceLock<DepsSet> = OnceLock::new();
 
 #[must_use]
+/// Lists dependency names declared by the workspace manifest.
+///
+/// Names borrow from the lazily parsed dependency map. Their ordering follows
+/// the map's deterministic key order.
+///
+/// # Panics
+///
+/// Panics when the embedded workspace manifest is invalid or lacks its
+/// workspace section.
 pub fn dependencies_names() -> Vec<&'static str> {
 	dependencies()
 		.keys()
@@ -49,6 +58,15 @@ pub fn dependencies_names() -> Vec<&'static str> {
 		.collect()
 }
 
+/// Returns dependencies declared by the embedded workspace manifest.
+///
+/// The manifest is parsed once on first access and the ordered map is retained
+/// for the process lifetime. Package-specific dependency tables are not merged
+/// here.
+///
+/// # Panics
+///
+/// Panics when the manifest is invalid or lacks its workspace section.
 pub fn dependencies() -> &'static DepsSet {
 	DEPENDENCIES.get_or_init(|| {
 		init_dependencies().unwrap_or_else(|e| panic!("Failed to initialize dependencies: {e}"))

--- a/src/core/info/mod.rs
+++ b/src/core/info/mod.rs
@@ -7,5 +7,14 @@ pub mod version;
 
 pub use tuwunel_macros::rustc_flags_capture;
 
+/// Names the root crate containing this module.
+///
+/// The value is derived at compile time from `module_path!`. It includes the
+/// full crate name before any Rust module separator.
 pub const MODULE_ROOT: &str = const_str::split!(std::module_path!(), "::")[0];
+
+/// Names the workspace crate-family prefix.
+///
+/// The value is the portion of [`MODULE_ROOT`] before its first underscore. It
+/// is shared by crates following the workspace naming convention.
 pub const CRATE_PREFIX: &str = const_str::split!(MODULE_ROOT, '_')[0];

--- a/src/core/info/version.rs
+++ b/src/core/info/version.rs
@@ -17,12 +17,24 @@ static USER_AGENT: OnceLock<String> = OnceLock::new();
 
 #[inline]
 #[must_use]
+/// Returns the compiled product branding.
+///
+/// The value is fixed at build time and remains valid for the process lifetime.
+/// It is used wherever a human-readable server name is required.
 pub fn name() -> &'static str { BRANDING }
 
 #[inline]
+/// Returns the detailed compiled version string.
+///
+/// Initialization occurs once on first access. Development builds may include
+/// source-control revision detail in addition to the semantic version.
 pub fn version() -> &'static str { VERSION.get_or_init(init_version) }
 
 #[inline]
+/// Returns the HTTP user-agent value for this build.
+///
+/// Initialization occurs once on first access. The value combines product and
+/// version information into the process-wide client identifier.
 pub fn user_agent() -> &'static str { USER_AGENT.get_or_init(init_user_agent) }
 
 fn init_user_agent() -> String { format!("{}/{}", name(), semantic()) }

--- a/src/core/log/capture/data.rs
+++ b/src/core/log/capture/data.rs
@@ -4,21 +4,60 @@ use tracing_core::{Event, span::Current};
 use super::{Layer, layer::Value};
 use crate::{info, utils::string::EMPTY};
 
+/// Presents one tracing event to a capture filter or callback.
+///
+/// The value borrows tracing metadata and any fields recorded for the current
+/// capture phase. Accessor methods provide common event attributes with empty
+/// fallbacks.
 pub struct Data<'a> {
+	/// Capture layer that observed the event.
+	///
+	/// The reference identifies the subscriber layer that dispatched the event.
 	pub layer: &'a Layer,
+
+	/// Tracing event being filtered or delivered.
+	///
+	/// Its metadata supplies the level, target, and module path.
 	pub event: &'a Event<'a>,
+
+	/// Subscriber's current span at the time of the event.
+	///
+	/// Metadata is absent when no span is entered or the subscriber does not
+	/// track the current span.
 	pub current: &'a Current,
+
+	/// Field names and formatted values recorded from the event.
+	///
+	/// Values are populated for callback delivery and can be empty during
+	/// filtering.
 	pub values: &'a [Value],
+
+	/// Span names in the event's subscriber scope.
+	///
+	/// Scope names are populated while filtering and can be empty during
+	/// callback delivery.
 	pub scope: &'a [&'static str],
 }
 
 impl Data<'_> {
+	/// Reports whether the event originated in a Tuwunel crate.
+	///
+	/// The check compares the event module path with the shared crate prefix.
+	/// An event without module metadata does not match.
 	#[must_use]
 	pub fn our_modules(&self) -> bool { self.mod_name().starts_with(info::CRATE_PREFIX) }
 
+	/// Returns the event's tracing level.
+	///
+	/// The level is copied from static tracing metadata and does not depend on
+	/// the active subscriber filter.
 	#[must_use]
 	pub fn level(&self) -> Level { *self.event.metadata().level() }
 
+	/// Returns the event's Rust module path.
+	///
+	/// Events without module metadata produce an empty string. The returned
+	/// value borrows static tracing metadata.
 	#[must_use]
 	pub fn mod_name(&self) -> &str {
 		self.event
@@ -27,6 +66,10 @@ impl Data<'_> {
 			.unwrap_or_default()
 	}
 
+	/// Returns the current span's name.
+	///
+	/// An empty string is returned when the subscriber has no current span or
+	/// no metadata for it.
 	#[must_use]
 	pub fn span_name(&self) -> &str {
 		self.current
@@ -34,6 +77,10 @@ impl Data<'_> {
 			.map_or(EMPTY, |s| s.name())
 	}
 
+	/// Returns the event's recorded message field.
+	///
+	/// The first field named `message` is selected. Events without that field
+	/// produce an empty string.
 	#[must_use]
 	pub fn message(&self) -> &str {
 		self.values

--- a/src/core/log/capture/layer.rs
+++ b/src/core/log/capture/layer.rs
@@ -7,6 +7,10 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
 use super::{Capture, Data, State};
 
+/// Tracing subscriber layer that dispatches events to active captures.
+///
+/// The layer evaluates each capture's filter before recording fields and
+/// running its callback. Capture registration is shared through `State`.
 pub struct Layer {
 	state: Arc<State>,
 }
@@ -16,11 +20,19 @@ struct Visitor {
 }
 
 type Values = ArrayVec<Value, 32>;
+/// Recorded tracing field name and formatted value.
+///
+/// Field names come from static callsite metadata. Values own their formatted
+/// text for the duration of callback delivery.
 pub type Value = (&'static str, String);
 
 type ScopeNames = ArrayVec<&'static str, 32>;
 
 impl Layer {
+	/// Creates a capture layer backed by shared registration state.
+	///
+	/// The shared state handle is cloned so captures registered through either
+	/// handle are visible to this subscriber layer.
 	#[inline]
 	pub fn new(state: &Arc<State>) -> Self { Self { state: state.clone() } }
 }

--- a/src/core/log/capture/mod.rs
+++ b/src/core/log/capture/mod.rs
@@ -1,7 +1,23 @@
+/// Captured tracing-event data and common accessors.
+///
+/// Values borrow the event, current span, and fields for one filter or callback
+/// invocation. They must not escape that invocation.
 pub mod data;
 mod guard;
+/// Tracing subscriber layer for ephemeral event captures.
+///
+/// The layer selects active captures, records event fields, and invokes their
+/// callbacks synchronously.
 pub mod layer;
+/// Shared registration state for active captures.
+///
+/// The state coordinates capture guards with the subscriber layer.
+/// Registrations are reference counted and protected for concurrent access.
 pub mod state;
+/// Callback constructors for formatting captured log events.
+///
+/// Helpers append HTML or Markdown lines to a shared formatter. A generic
+/// constructor accepts compatible formatting functions.
 pub mod util;
 
 use std::sync::{Arc, Mutex};
@@ -12,7 +28,19 @@ pub use layer::{Layer, Value};
 pub use state::State;
 pub use util::*;
 
+/// Predicate used to select tracing events for a capture.
+///
+/// Returning true delivers the event to the capture callback. Filters must be
+/// thread safe because tracing events can originate on any thread. They execute
+/// while registration state is read-locked and must not mutate captures on the
+/// same state.
 pub type Filter = dyn Fn(Data<'_>) -> bool + Send + Sync + 'static;
+
+/// Callback invoked for each tracing event selected by a capture.
+///
+/// The callback is serialized by the owning capture so mutable state can be
+/// updated safely. It executes while registration state is read-locked and must
+/// not mutate captures on the same state.
 pub type Closure = dyn FnMut(Data<'_>) + Send + Sync + 'static;
 
 /// Capture instance state.
@@ -38,11 +66,21 @@ impl Capture {
 		})
 	}
 
+	/// Creates one active registration for the lifetime of a scope guard.
+	///
+	/// Registration happens before the guard is returned. Multiple guards can
+	/// register the same capture, and dropping each guard removes its own
+	/// registration.
 	#[must_use]
 	pub fn start(self: &Arc<Self>) -> Guard {
 		self.state.add(self);
 		Guard { capture: self.clone() }
 	}
 
+	/// Removes one active registration for this capture.
+	///
+	/// Calling the method for an inactive capture has no effect. Other
+	/// registrations of the same capture remain active, and a callback already
+	/// in progress can finish before removal becomes observable.
 	pub fn stop(self: &Arc<Self>) { self.state.del(self); }
 }

--- a/src/core/log/capture/state.rs
+++ b/src/core/log/capture/state.rs
@@ -12,6 +12,10 @@ impl Default for State {
 }
 
 impl State {
+	/// Creates empty capture registration state.
+	///
+	/// No events are captured until a `Capture` is started against the returned
+	/// state. The state can then be shared with a subscriber layer.
 	#[must_use]
 	pub fn new() -> Self { Self { active: RwLock::new(Vec::new()) } }
 

--- a/src/core/log/capture/util.rs
+++ b/src/core/log/capture/util.rs
@@ -6,6 +6,11 @@ use super::{
 };
 use crate::Result;
 
+/// Builds a capture callback that appends HTML log lines.
+///
+/// Each event locks the shared output and formats its level, current span, and
+/// message. The callback owns the supplied output handle and panics if the lock
+/// is poisoned or formatting fails.
 pub fn fmt_html<S>(out: Arc<Mutex<S>>) -> Box<Closure>
 where
 	S: std::fmt::Write + Send + 'static,
@@ -13,6 +18,11 @@ where
 	fmt(fmt::html, out)
 }
 
+/// Builds a capture callback that appends Markdown log lines.
+///
+/// Each event locks the shared output and formats its level, current span, and
+/// message. The callback owns the supplied output handle and panics if the lock
+/// is poisoned or formatting fails.
 pub fn fmt_markdown<S>(out: Arc<Mutex<S>>) -> Box<Closure>
 where
 	S: std::fmt::Write + Send + 'static,
@@ -20,6 +30,11 @@ where
 	fmt(fmt::markdown, out)
 }
 
+/// Builds a capture callback around a compatible formatting function.
+///
+/// The output is locked for each event before the formatter is called. The
+/// returned callback panics if the lock is poisoned or the formatter returns an
+/// error.
 pub fn fmt<F, S>(fun: F, out: Arc<Mutex<S>>) -> Box<Closure>
 where
 	F: Fn(&mut S, &Level, &str, &str) -> Result + Send + Sync + Copy + 'static,

--- a/src/core/log/console.rs
+++ b/src/core/log/console.rs
@@ -26,6 +26,10 @@ static SYSTEMD_MODE: LazyLock<bool> =
 
 static TERMINAL_MODE: LazyLock<bool> = LazyLock::new(|| stdin().is_terminal());
 
+/// Routes formatted tracing events to console streams or the native journal.
+///
+/// Construction detects systemd stream mode and configured output preferences.
+/// Each event can then select a destination through `MakeWriter`.
 pub struct ConsoleWriter {
 	stdout: io::Stdout,
 	stderr: io::Stderr,
@@ -34,12 +38,30 @@ pub struct ConsoleWriter {
 	journal: Option<Journal>,
 }
 
+/// Writable destination selected for one formatted tracing event.
+///
+/// Console output delegates to the shared writer while journal output owns an
+/// entry buffer that submits when dropped.
 pub enum Sink<'a> {
+	/// Standard output or standard error through the shared console writer.
+	///
+	/// The writer selects the actual file descriptor from process and
+	/// configuration state.
 	Console(&'a ConsoleWriter),
+
+	/// Native journal entry associated with the event metadata.
+	///
+	/// Formatted bytes accumulate in the entry and are submitted when it is
+	/// dropped.
 	Journal(Entry<'a>),
 }
 
 impl ConsoleWriter {
+	/// Creates an output router from logging configuration and process state.
+	///
+	/// A detected journal stream or explicit setting selects standard error for
+	/// console output. Native journal submission is opened when enabled and
+	/// available.
 	#[must_use]
 	pub fn new(config: &Config) -> Self {
 		let journal_stream = get_journal_stream();
@@ -100,6 +122,11 @@ impl io::Write for &'_ ConsoleWriter {
 	}
 }
 
+/// Selects the configured tracing formatter for each console event.
+///
+/// Compact mode applies globally. Otherwise non-debug errors use the pretty
+/// formatter and remaining events use the full formatter. ANSI follows
+/// `log_colors` and is disabled for native journal submission.
 pub struct ConsoleFormat {
 	pretty: Format<Pretty>,
 	full: Format<Full>,
@@ -108,6 +135,11 @@ pub struct ConsoleFormat {
 }
 
 impl ConsoleFormat {
+	/// Creates console formatters from logging configuration.
+	///
+	/// The method configures ANSI output, thread identifiers, source locations,
+	/// and compact-mode selection. All formatter variants share the same ANSI
+	/// decision.
 	#[must_use]
 	pub fn new(config: &Config) -> Self {
 		let ansi = ansi_enabled(config);

--- a/src/core/log/fmt.rs
+++ b/src/core/log/fmt.rs
@@ -3,6 +3,10 @@ use std::fmt::Write;
 use super::{Level, color};
 use crate::Result;
 
+/// Appends one captured log event as an HTML line.
+///
+/// The level receives its level-specific Matrix color and each component is
+/// placed in a code element. A line break terminates the rendered entry.
 pub fn html<S>(out: &mut S, level: &Level, span: &str, msg: &str) -> Result
 where
 	S: Write + ?Sized,
@@ -18,6 +22,10 @@ where
 	Ok(())
 }
 
+/// Appends one captured log event as a Markdown line.
+///
+/// Level, span, and message are rendered as inline-code columns separated by
+/// spaces. A newline terminates the entry.
 pub fn markdown<S>(out: &mut S, level: &Level, span: &str, msg: &str) -> Result
 where
 	S: Write + ?Sized,
@@ -28,6 +36,10 @@ where
 	Ok(())
 }
 
+/// Appends one captured log event as a Markdown table row.
+///
+/// The level and span receive fixed-width alignment while the message remains
+/// left aligned. A newline terminates the row.
 pub fn markdown_table<S>(out: &mut S, level: &Level, span: &str, msg: &str) -> Result
 where
 	S: Write + ?Sized,
@@ -38,6 +50,10 @@ where
 	Ok(())
 }
 
+/// Appends the header for a captured-log Markdown table.
+///
+/// The header defines level, span, and message columns together with their
+/// alignment row. Callers can append rows with `markdown_table`.
 pub fn markdown_table_head<S>(out: &mut S) -> Result
 where
 	S: Write + ?Sized,

--- a/src/core/log/fmt_span.rs
+++ b/src/core/log/fmt_span.rs
@@ -2,6 +2,10 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use crate::Result;
 
+/// Parses a tracing span-lifecycle mode without case sensitivity.
+///
+/// Recognized names map to the corresponding `FmtSpan` flag. Unknown names
+/// return `FmtSpan::NONE` on the error side for use as a fallback.
 #[inline]
 pub fn from_str(str: &str) -> Result<FmtSpan, FmtSpan> {
 	match str.to_uppercase().as_str() {

--- a/src/core/log/journald.rs
+++ b/src/core/log/journald.rs
@@ -233,6 +233,11 @@ fn boundary(message: &[u8], len: usize) -> usize {
 }
 
 impl<L> Fields<L> {
+	/// Wraps a subscriber layer with optional native journal field recording.
+	///
+	/// Events always continue through the inner layer. Structured field
+	/// submission is enabled only when the supplied configuration selects the
+	/// journal.
 	pub fn new(inner: L, config: &Config) -> Self { Self { inner, submit: enabled(config) } }
 }
 

--- a/src/core/log/mod.rs
+++ b/src/core/log/mod.rs
@@ -1,8 +1,33 @@
+/// Ephemeral tracing-event capture.
+///
+/// Captures combine optional predicates with callbacks and remain active for a
+/// scope guard's lifetime. Formatting helpers support administrative output.
 pub mod capture;
+/// HTML color values for log levels.
+///
+/// Helpers map tracing metadata to hexadecimal colors for Matrix-formatted log
+/// output. HTML and code-tag capture formatters share these values.
 pub mod color;
+/// Console formatting and output routing.
+///
+/// The module selects stdout, stderr, or native journal output and formats each
+/// event according to logging configuration.
 pub mod console;
+/// HTML and Markdown formatting for captured log events.
+///
+/// Each helper appends one entry or table header to a caller-provided
+/// formatter. Event entries include tracing level and span context, while the
+/// header helper writes column labels.
 pub mod fmt;
+/// Parsing for tracing span-lifecycle formatting modes.
+///
+/// Known text values map case-insensitively to `FmtSpan` flags. Unknown values
+/// return `FmtSpan::NONE` in the error variant.
 pub mod fmt_span;
+/// Native systemd journal submission and field recording.
+///
+/// The module routes formatted messages to the journal socket and records
+/// structured tracing fields for journal queries.
 pub mod journald;
 mod reload;
 mod suppress;
@@ -20,17 +45,28 @@ pub use self::{
 	suppress::Suppress,
 };
 
-/// Logging subsystem. This is a singleton member of super::Server which holds
-/// all logging and tracing related state rather than shoving it all in
-/// super::Server directly.
+/// Owns the server's shared logging and tracing state.
+///
+/// The singleton groups the configured subscriber, reload handles, and
+/// ephemeral capture registry. `Server` exposes this value to components that
+/// adjust logging.
 pub struct Logging {
-	/// Subscriber assigned to globals and defaults; may also be NoSubscriber.
+	/// Retains the subscriber configured for the server.
+	///
+	/// Initialization may register it globally when `log_global_default` is
+	/// enabled. Otherwise no global registration occurs, and disabled logging
+	/// can retain a no-op subscriber.
 	pub subscriber: Arc<dyn Subscriber + Send + Sync>,
 
-	/// General log level reload handles.
+	/// Named handles for changing subscriber filters at runtime.
+	///
+	/// Administrative commands and scoped guards use these handles without
+	/// knowing the concrete subscriber stack type.
 	pub reload: LogLevelReloadHandles,
 
-	/// Tracing capture state for ephemeral/oneshot uses.
+	/// Shared registration state for ephemeral tracing captures.
+	///
+	/// Capture guards add and remove callbacks observed by the capture layer.
 	pub capture: Arc<capture::State>,
 }
 
@@ -39,32 +75,56 @@ pub struct Logging {
 // necessary but discouraged. Remember debug_ log macros are also exported to
 // the crate namespace like these.
 
+/// Emits a tracing event at a caller-supplied level.
+///
+/// The macro forwards tracing fields and message tokens to `tracing::event!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 #[collapse_debuginfo(yes)]
 macro_rules! event {
 	( $level:expr_2021, $($x:tt)+ ) => { ::tracing::event!( $level, $($x)+ ) }
 }
 
+/// Emits an error-level tracing event.
+///
+/// The macro forwards all fields and message tokens to `tracing::error!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 macro_rules! error {
     ( $($x:tt)+ ) => { ::tracing::error!( $($x)+ ) }
 }
 
+/// Emits a warning-level tracing event.
+///
+/// The macro forwards all fields and message tokens to `tracing::warn!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 macro_rules! warn {
     ( $($x:tt)+ ) => { ::tracing::warn!( $($x)+ ) }
 }
 
+/// Emits an informational tracing event.
+///
+/// The macro forwards all fields and message tokens to `tracing::info!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 macro_rules! info {
     ( $($x:tt)+ ) => { ::tracing::info!( $($x)+ ) }
 }
 
+/// Emits a debug-level tracing event.
+///
+/// The macro forwards all fields and message tokens to `tracing::debug!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 macro_rules! debug {
     ( $($x:tt)+ ) => { ::tracing::debug!( $($x)+ ) }
 }
 
+/// Emits a trace-level tracing event.
+///
+/// The macro forwards all fields and message tokens to `tracing::trace!`.
+/// Project code can use it without importing the tracing crate directly.
 #[macro_export]
 macro_rules! trace {
     ( $($x:tt)+ ) => { ::tracing::trace!( $($x)+ ) }

--- a/src/core/log/reload.rs
+++ b/src/core/log/reload.rs
@@ -13,8 +13,17 @@ use crate::{Result, error};
 /// and can include unnameable `impl Trait` types. This interface hides `S` so
 /// handles can be stored as trait objects.
 pub trait ReloadHandle<L> {
+	/// Clones the filter currently installed through this handle.
+	///
+	/// A missing value indicates that the subscriber or reload layer is no
+	/// longer available. The type-erased interface preserves the concrete
+	/// layer value.
 	fn current(&self) -> Option<L>;
 
+	/// Replaces the layer value controlled by this handle.
+	///
+	/// Reloading affects future subscriber decisions without reconstructing the
+	/// subscriber stack. The underlying reload layer reports unavailable state.
 	fn reload(&self, new_value: L) -> Result<(), reload::Error>;
 }
 
@@ -24,6 +33,10 @@ impl<L: Clone, S> ReloadHandle<L> for reload::Handle<L, S> {
 	fn reload(&self, new_value: L) -> Result<(), reload::Error> { Self::reload(self, new_value) }
 }
 
+/// Named collection of type-erased log-filter reload handles.
+///
+/// Clones share the same synchronized handle map. Names let administrative and
+/// scoped operations target individual subscriber layers.
 #[derive(Clone)]
 pub struct LogLevelReloadHandles {
 	handles: Arc<Mutex<HandleMap>>,
@@ -33,6 +46,14 @@ type HandleMap = HashMap<String, Handle>;
 type Handle = Box<dyn ReloadHandle<EnvFilter> + Send + Sync>;
 
 impl LogLevelReloadHandles {
+	/// Registers or replaces a reload handle under a name.
+	///
+	/// Later calls to `reload` and `current` address the handle by this name.
+	/// The handle remains owned by the shared collection.
+	///
+	/// # Panics
+	///
+	/// Panics if the shared handle map mutex is poisoned.
 	pub fn add(&self, name: &str, handle: Handle) {
 		self.handles
 			.lock()
@@ -40,6 +61,15 @@ impl LogLevelReloadHandles {
 			.insert(name.into(), handle);
 	}
 
+	/// Applies a log filter to the selected named handles.
+	///
+	/// Only handles whose names occur in the supplied slice are changed; `None`
+	/// selects no handles. Individual reload failures are logged and do not
+	/// stop other handles.
+	///
+	/// # Panics
+	///
+	/// Panics if the shared handle map mutex is poisoned.
 	pub fn reload(&self, new_value: &EnvFilter, names: Option<&[&str]>) -> Result {
 		self.handles
 			.lock()
@@ -55,6 +85,14 @@ impl LogLevelReloadHandles {
 		Ok(())
 	}
 
+	/// Returns the current filter for a named handle.
+	///
+	/// Missing names and unavailable reload layers both produce `None`. The
+	/// returned filter is cloned from the layer.
+	///
+	/// # Panics
+	///
+	/// Panics if the shared handle map mutex is poisoned.
 	#[must_use]
 	pub fn current(&self, name: &str) -> Option<EnvFilter> {
 		self.handles

--- a/src/core/log/suppress.rs
+++ b/src/core/log/suppress.rs
@@ -3,12 +3,25 @@ use std::sync::Arc;
 use super::EnvFilter;
 use crate::Server;
 
+/// Temporarily suppresses the console log subscriber layer.
+///
+/// Construction replaces the console filter with an empty filter and retains a
+/// restoration filter. Dropping the guard restores that value.
 pub struct Suppress {
 	server: Arc<Server>,
 	restore: EnvFilter,
 }
 
 impl Suppress {
+	/// Suppresses console logging until the returned guard is dropped.
+	///
+	/// The current console filter is saved when available; otherwise one is
+	/// rebuilt from the configured directives. The stored filter and cloned
+	/// server handle let `Drop` reach the reload map and restore logging.
+	///
+	/// # Panics
+	///
+	/// Panics if the shared reload-handle map mutex is poisoned.
 	pub fn new(server: &Arc<Server>) -> Self {
 		let handle = "console";
 		let config = &server.config.log;

--- a/src/core/matrix/event.rs
+++ b/src/core/matrix/event.rs
@@ -4,6 +4,10 @@ mod format;
 mod id;
 mod redact;
 mod relation;
+/// State-event key types and ordering helpers.
+///
+/// Keys combine a state event type with its state key for use in maps. The
+/// module also provides forward and reverse comparison functions.
 pub mod state_key;
 mod type_ext;
 mod unsigned;
@@ -30,6 +34,10 @@ use crate::{Result, utils};
 
 /// Abstraction of a PDU so users can have their own PDU types.
 pub trait Event: Clone + Debug + Send + Sync {
+	/// Checks whether this event has both the requested type and state key.
+	///
+	/// Message-like events never match because their state key is absent. The
+	/// comparison does not inspect event content.
 	#[inline]
 	fn is_type_and_state_key(&self, kind: &TimelineEventType, state_key: &str) -> bool {
 		self.kind() == kind && self.state_key() == Some(state_key)
@@ -55,6 +63,11 @@ pub trait Event: Clone + Debug + Send + Sync {
 		Ref(self).into()
 	}
 
+	/// Checks an unsigned-data property with a caller-supplied predicate.
+	///
+	/// The method returns false when the property is absent or the predicate
+	/// rejects its value. Missing or malformed unsigned data is treated as
+	/// empty.
 	#[inline]
 	fn contains_unsigned_property<T>(&self, property: &str, is_type: T) -> bool
 	where
@@ -64,6 +77,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 		unsigned::contains_unsigned_property::<T, _>(self, property, is_type)
 	}
 
+	/// Deserializes one property from the event's unsigned data.
+	///
+	/// A missing property or malformed unsigned data is reported as not found.
+	/// A value of the wrong type fails deserialization.
 	#[inline]
 	fn get_unsigned_property<T>(&self, property: &str) -> Result<T>
 	where
@@ -73,6 +90,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 		unsigned::get_unsigned_property::<T, _>(self, property)
 	}
 
+	/// Deserializes the event's unsigned data as a JSON value.
+	///
+	/// Missing or malformed unsigned data produces JSON null. Use
+	/// `get_unsigned` when the distinction must be preserved.
 	#[inline]
 	fn get_unsigned_as_value(&self) -> JsonValue
 	where
@@ -81,6 +102,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 		unsigned::get_unsigned_as_value(self)
 	}
 
+	/// Deserializes the complete unsigned-data object into a requested type.
+	///
+	/// Missing unsigned data is reported as not found. Invalid JSON or a type
+	/// mismatch fails deserialization.
 	#[inline]
 	fn get_unsigned<T>(&self) -> Result<T>
 	where
@@ -90,6 +115,14 @@ pub trait Event: Clone + Debug + Send + Sync {
 		unsigned::get_unsigned::<T, _>(self)
 	}
 
+	/// Deserializes event content as an untyped JSON value.
+	///
+	/// The returned value owns its data and can be inspected without borrowing
+	/// the event. Typed consumers should prefer `get_content`.
+	///
+	/// # Panics
+	///
+	/// Panics when the stored content is not valid JSON.
 	#[inline]
 	fn get_content_as_value(&self) -> JsonValue
 	where
@@ -98,6 +131,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 		content::as_value(self)
 	}
 
+	/// Deserializes event content into a requested type.
+	///
+	/// The target type determines which event-content shape is accepted.
+	/// Invalid JSON or a mismatched target type produces a bad-JSON result.
 	#[inline]
 	fn get_content<T>(&self) -> Result<T>
 	where
@@ -107,6 +144,11 @@ pub trait Event: Clone + Debug + Send + Sync {
 		content::get::<T, _>(self)
 	}
 
+	/// Resolves the event ID targeted by a redaction event.
+	///
+	/// The selected room rules determine whether the ID is read from event
+	/// content or the top-level `redacts` field. Non-redaction events and
+	/// malformed content return `None`.
 	#[inline]
 	fn redacts_id(&self, room_rules: &RoomVersionRules) -> Option<OwnedEventId>
 	where
@@ -115,6 +157,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 		redact::redacts_id(self, room_rules)
 	}
 
+	/// Reports whether the event carries redaction metadata.
+	///
+	/// Redaction is recognized by the presence of `unsigned.redacted_because`.
+	/// Missing or malformed unsigned data is treated as not redacted.
 	#[inline]
 	fn is_redacted(&self) -> bool
 	where
@@ -123,6 +169,14 @@ pub trait Event: Clone + Debug + Send + Sync {
 		redact::is_redacted(self)
 	}
 
+	/// Consumes the event and serializes its PDU as a canonical JSON object.
+	///
+	/// Implementations first convert the event to the common `Pdu`
+	/// representation. The resulting object preserves the stored event fields.
+	///
+	/// # Panics
+	///
+	/// Panics if the PDU cannot be serialized as a canonical JSON object.
 	#[inline]
 	fn into_canonical_object(self) -> CanonicalJsonObject
 	where
@@ -131,11 +185,27 @@ pub trait Event: Clone + Debug + Send + Sync {
 		utils::to_canonical_object(self.into_pdu()).expect("failed to create Value::Object")
 	}
 
+	/// Serializes the event's PDU as an owned canonical JSON object.
+	///
+	/// The event remains available after conversion. The resulting object
+	/// preserves the stored event fields.
+	///
+	/// # Panics
+	///
+	/// Panics if the PDU cannot be serialized as a canonical JSON object.
 	#[inline]
 	fn to_canonical_object(&self) -> CanonicalJsonObject {
 		utils::to_canonical_object(self.as_pdu()).expect("failed to create Value::Object")
 	}
 
+	/// Consumes the event and serializes its PDU as a JSON value.
+	///
+	/// Implementations first convert the event to the common `Pdu`
+	/// representation. The returned value is an owned JSON object.
+	///
+	/// # Panics
+	///
+	/// Panics if the PDU cannot be serialized as JSON.
 	#[inline]
 	fn into_value(self) -> JsonValue
 	where
@@ -144,18 +214,46 @@ pub trait Event: Clone + Debug + Send + Sync {
 		serde_json::to_value(self.into_pdu()).expect("failed to create JSON Value")
 	}
 
+	/// Serializes the event's PDU as an owned JSON value.
+	///
+	/// The event remains available after conversion. The returned value is an
+	/// owned JSON object.
+	///
+	/// # Panics
+	///
+	/// Panics if the PDU cannot be serialized as JSON.
 	#[inline]
 	fn to_value(&self) -> JsonValue {
 		serde_json::to_value(self.as_pdu()).expect("failed to create JSON Value")
 	}
 
+	/// Returns mutable access to the common PDU representation.
+	///
+	/// Implementations backed by a mutable `Pdu` override this method. The
+	/// default implementation marks mutable conversion as unsupported.
+	///
+	/// # Panics
+	///
+	/// Panics when the implementation does not provide mutable PDU access.
 	#[inline]
 	fn as_mut_pdu(&mut self) -> &mut Pdu { unimplemented!("not a mutable Pdu") }
 
+	/// Borrows the event as the common PDU representation.
+	///
+	/// Implementations may return their underlying PDU directly or a borrowed
+	/// PDU representation with the same event data.
 	fn as_pdu(&self) -> &Pdu;
 
+	/// Converts the event into an owned common PDU representation.
+	///
+	/// Owned implementations can move their PDU. Borrowed implementations clone
+	/// the PDU so the returned value owns every field.
 	fn into_pdu(self) -> Pdu;
 
+	/// Reports whether consuming conversion can move an owned PDU.
+	///
+	/// A false result indicates that `into_pdu` must clone borrowed event data.
+	/// The value can help callers choose a conversion path.
 	fn is_owned(&self) -> bool;
 
 	//
@@ -204,6 +302,10 @@ pub trait Event: Clone + Debug + Send + Sync {
 	fn unsigned(&self) -> Option<&RawJsonValue>;
 
 	//#[deprecated]
+	/// Returns the event's timeline type.
+	///
+	/// This compatibility accessor delegates directly to `kind`. New callers
+	/// can use either name without changing the returned value.
 	#[inline]
 	fn event_type(&self) -> &TimelineEventType { self.kind() }
 }

--- a/src/core/matrix/event/filter.rs
+++ b/src/core/matrix/event/filter.rs
@@ -14,7 +14,17 @@ use crate::is_equal_to;
 /// Segments of one `event_fields` entry; most paths are one or two deep.
 type FieldPath = SmallVec<[String; 2]>;
 
+/// Tests values against a Matrix filter.
+///
+/// Implementations apply the allow and deny lists relevant to the value being
+/// tested. A value matches only when every applicable filter condition accepts
+/// it.
 pub trait Matches<T> {
+	/// Returns whether the supplied value satisfies this filter.
+	///
+	/// The value type selects which filter fields participate in the
+	/// comparison. Built-in implementations reject deny-list matches before
+	/// accepting allow-list matches.
 	fn matches(&self, t: T) -> bool;
 }
 

--- a/src/core/matrix/event/format.rs
+++ b/src/core/matrix/event/format.rs
@@ -11,8 +11,16 @@ use serde_json::value::to_raw_value;
 
 use super::{Event, redact};
 
+/// Owns an event for conversion into a Ruma event envelope.
+///
+/// `From` implementations select the fields required by each client event
+/// shape. Consuming the wrapper also consumes the source event.
 pub struct Owned<E: Event>(pub(super) E);
 
+/// Borrows an event for conversion into a Ruma event envelope.
+///
+/// `From` implementations select the fields required by each client event
+/// shape. The source event remains available after conversion.
 pub struct Ref<'a, E: Event>(pub(super) &'a E);
 
 impl<E: Event> From<Owned<E>> for Raw<AnySyncTimelineEvent> {

--- a/src/core/matrix/event/relation.rs
+++ b/src/core/matrix/event/relation.rs
@@ -3,7 +3,15 @@ use serde::Deserialize;
 
 use super::Event;
 
+/// Compares an event's relation type with a requested relation type.
+///
+/// Implementations inspect the `m.relates_to.rel_type` field in event content.
+/// Missing or malformed relation content does not match.
 pub trait RelationTypeEqual<E: Event> {
+	/// Returns whether the event declares this relation type.
+	///
+	/// The comparison deserializes only the relation fields needed for the
+	/// check. Content that cannot be deserialized returns false.
 	fn relation_type_equal(&self, event: &E) -> bool;
 }
 

--- a/src/core/matrix/event/state_key.rs
+++ b/src/core/matrix/event/state_key.rs
@@ -3,15 +3,32 @@ use std::cmp::Ordering;
 use ruma::events::StateEventType;
 use smallstr::SmallString;
 
+/// Composite key identifying one state event slot.
+///
+/// The event type is compared before the state-key string. This layout is used
+/// as the key for in-memory state maps.
 pub type TypeStateKey = (StateEventType, StateKey);
+
+/// Inline-backed string used for Matrix state keys.
+///
+/// The inline budget lets short keys remain inline, while longer keys spill to
+/// heap storage.
 pub type StateKey = SmallString<[u8; INLINE_SIZE]>;
 
 const INLINE_SIZE: usize = 48;
 
+/// Compares state keys in ascending event-type and state-key order.
+///
+/// Event type is the primary key and the state-key string breaks ties. The
+/// ordering matches the natural tuple order of `TypeStateKey`.
 #[inline]
 #[must_use]
 pub fn cmp(a: &TypeStateKey, b: &TypeStateKey) -> Ordering { a.0.cmp(&b.0).then(a.1.cmp(&b.1)) }
 
+/// Compares state keys in descending event-type and state-key order.
+///
+/// Both components are reversed together, producing the inverse of `cmp`. It is
+/// suitable for descending sorts over the same key domain.
 #[inline]
 #[must_use]
 pub fn rcmp(a: &TypeStateKey, b: &TypeStateKey) -> Ordering { b.0.cmp(&a.0).then(b.1.cmp(&a.1)) }

--- a/src/core/matrix/event/type_ext.rs
+++ b/src/core/matrix/event/type_ext.rs
@@ -4,6 +4,10 @@ use super::StateKey;
 
 /// Convenience trait for adding event type plus state key to state maps.
 pub trait TypeExt {
+	/// Pairs this event type with an owned state key.
+	///
+	/// Timeline event types are converted to their state-event type spelling.
+	/// Borrowed event types are cloned as needed for the returned pair.
 	fn with_state_key(self, state_key: impl Into<StateKey>) -> (StateEventType, StateKey);
 }
 

--- a/src/core/matrix/mod.rs
+++ b/src/core/matrix/mod.rs
@@ -1,15 +1,52 @@
-//! Core Matrix Library
+//! Core Matrix event and room-version types.
+//!
+//! The module exposes the shared event model, PDU storage types, and
+//! room-version rule lookup used throughout the server. Short identifiers are
+//! compact database surrogates for Matrix identifiers.
 
+/// Event access, conversion, filtering, and state-key utilities.
+///
+/// The module defines the common event trait and adapters for client and
+/// federation representations. It also exposes helpers for inspecting event
+/// data.
 pub mod event;
 pub mod event_id;
+/// Persistent data unit storage and federation-format utilities.
+///
+/// The module contains the stored event representation, sequence identifiers,
+/// builders, and validation helpers. Its wire-format adapters account for
+/// room-version rules.
 pub mod pdu;
+/// Room-version identifiers and rule lookup.
+///
+/// The module re-exports Ruma's room-version types and resolves the rules for
+/// supported versions. It also extracts versions from room creation events.
 pub mod room_version;
 
 pub use event::{Event, StateKey, TypeExt as EventTypeExt, TypeStateKey, state_key};
 pub use pdu::{EventHash, Pdu, PduBuilder, PduCount, PduEvent, PduId, RawPduId};
 pub use room_version::{RoomVersion, RoomVersionRules};
 
+/// Compact database identifier for an event type and state-key pair.
+///
+/// Values are allocated by the short-state-key service and have meaning only
+/// within the local database. They are not Matrix protocol identifiers.
 pub type ShortStateKey = ShortId;
+
+/// Compact database identifier for a Matrix event ID.
+///
+/// Values are allocated by the short-event-ID service and have meaning only
+/// within the local database. They are not Matrix protocol identifiers.
 pub type ShortEventId = ShortId;
+
+/// Compact database identifier for a Matrix room ID.
+///
+/// Values are allocated by the short-room-ID service and have meaning only
+/// within the local database. They are not Matrix protocol identifiers.
 pub type ShortRoomId = ShortId;
+
+/// Integer storage shared by the database's compact Matrix identifiers.
+///
+/// The allocation services draw from one global counter. Each alias selects the
+/// database mapping in which a value is interpreted.
 pub type ShortId = u64;

--- a/src/core/matrix/pdu.rs
+++ b/src/core/matrix/pdu.rs
@@ -37,43 +37,102 @@ pub use self::{
 use super::{Event, ShortRoomId, StateKey};
 use crate::{Result, err};
 
-/// Persistent Data Unit (Event)
+/// Stores a Matrix persistent data unit in typed form.
+///
+/// The representation retains canonical event fields used by state resolution,
+/// storage, and client serialization. Federation adapters normalize
+/// version-specific wire shapes.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Pdu {
+	/// Matrix event type.
+	///
+	/// The value is serialized under the top-level `type` field.
 	#[serde(rename = "type")]
 	pub kind: TimelineEventType,
 
+	/// Raw canonical event content.
+	///
+	/// Content remains encoded until a caller requests a typed or JSON value.
 	pub content: Content,
 
+	/// Matrix identifier assigned to this event.
+	///
+	/// Stored PDUs always carry an owned event ID, including room versions that
+	/// derive it outside the federation wire object.
 	pub event_id: OwnedEventId,
 
+	/// Matrix room containing this event.
+	///
+	/// Stored PDUs carry the room ID even when a room version omits it from a
+	/// creation event's federation representation.
 	pub room_id: OwnedRoomId,
 
+	/// Matrix user who sent the event.
+	///
+	/// The sender participates in authorization and client-visible event
+	/// output.
 	pub sender: OwnedUserId,
 
+	/// State key when this is a state event.
+	///
+	/// Message-like events store `None` and omit the field during
+	/// serialization.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub state_key: Option<StateKey>,
 
+	/// Event targeted by a redaction when carried at the top level.
+	///
+	/// Newer room versions can place this value in event content instead. An
+	/// absent target is omitted during serialization.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub redacts: Option<OwnedEventId>,
 
+	/// Events declared as direct predecessors of this event.
+	///
+	/// The sequence is stored inline for the common single-predecessor case.
 	pub prev_events: PrevEvents,
 
+	/// Events used to authorize this event.
+	///
+	/// These identifiers form the event's explicit authorization dependency
+	/// set.
 	pub auth_events: AuthEvents,
 
+	/// Millisecond timestamp supplied by the originating server.
+	///
+	/// The value is preserved for ordering metadata and client serialization.
 	pub origin_server_ts: UInt,
 
+	/// Event depth in the room directed acyclic graph.
+	///
+	/// Depth is originating-server-provided graph metadata and is distinct from
+	/// the local timeline sequence.
 	pub depth: UInt,
 
+	/// Content hash declared by the event.
+	///
+	/// Federation validation compares the declaration with the computed content
+	/// hash to detect content changes.
 	pub hashes: EventHash,
 
+	/// Server that originated an event carrying a top-level `origin` field.
+	///
+	/// Legacy event formats retain this value for local and remote events. The
+	/// field is absent when it was not carried by the event format.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub origin: Option<OwnedServerName>,
 
+	/// Unsigned metadata excluded from event hashing and signing.
+	///
+	/// Stored values are local annotations such as transaction IDs, age, prior
+	/// state, and bundled relations. The field is omitted when absent.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub unsigned: Option<Unsigned>,
 
 	//TODO: https://spec.matrix.org/v1.14/rooms/v11/#rejected-events
+	/// Whether state resolution rejected this event in test fixtures.
+	///
+	/// Production builds derive rejection state outside the serialized PDU.
 	#[cfg(test)]
 	#[serde(default, skip_serializing)]
 	pub rejected: bool,
@@ -118,6 +177,10 @@ pub const MAX_PREV_EVENTS: usize = 20;
 pub const MAX_AUTH_EVENTS: usize = 10;
 
 impl Pdu {
+	/// Inserts room and event IDs before deserializing a canonical PDU object.
+	///
+	/// Existing values under those keys are replaced. The resulting typed PDU
+	/// owns both supplied identifiers.
 	pub fn from_object_and_roomid_and_eventid(
 		room_id: &RoomId,
 		event_id: &EventId,
@@ -128,6 +191,10 @@ impl Pdu {
 		Self::from_object_and_eventid(event_id, json)
 	}
 
+	/// Inserts an event ID before deserializing a canonical PDU object.
+	///
+	/// Any existing `event_id` value is replaced. Other object fields pass
+	/// through to normal PDU deserialization.
 	pub fn from_object_and_eventid(
 		event_id: &EventId,
 		mut json: CanonicalJsonObject,
@@ -137,6 +204,16 @@ impl Pdu {
 		Self::from_object(json)
 	}
 
+	/// Normalizes federation wire fields and validates PDU format and room ID.
+	///
+	/// Version-specific wire fields are converted to the stored representation
+	/// before these checks. Signature, content-hash, and authorization
+	/// validation remain the caller's responsibility.
+	///
+	/// # Panics
+	///
+	/// Panics if the object lacks `type` while the selected rules do not
+	/// require a create-event room ID.
 	pub fn from_object_federation(
 		room_id: &RoomId,
 		event_id: &EventId,
@@ -149,6 +226,10 @@ impl Pdu {
 		Ok((pdu, json))
 	}
 
+	/// Validates a canonical PDU object before deserializing it.
+	///
+	/// Checks use the supplied room-version event-format rules. Successful
+	/// validation returns the typed stored representation.
 	pub fn from_object_checked(
 		json: CanonicalJsonObject,
 		rules: &RoomVersionRules,
@@ -157,20 +238,43 @@ impl Pdu {
 		Self::from_object(json)
 	}
 
+	/// Deserializes a canonical JSON object into a stored PDU.
+	///
+	/// The object is wrapped as a canonical JSON value before typed
+	/// deserialization. No room-version format checks are performed.
 	pub fn from_object(json: CanonicalJsonObject) -> Result<Self> {
 		let json = CanonicalJsonValue::Object(json);
 		Self::from_value(json)
 	}
 
+	/// Deserializes raw JSON through a canonical JSON value.
+	///
+	/// Canonical conversion normalizes integer and object representation before
+	/// the PDU fields are decoded. No room-version format checks are
+	/// performed.
+	///
+	/// # Panics
+	///
+	/// Panics if the raw JSON contains a value outside canonical JSON, such as
+	/// a floating-point value or an integer outside the canonical range.
 	pub fn from_raw_value(json: &RawJsonValue) -> Result<Self> {
 		let json: CanonicalJsonValue = json.into();
 		Self::from_value(json)
 	}
 
+	/// Deserializes a canonical JSON value into a stored PDU.
+	///
+	/// The input must contain the fields required by `Pdu`. No room-version
+	/// format checks are performed before deserialization.
 	pub fn from_value(json: CanonicalJsonValue) -> Result<Self> {
 		serde_json::from_value(json.into()).map_err(Into::into)
 	}
 
+	/// Deserializes raw JSON directly into a stored PDU.
+	///
+	/// This path uses `Pdu`'s Serde representation without first canonicalizing
+	/// the input. Callers that require canonical validation should use a
+	/// checked constructor.
 	pub fn from_raw_json(json: &RawJsonValue) -> Result<Self> {
 		Self::deserialize(json).map_err(Into::into)
 	}

--- a/src/core/matrix/pdu/builder.rs
+++ b/src/core/matrix/pdu/builder.rs
@@ -9,22 +9,45 @@ use serde_json::value::{RawValue as RawJsonValue, to_raw_value};
 
 use super::{Content, StateKey};
 
-/// Build the start of a PDU in order to add it to the Database.
+/// Collects the initial fields needed to build and append a PDU.
+///
+/// The timeline service supplies event graph fields, sender data, and hashes
+/// after this value is created. Constructors serialize typed Ruma event
+/// content.
 #[derive(Deserialize)]
 pub struct Builder {
+	/// Matrix event type for the new PDU.
+	///
+	/// Typed constructors derive this value from the supplied event content.
 	#[serde(rename = "type")]
 	pub event_type: TimelineEventType,
 
+	/// Raw canonical content for the new event.
+	///
+	/// The builder retains encoded content until the PDU is assembled and
+	/// signed.
 	pub content: Content,
 
+	/// Unsigned metadata to include with the new event.
+	///
+	/// Typical values include local transaction IDs and prior-state metadata.
 	pub unsigned: Option<BTreeMap<String, serde_json::Value>>,
 
+	/// State key for a state event.
+	///
+	/// A missing key identifies a message-like timeline event.
 	pub state_key: Option<StateKey>,
 
+	/// Event ID targeted by a redaction.
+	///
+	/// The value becomes the legacy top-level `redacts` field. Callers place a
+	/// content-based redaction target in the encoded content separately.
 	pub redacts: Option<OwnedEventId>,
 
-	/// For timestamped messaging, should only be used for appservices.
-	/// Will be set to current time if None
+	/// Overrides the event timestamp for appservice messaging.
+	///
+	/// An absent value uses the current time when the PDU is built. Ordinary
+	/// callers should leave this field unset.
 	pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
 }
 
@@ -42,6 +65,15 @@ impl Default for Builder {
 }
 
 impl Builder {
+	/// Builds a state-event template from typed event content.
+	///
+	/// The content's event type and supplied state key populate the
+	/// corresponding builder fields. Remaining optional fields use their
+	/// defaults.
+	///
+	/// # Panics
+	///
+	/// Panics if the event content cannot be serialized as raw JSON.
 	pub fn state<S, T>(state_key: S, content: &T) -> Self
 	where
 		T: StateEventContent,
@@ -57,6 +89,14 @@ impl Builder {
 		}
 	}
 
+	/// Builds a message-like event template from typed event content.
+	///
+	/// The content's event type populates the builder and the state key remains
+	/// absent. Remaining optional fields use their defaults.
+	///
+	/// # Panics
+	///
+	/// Panics if the event content cannot be serialized as raw JSON.
 	pub fn timeline<T>(content: &T) -> Self
 	where
 		T: MessageLikeEventContent,

--- a/src/core/matrix/pdu/count.rs
+++ b/src/core/matrix/pdu/count.rs
@@ -10,22 +10,52 @@ use ruma::api::Direction;
 
 use crate::{Error, Result, err};
 
+/// Sequence number locating a PDU in a room timeline.
+///
+/// Valid normal counts range from zero through `i64::MAX`, while valid
+/// backfilled counts range from `i64::MIN` through zero. Ordering compares
+/// their signed representations, with zero shared by both variants.
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
-// PDU's sequence number
 pub enum Count {
+	/// Sequence assigned to an event in the normal timeline.
+	///
+	/// Normal counts advance forward as new local or federated events are
+	/// appended. Valid values do not exceed `i64::MAX`.
 	Normal(u64),
+
+	/// Sequence assigned to an event in the backfilled timeline.
+	///
+	/// Valid backfilled counts occupy the nonpositive signed ordering range.
 	Backfilled(i64),
 }
 
 impl Count {
+	/// Encodes the count's integer bits in big-endian order.
+	///
+	/// Normal values retain their unsigned representation. Backfilled values
+	/// are reinterpreted as unsigned two's-complement bits before encoding.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds if a positive `Backfilled` value was constructed
+	/// directly.
 	#[inline]
 	#[must_use]
 	pub fn to_be_bytes(self) -> [u8; size_of::<u64>()] { self.into_unsigned().to_be_bytes() }
 
+	/// Interprets unsigned integer bits as a signed timeline count.
+	///
+	/// Values with the high bit set become negative backfilled counts. Other
+	/// positive values become normal counts, while zero becomes backfilled
+	/// zero.
 	#[inline]
 	#[must_use]
 	pub fn from_unsigned(unsigned: u64) -> Self { Self::from_signed(unsigned as i64) }
 
+	/// Classifies a signed integer as a normal or backfilled count.
+	///
+	/// Positive values become normal counts. Zero and negative values become
+	/// backfilled counts.
 	#[inline]
 	#[must_use]
 	pub fn from_signed(signed: i64) -> Self {
@@ -35,6 +65,15 @@ impl Count {
 		}
 	}
 
+	/// Converts the count to its unsigned integer bit representation.
+	///
+	/// Backfilled values are reinterpreted using two's-complement bits. The
+	/// variant information is not retained in the returned integer.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds if a positive `Backfilled` value was constructed
+	/// directly.
 	#[inline]
 	#[must_use]
 	pub fn into_unsigned(self) -> u64 {
@@ -45,6 +84,16 @@ impl Count {
 		}
 	}
 
+	/// Converts the count to the signed representation used for ordering.
+	///
+	/// Valid normal values cast into the nonnegative signed domain, while valid
+	/// backfilled values retain their signed count. Direct construction outside
+	/// the documented ranges violates the ordering invariant.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds if a positive `Backfilled` value was constructed
+	/// directly.
 	#[inline]
 	#[must_use]
 	pub fn into_signed(self) -> i64 {
@@ -55,6 +104,15 @@ impl Count {
 		}
 	}
 
+	/// Converts a count to a normal-timeline position.
+	///
+	/// Existing normal counts are preserved. Any backfilled count maps to the
+	/// beginning of the normal timeline at zero.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds if a positive `Backfilled` value was constructed
+	/// directly.
 	#[inline]
 	#[must_use]
 	pub fn into_normal(self) -> Self {
@@ -65,6 +123,11 @@ impl Count {
 		}
 	}
 
+	/// Advances or retreats the count by one without integer overflow.
+	///
+	/// Forward movement adds one and backward movement subtracts one. The
+	/// original variant is preserved, so callers must avoid crossing that
+	/// variant's valid timeline range.
 	#[inline]
 	pub fn checked_inc(self, dir: Direction) -> Result<Self, Error> {
 		match dir {
@@ -73,6 +136,11 @@ impl Count {
 		}
 	}
 
+	/// Adds an unsigned offset without integer overflow.
+	///
+	/// Backfilled offsets are cast to `i64` and must not exceed `i64::MAX`.
+	/// Callers must keep the resulting variant within its documented range;
+	/// integer overflow returns an arithmetic error.
 	#[inline]
 	pub fn checked_add(self, add: u64) -> Result<Self, Error> {
 		Ok(match self {
@@ -87,6 +155,11 @@ impl Count {
 		})
 	}
 
+	/// Subtracts an unsigned offset without integer underflow.
+	///
+	/// Backfilled offsets are cast to `i64` and must not exceed `i64::MAX`.
+	/// Callers must keep the resulting variant within its documented range;
+	/// integer underflow returns an arithmetic error.
 	#[inline]
 	pub fn checked_sub(self, sub: u64) -> Result<Self, Error> {
 		Ok(match self {
@@ -101,6 +174,11 @@ impl Count {
 		})
 	}
 
+	/// Advances or retreats the count by one with saturation.
+	///
+	/// Forward movement adds one and backward movement subtracts one.
+	/// Saturation uses the integer boundary of the existing variant and does
+	/// not prevent a backfilled value from crossing zero.
 	#[inline]
 	#[must_use]
 	pub fn saturating_inc(self, dir: Direction) -> Self {
@@ -110,6 +188,11 @@ impl Count {
 		}
 	}
 
+	/// Adds an unsigned offset with saturation at the integer boundary.
+	///
+	/// Backfilled offsets are cast to `i64` and must not exceed `i64::MAX`.
+	/// Saturation uses the underlying integer boundary and does not repair a
+	/// result outside the variant's documented range.
 	#[inline]
 	#[must_use]
 	pub fn saturating_add(self, add: u64) -> Self {
@@ -119,6 +202,11 @@ impl Count {
 		}
 	}
 
+	/// Subtracts an unsigned offset with saturation at the integer boundary.
+	///
+	/// Backfilled offsets are cast to `i64` and must not exceed `i64::MAX`.
+	/// Saturation uses the underlying integer boundary and does not repair a
+	/// result outside the variant's documented range.
 	#[inline]
 	#[must_use]
 	pub fn saturating_sub(self, sub: u64) -> Self {
@@ -128,10 +216,18 @@ impl Count {
 		}
 	}
 
+	/// Returns the earliest valid timeline count.
+	///
+	/// The minimum is a backfilled count at `i64::MIN`. It sorts before every
+	/// other valid count.
 	#[inline]
 	#[must_use]
 	pub const fn min() -> Self { Self::Backfilled(i64::MIN) }
 
+	/// Returns the latest valid timeline count.
+	///
+	/// The maximum is a normal count at `i64::MAX`. This keeps the value within
+	/// the signed domain used by ordering.
 	#[inline]
 	#[must_use]
 	pub const fn max() -> Self { Self::Normal(i64::MAX as u64) }

--- a/src/core/matrix/pdu/format.rs
+++ b/src/core/matrix/pdu/format.rs
@@ -7,6 +7,11 @@ use ruma::{
 
 use crate::{extract_variant, is_equal_to, matrix::room_version};
 
+/// Converts a stored PDU object to its federation wire representation.
+///
+/// Local transaction metadata is removed and room-version rules select the
+/// fields and event-reference shape sent to peers. When rules are unavailable,
+/// the event ID is removed without rewriting event references.
 #[must_use]
 pub fn into_outgoing_federation(
 	mut pdu_json: CanonicalJsonObject,
@@ -66,6 +71,11 @@ fn mutate_outgoing_reference_format(value: &mut CanonicalJsonValue) {
 		});
 }
 
+/// Normalizes a federation PDU object into the stored representation.
+///
+/// Legacy event-reference tuples are collapsed and omitted room or event IDs
+/// are restored from trusted request context. The supplied rules must match the
+/// event's room version.
 #[must_use]
 pub fn from_incoming_federation(
 	room_id: &RoomId,

--- a/src/core/matrix/pdu/format/check.rs
+++ b/src/core/matrix/pdu/format/check.rs
@@ -7,6 +7,10 @@ use serde_json::to_string as to_json_string;
 use super::super::{MAX_AUTH_EVENTS, MAX_PDU_BYTES, MAX_PREV_EVENTS, Pdu};
 use crate::{Err, Result, err};
 
+/// Verifies that a parsed PDU belongs to the expected room.
+///
+/// The comparison uses the room ID retained in the stored representation. A
+/// mismatch is reported as an invalid request parameter.
 pub fn check_room_id(pdu: &Pdu, room_id: &RoomId) -> Result {
 	if pdu.room_id != room_id {
 		return Err!(Request(InvalidParam(error!(

--- a/src/core/matrix/pdu/id.rs
+++ b/src/core/matrix/pdu/id.rs
@@ -1,8 +1,20 @@
 use super::{Count, RawId, ShortRoomId};
 
+/// Typed components of a PDU database key.
+///
+/// The room surrogate scopes the key and the count locates the event within the
+/// normal or backfilled timeline. Conversion to `RawId` packs both components.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Id {
+	/// Compact local identifier of the event's room.
+	///
+	/// This is encoded first so room-scoped database scans share a fixed
+	/// prefix.
 	pub shortroomid: ShortRoomId,
+
+	/// Timeline sequence assigned to the event.
+	///
+	/// The count selects the normal or backfilled raw-key layout when encoded.
 	pub count: Count,
 }
 

--- a/src/core/matrix/pdu/raw_id.rs
+++ b/src/core/matrix/pdu/raw_id.rs
@@ -8,9 +8,22 @@ use super::{
 	Count, Id,
 };
 
+/// Packed database key for a room's normal or backfilled PDU.
+///
+/// Both layouts begin with the big-endian compact room identifier. Normal keys
+/// are 16 bytes and backfilled keys are 24 bytes.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub enum RawId {
+	/// Packed key for an event in the normal timeline.
+	///
+	/// The key concatenates the room surrogate and unsigned count as two
+	/// big-endian integers.
 	Normal(RawIdNormal),
+
+	/// Packed key for an event in the backfilled timeline.
+	///
+	/// The key inserts an eight-byte zero marker between the room surrogate and
+	/// signed count bits.
 	Backfilled(RawIdBackfilled),
 }
 
@@ -26,10 +39,18 @@ impl RawId {
 	const MAX_LEN: usize = Self::BACKFILLED_LEN;
 	const NORMAL_LEN: usize = size_of::<ShortRoomId>() + size_of::<u64>();
 
+	/// Checks whether two raw PDU keys belong to the same room.
+	///
+	/// Only the leading compact room identifier is compared. Timeline kind and
+	/// event count do not affect the result.
 	#[inline]
 	#[must_use]
 	pub fn is_room_eq(self, other: Self) -> bool { self.shortroomid() == other.shortroomid() }
 
+	/// Decodes the timeline count stored in this raw key.
+	///
+	/// Normal and backfilled layouts are converted to the corresponding `Count`
+	/// variant. The compact room identifier is ignored.
 	#[inline]
 	#[must_use]
 	pub fn pdu_count(self) -> Count {
@@ -37,6 +58,10 @@ impl RawId {
 		id.count
 	}
 
+	/// Returns the encoded compact room identifier.
+	///
+	/// The bytes remain in big-endian database order. Use `Id::from` when a
+	/// typed integer value is needed.
 	#[inline]
 	#[must_use]
 	pub fn shortroomid(self) -> [u8; INT_LEN] {
@@ -50,6 +75,10 @@ impl RawId {
 		}
 	}
 
+	/// Returns the encoded timeline count.
+	///
+	/// The bytes remain in big-endian database order. For backfilled keys the
+	/// intervening zero marker is omitted.
 	#[inline]
 	#[must_use]
 	pub fn count(self) -> [u8; INT_LEN] {
@@ -63,6 +92,10 @@ impl RawId {
 		}
 	}
 
+	/// Borrows the complete packed database key.
+	///
+	/// The returned slice is 16 bytes for a normal key and 24 bytes for a
+	/// backfilled key. Its lifetime is tied to this value.
 	#[inline]
 	#[must_use]
 	pub fn as_bytes(&self) -> &[u8] {

--- a/src/core/matrix/pdu/unsigned.rs
+++ b/src/core/matrix/pdu/unsigned.rs
@@ -11,6 +11,10 @@ use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue, to_raw_val
 use super::{Pdu, Unsigned};
 use crate::{Result, err, implement, utils::BoolExt};
 
+/// Removes the local transaction ID from unsigned event metadata.
+///
+/// Other unsigned properties are retained and the object is re-encoded. An
+/// event without unsigned data is left unchanged.
 #[implement(Pdu)]
 pub fn remove_transaction_id(&mut self) -> Result {
 	use BTreeMap as Map;
@@ -63,6 +67,11 @@ pub fn remove_prev_state(&mut self) -> Result {
 	Ok(())
 }
 
+/// Adds the event's current age to unsigned metadata.
+///
+/// Age is the saturating millisecond difference between the current time and
+/// `origin_server_ts`. Future timestamps can therefore produce a negative
+/// value.
 #[implement(Pdu)]
 pub fn add_age(&mut self) -> Result {
 	use BTreeMap as Map;
@@ -106,6 +115,11 @@ pub fn add_membership(&mut self, membership: &MembershipState) -> Result {
 	Ok(())
 }
 
+/// Adds or replaces a named bundled relation in unsigned metadata.
+///
+/// The related PDU is serialized under `unsigned.m.relations`; `None` stores an
+/// empty object for the named relation. Existing unsigned properties are
+/// retained.
 #[implement(Pdu)]
 pub fn add_relation(&mut self, name: &str, pdu: Option<&Pdu>) -> Result {
 	use serde_json::Map;

--- a/src/core/matrix/room_version.rs
+++ b/src/core/matrix/room_version.rs
@@ -3,6 +3,11 @@ pub use ruma::{RoomVersionId as RoomVersion, room_version_rules::RoomVersionRule
 
 use crate::{Result, err, matrix::Event};
 
+/// Resolves the rule set for a supported room version.
+///
+/// Known versions return Ruma's complete authorization, redaction, and
+/// event-format rules. Custom or unsupported identifiers produce an
+/// unsupported-version result.
 pub fn rules(room_version_id: &RoomVersionId) -> Result<RoomVersionRules> {
 	room_version_id.rules().ok_or_else(|| {
 		err!(Request(UnsupportedRoomVersion(
@@ -11,11 +16,19 @@ pub fn rules(room_version_id: &RoomVersionId) -> Result<RoomVersionRules> {
 	})
 }
 
+/// Extracts the room version declared by a room creation event.
+///
+/// The event content is deserialized as `m.room.create` content. The returned
+/// identifier is owned independently of the event.
 pub fn from_create_event<Pdu: Event>(create_event: &Pdu) -> Result<RoomVersionId> {
 	let content: RoomCreateEventContent = create_event.get_content()?;
 	Ok(from_create_content(&content).clone())
 }
 
+/// Borrows the room version from parsed room creation content.
+///
+/// Ruma applies the protocol default while deserializing content that omits the
+/// field. This accessor performs no additional validation.
 #[inline]
 #[must_use]
 pub fn from_create_content(content: &RoomCreateEventContent) -> &RoomVersionId {

--- a/src/core/metrics/dump.rs
+++ b/src/core/metrics/dump.rs
@@ -46,6 +46,11 @@ impl DumpMeta {
 }
 
 #[cfg(tokio_unstable)]
+/// Writes a runtime metrics snapshot into a process-specific JSON file.
+///
+/// The output filename includes the current process identifier. Serialization
+/// and file-system failures are reported through logging instead of being
+/// returned.
 pub fn write_runtime_metrics(dir: &Path, metrics: &RuntimeMetrics) {
 	let pid = process::id();
 	let path = dir.join(format!("{RUNTIME_METRICS_PREFIX}.{pid}.json"));
@@ -58,6 +63,11 @@ pub fn write_runtime_metrics(dir: &Path, metrics: &RuntimeMetrics) {
 	report(&path, "runtime_metrics", write_json(&path, &dump));
 }
 
+/// Writes a resource usage snapshot into a process-specific JSON file.
+///
+/// The output filename includes the current process identifier. Serialization
+/// and file-system failures are reported through logging instead of being
+/// returned.
 pub fn write_resource_usage(dir: &Path, usage: &Usage) {
 	let pid = process::id();
 	let path = dir.join(format!("{RUNTIME_USAGE_PREFIX}.{pid}.json"));

--- a/src/core/metrics/mod.rs
+++ b/src/core/metrics/mod.rs
@@ -28,6 +28,11 @@ type Counts = SmallVec<[u64; 20]>;
 #[cfg(tokio_unstable)]
 type Bucket = (Range<Duration>, u64);
 
+/// Owns process-wide runtime, task, and request measurements.
+///
+/// Task monitoring is available in builds with Tokio's unstable metrics.
+/// Runtime monitoring additionally requires an embedding runtime handle, while
+/// request counters remain independent of either monitor.
 pub struct Metrics {
 	_runtime: Option<runtime::Handle>,
 
@@ -47,14 +52,38 @@ pub struct Metrics {
 	sched_histogram_last: Mutex<Counts>,
 
 	// TODO: move stats
+	/// Supplies identifiers for traced requests.
+	///
+	/// The tracing span consumes and increments the sequence when its fields
+	/// are evaluated. It is not an unconditional request-traffic counter.
 	pub requests_count: AtomicU64,
+
+	/// Counts request handlers that have finished in debug builds.
+	///
+	/// The counter is monotonic and remains separate from the gauge of handlers
+	/// still active. Release builds leave it at zero.
 	pub requests_handle_finished: AtomicU64,
+
+	/// Tracks request handlers currently executing in debug builds.
+	///
+	/// The value is a gauge rather than a lifetime total. Release builds leave
+	/// it at zero.
 	pub requests_handle_active: AtomicU32,
+
+	/// Counts request handlers that terminated through panic handling.
+	///
+	/// The counter is scoped to request handling rather than all process
+	/// panics. It is monotonic for the lifetime of the process.
 	pub requests_panic: AtomicU32,
 }
 
 impl Metrics {
 	#[must_use]
+	/// Creates shared metrics state for an optional runtime.
+	///
+	/// A runtime handle enables runtime snapshots. Builds exposing Tokio's
+	/// unstable metrics also install task monitoring independently of that
+	/// handle.
 	pub fn new(runtime: Option<&runtime::Handle>) -> Arc<Self> {
 		#[cfg(tokio_unstable)]
 		let runtime_monitor = runtime.map(RuntimeMonitor::new);
@@ -104,6 +133,10 @@ impl Metrics {
 	}
 
 	#[inline]
+	/// Awaits a future under task instrumentation when a monitor is available.
+	///
+	/// Instrumented futures contribute to task interval snapshots. Builds
+	/// without a task monitor await the future directly with no wrapper.
 	pub async fn instrument<F, Output>(&self, f: F) -> Output
 	where
 		F: Future<Output = Output>,
@@ -115,6 +148,14 @@ impl Metrics {
 		}
 	}
 
+	/// Advances the task monitor and returns its next interval sample.
+	///
+	/// A server without task monitoring returns `None`. Samples describe only
+	/// futures explicitly passed through [`Self::instrument`].
+	///
+	/// # Panics
+	///
+	/// Panics when the interval mutex is poisoned.
 	pub fn task_interval(&self) -> Option<TaskMetrics> {
 		self.task_intervals
 			.lock()
@@ -124,6 +165,15 @@ impl Metrics {
 	}
 
 	#[cfg(tokio_unstable)]
+	/// Advances the runtime monitor and returns its next interval sample.
+	///
+	/// The returned value is absent only if the monitor's interval iterator
+	/// ends. Calls require a runtime handle to have been supplied at
+	/// construction.
+	///
+	/// # Panics
+	///
+	/// Panics when the interval mutex is poisoned or no runtime monitor exists.
 	pub fn runtime_interval(&self) -> Option<tokio_metrics::RuntimeMetrics> {
 		self.runtime_intervals
 			.lock()
@@ -139,6 +189,10 @@ impl Metrics {
 	/// previous sample and replaces it, so the counts are the traffic of one
 	/// interval rather than the totals tokio exposes. Returns `None` when the
 	/// runtime was built without the histogram.
+	///
+	/// # Panics
+	///
+	/// Panics when the scheduler histogram state mutex is poisoned.
 	#[cfg(tokio_unstable)]
 	pub fn sched_histogram_interval(&self) -> Option<impl Iterator<Item = Bucket>> {
 		let metrics = self
@@ -171,15 +225,28 @@ impl Metrics {
 	}
 
 	#[inline]
+	/// Returns the number of workers in the monitored runtime.
+	///
+	/// A server constructed without a runtime handle reports zero. The value
+	/// comes directly from Tokio's runtime metrics snapshot.
 	pub fn num_workers(&self) -> usize {
 		self.runtime_metrics()
 			.map_or(0, runtime::RuntimeMetrics::num_workers)
 	}
 
 	#[inline]
+	/// Returns the optional task monitor.
+	///
+	/// The monitor exists only when task metrics were enabled at construction.
+	/// It may be used to instrument futures or inspect cumulative task
+	/// measurements.
 	pub fn task_metrics(&self) -> Option<&TaskMonitor> { self.task_monitor.as_ref() }
 
 	#[inline]
+	/// Returns the optional Tokio runtime metrics handle.
+	///
+	/// The handle exists when server construction received an embedding
+	/// runtime. Callers borrow it without advancing any interval monitor.
 	pub fn runtime_metrics(&self) -> Option<&runtime::RuntimeMetrics> {
 		self.runtime_metrics.as_ref()
 	}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,12 +1,42 @@
+//! Provides shared runtime foundations for Tuwunel.
+//!
+//! The crate centralizes configuration, errors, Matrix data types, logging,
+//! metrics, server lifecycle state, and reusable utilities. Higher-level
+//! workspace crates consume these APIs through a shared foundational
+//! dependency.
+#![deny(missing_docs)]
+
 pub mod alloc;
+/// Loads and validates server configuration.
+///
+/// Configuration types preserve startup sources for reloads and expose typed
+/// settings to the rest of the workspace. Field documentation also supplies the
+/// generated example configuration.
 pub mod config;
 pub mod debug;
+/// Defines shared error and result types.
+///
+/// Errors retain protocol and transport context across crate boundaries. The
+/// module also provides the macros used to construct and report them.
 pub mod error;
 pub mod info;
+/// Configures structured logging and in-memory capture.
+///
+/// The module builds tracing layers for supported output targets. It also
+/// exposes scoped capture and reload controls to the server.
 pub mod log;
 pub mod matrix;
+/// Collects task, runtime, and request metrics.
+///
+/// Runtime instrumentation is enabled when the required Tokio facilities are
+/// available. Snapshot helpers expose interval data to diagnostics and
+/// telemetry.
 pub mod metrics;
 pub mod mods;
+/// Tracks server lifecycle state and its runtime handle.
+///
+/// The server coordinates reload, restart, and shutdown notifications. Shared
+/// services use its state to stop work promptly during teardown.
 pub mod server;
 pub mod utils;
 
@@ -33,14 +63,26 @@ pub use crate as tuwunel_core;
 rustc_flags_capture! {}
 
 #[cfg(any(not(tuwunel_mods), not(feature = "tuwunel_mods")))]
+/// Provides inert dynamic-module hooks when module loading is unavailable.
+///
+/// The fallback keeps call sites portable across builds with and without the
+/// dynamic module feature. Its exported macros intentionally perform no work.
 pub mod mods {
 	use log as _;
 
 	#[macro_export]
+	/// Defines an empty module-constructor hook.
+	///
+	/// Builds without dynamic module support can keep the same `mod_ctor!`
+	/// invocation as enabled builds. Invoking it emits no constructor.
 	macro_rules! mod_ctor {
 		() => {};
 	}
 	#[macro_export]
+	/// Defines an empty module-destructor hook.
+	///
+	/// Builds without dynamic module support can keep the same `mod_dtor!`
+	/// invocation as enabled builds. Invoking it emits no destructor.
 	macro_rules! mod_dtor {
 		() => {};
 	}

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -61,6 +61,11 @@ pub struct Server {
 
 impl Server {
 	#[must_use]
+	/// Creates shared server lifecycle state.
+	///
+	/// The initial configuration, source list, logging state, and metrics
+	/// become available to all services. A supplied runtime handle enables
+	/// task spawning.
 	pub fn new(
 		config: Config,
 		config_sources: config::Sources,
@@ -84,6 +89,11 @@ impl Server {
 		}
 	}
 
+	/// Requests a dynamic module reload.
+	///
+	/// The request marks the server as reloading and stopping before
+	/// broadcasting `SIGINT`. Concurrent reload or shutdown requests are
+	/// rejected.
 	pub fn reload(&self) -> Result {
 		if cfg!(any(not(tuwunel_mods), not(feature = "tuwunel_mods"))) {
 			return Err!("Reloading not enabled");
@@ -103,6 +113,10 @@ impl Server {
 		})
 	}
 
+	/// Requests a process restart through the normal shutdown path.
+	///
+	/// The restarting flag is claimed once before shutdown begins. A rejected
+	/// shutdown clears that flag so a later request may retry.
 	pub fn restart(&self) -> Result {
 		if self.restarting.swap(true, Ordering::AcqRel) {
 			return Err!("Restart already in progress");
@@ -113,6 +127,10 @@ impl Server {
 		})
 	}
 
+	/// Requests an orderly server shutdown.
+	///
+	/// The stopping flag is claimed once before broadcasting `SIGTERM`. A
+	/// second request is rejected while shutdown remains in progress.
 	pub fn shutdown(&self) -> Result {
 		if self.stopping.swap(true, Ordering::AcqRel) {
 			return Err!("Shutdown already in progress");
@@ -130,12 +148,20 @@ impl Server {
 		!self.backup_restored.swap(true, Ordering::AcqRel)
 	}
 
+	/// Broadcasts a process-signal name to lifecycle subscribers.
+	///
+	/// Delivery is best effort because subscribers may not yet be listening.
+	/// The method therefore succeeds even when the channel has no receivers.
 	pub fn signal(&self, sig: &'static str) -> Result {
 		self.signal.send(sig).ok();
 		Ok(())
 	}
 
 	#[inline]
+	/// Waits until the server enters its stopping state.
+	///
+	/// Lifecycle notifications wake the loop so it can recheck the shared
+	/// state. Calling it after shutdown has begun returns immediately.
 	pub async fn until_shutdown(self: &Arc<Self>) {
 		let mut signal = self.signal.subscribe();
 		while self.is_running() {
@@ -144,6 +170,14 @@ impl Server {
 	}
 
 	#[inline]
+	/// Returns the runtime handle supplied during server construction.
+	///
+	/// Services use this handle to spawn work on the embedding runtime. The
+	/// handle is borrowed for the lifetime of the server.
+	///
+	/// # Panics
+	///
+	/// Panics when the server was constructed without a runtime handle.
 	pub fn runtime(&self) -> &runtime::Handle {
 		self.runtime
 			.as_ref()
@@ -151,6 +185,10 @@ impl Server {
 	}
 
 	#[inline]
+	/// Rejects new work after shutdown begins.
+	///
+	/// A running server returns success. A stopping server returns an
+	/// interrupted I/O error wrapped in the shared error type.
 	pub fn check_running(&self) -> Result {
 		use std::{io, io::ErrorKind::Interrupted};
 
@@ -161,17 +199,39 @@ impl Server {
 	}
 
 	#[inline]
+	/// Reports whether the server still accepts work.
+	///
+	/// Running is the inverse of the stopping state. Reload and restart
+	/// requests also transition the server through stopping.
 	pub fn is_running(&self) -> bool { !self.is_stopping() }
 
 	#[inline]
+	/// Reports whether shutdown has begun.
+	///
+	/// The flag is set by shutdown and reload transitions. Reads are relaxed
+	/// because callers use it as a lifecycle observation rather than a
+	/// synchronization edge.
 	pub fn is_stopping(&self) -> bool { self.stopping.load(Ordering::Relaxed) }
 
 	#[inline]
+	/// Reports whether a dynamic module reload is in progress.
+	///
+	/// Reload claims the flag before checking the stopping state.
+	/// Signal-delivery failure clears it, while rejection by an existing
+	/// shutdown can leave it set.
 	pub fn is_reloading(&self) -> bool { self.reloading.load(Ordering::Relaxed) }
 
 	#[inline]
+	/// Reports whether a process restart is in progress.
+	///
+	/// Restart claims the flag before requesting shutdown. Failed shutdown
+	/// initiation clears it for a later attempt.
 	pub fn is_restarting(&self) -> bool { self.restarting.load(Ordering::Relaxed) }
 
 	#[inline]
+	/// Reports whether a name matches the configured local server name.
+	///
+	/// The comparison uses the active configuration snapshot. It performs an
+	/// exact, case-sensitive string comparison.
 	pub fn is_ours(&self, name: &str) -> bool { name == self.config.server_name }
 }

--- a/src/core/utils/arrayvec.rs
+++ b/src/core/utils/arrayvec.rs
@@ -1,6 +1,18 @@
 use ::arrayvec::ArrayVec;
 
+/// Adds fluent slice extension to fixed-capacity vectors.
+///
+/// Elements are copied into the vector's inline storage. The returned mutable
+/// reference permits continued method chaining.
 pub trait ArrayVecExt<T> {
+	/// Appends every element from `other` and returns the vector.
+	///
+	/// The operation copies the slice without allocating fallback storage. On
+	/// success, each slice element is appended in order.
+	///
+	/// # Panics
+	///
+	/// Panics when the remaining capacity cannot hold the entire slice.
 	fn extend_from_slice(&mut self, other: &[T]) -> &mut Self;
 }
 

--- a/src/core/utils/bool.rs
+++ b/src/core/utils/bool.rs
@@ -2,62 +2,166 @@
 
 use futures::future::OptionFuture;
 
-/// Boolean extensions and chain.starters
+/// Adds composable branching and conversion operations to Boolean values.
+///
+/// The adapters map conditions into options, results, futures, or selected
+/// values. Lazy variants invoke their closure only on the documented branch.
 pub trait BoolExt {
+	/// Retains `t` only when the Boolean is true.
+	///
+	/// A false value produces `None` regardless of `t`. An existing `None`
+	/// remains absent on either branch.
 	fn and<T>(self, t: Option<T>) -> Option<T>;
 
+	/// Computes the conjunction with another Boolean.
+	///
+	/// Both operands are already evaluated before the method runs. The result
+	/// is true only when both values are true.
 	#[must_use]
 	fn and_is(self, b: bool) -> bool;
 
+	/// Computes a conjunction with the closure's Boolean result.
+	///
+	/// The closure is invoked even when the receiver is false. Its result is
+	/// then combined with the receiver using logical conjunction.
 	#[must_use]
 	fn and_if<F: FnOnce() -> bool>(self, f: F) -> bool;
 
+	/// Invokes `f` and returns its option only when the Boolean is true.
+	///
+	/// A false receiver returns `None` without calling the closure. A true
+	/// receiver preserves either option variant returned by `f`.
 	fn and_then<T, F: FnOnce() -> Option<T>>(self, f: F) -> Option<T>;
 
+	/// Clones `t` when true or returns `err` when false.
+	///
+	/// The referenced value is cloned only for the true branch. The owned
+	/// fallback is returned for false and dropped for true.
 	#[must_use]
 	fn clone_or<T: Clone>(self, err: T, t: &T) -> T;
 
+	/// Copies `t` when true or returns `err` when false.
+	///
+	/// Both candidate values are passed by value. The Boolean selects which
+	/// copy becomes the result.
 	#[must_use]
 	fn copy_or<T: Copy>(self, err: T, t: T) -> T;
 
+	/// Asserts that the Boolean is true and returns it.
+	///
+	/// A successful assertion always returns `true`. The supplied message is
+	/// used only for a failed assertion.
+	///
+	/// # Panics
+	///
+	/// Panics with `msg` when the Boolean is false.
 	#[must_use]
 	fn expect(self, msg: &str) -> Self;
 
+	/// Asserts that the Boolean is false and returns it.
+	///
+	/// A successful assertion always returns `false`. The supplied message is
+	/// used only for a failed assertion.
+	///
+	/// # Panics
+	///
+	/// Panics with `msg` when the Boolean is true.
 	#[must_use]
 	fn expect_false(self, msg: &str) -> Self;
 
+	/// Converts true to `Some(())` and false to `None`.
+	///
+	/// The unit value carries no additional state. The option is useful for
+	/// continuing condition-driven combinator chains.
 	fn into_option(self) -> Option<()>;
 
+	/// Converts true to `Ok(())` and false to `Err(())`.
+	///
+	/// Both result payloads are unit values. The conversion preserves only the
+	/// receiver's success or failure state.
 	#[expect(clippy::result_unit_err)]
 	fn into_result(self) -> Result<(), ()>;
 
+	/// Reports whether the Boolean is false.
+	///
+	/// The receiver is borrowed rather than consumed. The returned value is the
+	/// logical negation of the receiver.
 	#[must_use]
 	fn is_false(&self) -> Self;
 
+	/// Applies `f` to the Boolean value.
+	///
+	/// The closure is invoked exactly once for either Boolean branch. This
+	/// method allows a Boolean to begin a generic method chain.
 	fn map<T, F: FnOnce(Self) -> T>(self, f: F) -> T
 	where
 		Self: Sized;
 
+	/// Maps true through `f` or returns `err` for false.
+	///
+	/// The closure is called only for the true branch. The error is supplied
+	/// eagerly, returned for false, and dropped for true.
 	fn map_ok_or<T, E, F: FnOnce() -> T>(self, err: E, f: F) -> Result<T, E>;
 
+	/// Maps true through `f` or returns `err` for false.
+	///
+	/// The closure is called only for the true branch. The fallback value is
+	/// returned directly when the receiver is false.
 	fn map_or<T, F: FnOnce() -> T>(self, err: T, f: F) -> T;
 
+	/// Selects between lazy false and true branch closures.
+	///
+	/// `f` is invoked when the receiver is true, while `err` is invoked when it
+	/// is false. Exactly one closure runs.
 	fn map_or_else<T, E: FnOnce() -> T, F: FnOnce() -> T>(self, err: E, f: F) -> T;
 
+	/// Converts true to `Ok(())` and false to the supplied error.
+	///
+	/// The error value is supplied eagerly and returned by the false branch.
+	/// The true branch drops it and carries a unit success value.
 	fn ok_or<E>(self, err: E) -> Result<(), E>;
 
+	/// Converts true to `Ok(())` or lazily creates an error for false.
+	///
+	/// The closure is called only when the receiver is false. A true receiver
+	/// produces the unit success value directly.
 	fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<(), E>;
 
+	/// Invokes `f` and returns its value only when the Boolean is false.
+	///
+	/// A true receiver returns `None` without calling the closure. It is the
+	/// false-branch counterpart to `bool::then`.
 	fn or<T, F: FnOnce() -> T>(self, f: F) -> Option<T>;
 
+	/// Returns `Some(t)` when false and `None` when true.
+	///
+	/// The supplied value is returned for false and dropped for true. It is the
+	/// inverse of `bool::then_some`.
 	fn or_some<T>(self, t: T) -> Option<T>;
 
+	/// Creates an optional future only when the Boolean is true.
+	///
+	/// The closure is not invoked for a false receiver. Awaiting the returned
+	/// [`OptionFuture`] yields `Some(output)` when constructed or `None`
+	/// otherwise.
 	fn then_async<O: Future, F: FnOnce() -> O>(self, f: F) -> OptionFuture<O>;
 
+	/// Produces an absent option for any Boolean value.
+	///
+	/// The receiver is consumed only to preserve chain shape. No value is
+	/// constructed for either branch.
 	fn then_none<T>(self) -> Option<T>;
 
+	/// Returns `Ok(t)` when true or `Err(e)` when false.
+	///
+	/// Both values are supplied eagerly and the Boolean selects the result
+	/// variant. Neither value is converted.
 	fn then_ok_or<T, E>(self, t: T, e: E) -> Result<T, E>;
 
+	/// Returns `Ok(t)` when true or lazily creates an error when false.
+	///
+	/// The error closure is called only for the false branch. The success value
+	/// is moved into `Ok` when the receiver is true.
 	fn then_ok_or_else<T, E, F: FnOnce() -> E>(self, t: T, e: F) -> Result<T, E>;
 }
 

--- a/src/core/utils/bytes.rs
+++ b/src/core/utils/bytes.rs
@@ -50,6 +50,10 @@ pub fn pretty(bytes: usize) -> String {
 	ByteSize::b(bytes).display().iec().to_string()
 }
 
+/// Increments an optional big-endian counter with wrapping arithmetic.
+///
+/// Missing or malformed input is treated as zero. The returned array contains
+/// the incremented value in big-endian byte order.
 #[inline]
 #[must_use]
 pub fn increment(old: Option<&[u8]>) -> [u8; 8] {

--- a/src/core/utils/future/bool_ext.rs
+++ b/src/core/utils/future/bool_ext.rs
@@ -11,26 +11,47 @@ use futures::{
 
 use crate::utils::BoolExt as _;
 
+/// Combines Boolean futures with concurrent short-circuit logic.
+///
+/// Conjunction resolves false on the first false output and true only after
+/// every input resolves true. Disjunction resolves true on the first true
+/// output and false only after every input resolves false.
 pub trait BoolExt
 where
 	Self: Future<Output = bool> + Send,
 {
+	/// Computes the disjunction of two Boolean futures.
+	///
+	/// Both futures are polled concurrently. The returned future resolves true
+	/// on the first true output or false after both produce false.
 	fn or<B>(self, b: B) -> impl Future<Output = bool> + Send
 	where
 		B: Future<Output = bool> + Send + Unpin,
 		Self: Sized + Unpin;
 
+	/// Computes the conjunction of two Boolean futures.
+	///
+	/// Both futures are polled concurrently. The returned future resolves false
+	/// on the first false output or true after both produce true.
 	fn and<B>(self, b: B) -> impl Future<Output = bool> + Send
 	where
 		B: Future<Output = bool> + Send,
 		Self: Sized;
 
+	/// Computes the conjunction of three Boolean futures.
+	///
+	/// The receiver and both arguments are polled concurrently. The result is
+	/// true only when all three futures produce true.
 	fn and2<B, C>(self, b: B, c: C) -> impl Future<Output = bool> + Send
 	where
 		B: Future<Output = bool> + Send,
 		C: Future<Output = bool> + Send,
 		Self: Sized;
 
+	/// Computes the conjunction of four Boolean futures.
+	///
+	/// The receiver and all three arguments are polled concurrently. The result
+	/// is true only when every future produces true.
 	fn and3<B, C, D>(self, b: B, c: C, d: D) -> impl Future<Output = bool> + Send
 	where
 		B: Future<Output = bool> + Send,
@@ -79,6 +100,10 @@ where
 	}
 }
 
+/// Computes the conjunction of an iterator of Boolean futures.
+///
+/// All inputs are polled concurrently and false short-circuits the operation.
+/// An empty iterator resolves to true.
 pub fn and<I, F>(args: I) -> impl Future<Output = bool> + Send
 where
 	I: Iterator<Item = F> + Send,
@@ -89,6 +114,14 @@ where
 	try_join_all(args).map(|res| res.is_ok())
 }
 
+/// Computes the disjunction of an iterator of Boolean futures.
+///
+/// All inputs are polled concurrently and true short-circuits the operation.
+/// False is returned only after every input resolves to false.
+///
+/// # Panics
+///
+/// Panics when the iterator contains no futures.
 pub fn or<I, F>(args: I) -> impl Future<Output = bool> + Send
 where
 	I: Iterator<Item = F> + Send,
@@ -99,6 +132,10 @@ where
 	select_ok(args).map(|res| res.is_ok())
 }
 
+/// Computes the conjunction of four Boolean futures.
+///
+/// All four inputs are polled concurrently. The result is true only when every
+/// future resolves to true.
 pub fn and4(
 	a: impl Future<Output = bool> + Send,
 	b: impl Future<Output = bool> + Send,
@@ -108,6 +145,10 @@ pub fn and4(
 	a.and3(b, c, d)
 }
 
+/// Computes the conjunction of five Boolean futures.
+///
+/// All five inputs are polled concurrently. The result is true only when every
+/// future resolves to true.
 pub fn and5(
 	a: impl Future<Output = bool> + Send,
 	b: impl Future<Output = bool> + Send,
@@ -118,6 +159,10 @@ pub fn and5(
 	a.and2(b, c).and2(d, e)
 }
 
+/// Computes the conjunction of six Boolean futures.
+///
+/// All six inputs are polled concurrently. The result is true only when every
+/// future resolves to true.
 pub fn and6(
 	a: impl Future<Output = bool> + Send,
 	b: impl Future<Output = bool> + Send,
@@ -129,6 +174,10 @@ pub fn and6(
 	a.and3(b, c, d).and2(e, f)
 }
 
+/// Computes the conjunction of seven Boolean futures.
+///
+/// All seven inputs are polled concurrently. The result is true only when every
+/// future resolves to true.
 pub fn and7(
 	a: impl Future<Output = bool> + Send,
 	b: impl Future<Output = bool> + Send,

--- a/src/core/utils/future/ext_ext.rs
+++ b/src/core/utils/future/ext_ext.rs
@@ -2,11 +2,18 @@
 
 use futures::{future, future::Select};
 
-/// This interface is not necessarily complete; feel free to add as-needed.
+/// Adds a stop-future race to ordinary futures.
+///
+/// The returned selector resolves when either future completes. Its output
+/// identifies the winner and retains the unfinished future.
 pub trait ExtExt<T>
 where
 	Self: Future<Output = T> + Send,
 {
+	/// Races the receiver against a unit-output stopping future.
+	///
+	/// `f` constructs the stopping future when the selector is created. The
+	/// returned [`Select`] preserves whichever future has not completed.
 	fn until<A, B, F>(self, f: F) -> Select<A, B>
 	where
 		Self: Sized,

--- a/src/core/utils/future/option_ext.rs
+++ b/src/core/utils/future/option_ext.rs
@@ -4,19 +4,48 @@ use futures::{FutureExt, future::OptionFuture};
 
 use super::super::BoolExt;
 
+/// Adds option-like combinators to futures with optional output.
+///
+/// Each adapter transforms the eventual `Option<T>` without requiring an
+/// intermediate await. Lazy fallbacks run only for absent output.
 pub trait OptionFutureExt<T> {
+	/// Tests whether the future yields no value or one matching `f`.
+	///
+	/// An absent output returns true without invoking the predicate. A present
+	/// value is borrowed for the predicate after the future resolves.
 	fn is_none_or(self, f: impl FnOnce(&T) -> bool + Send) -> impl Future<Output = bool> + Send;
 
+	/// Tests whether the future yields a value matching `f`.
+	///
+	/// An absent output returns false without invoking the predicate. A present
+	/// value is borrowed for the predicate after the future resolves.
 	fn is_some_and(self, f: impl FnOnce(&T) -> bool + Send) -> impl Future<Output = bool> + Send;
 
+	/// Returns the future's value or the supplied fallback.
+	///
+	/// The fallback is supplied eagerly and used only for absent output. A
+	/// present value passes through unchanged.
 	fn unwrap_or(self, t: T) -> impl Future<Output = T> + Send;
 
+	/// Returns the future's value or `T::default()`.
+	///
+	/// The default is constructed only after the future yields `None`. A
+	/// present value passes through unchanged.
 	fn unwrap_or_default(self) -> impl Future<Output = T> + Send
 	where
 		T: Default;
 
+	/// Returns the future's value or lazily computes a fallback.
+	///
+	/// The closure is called only after the future yields `None`. A present
+	/// value passes through without invoking it.
 	fn unwrap_or_else(self, f: impl FnOnce() -> T + Send) -> impl Future<Output = T> + Send;
 
+	/// Runs an asynchronous fallback only when the future yields `None`.
+	///
+	/// Absent output becomes `Some` of the fallback future's output. Present
+	/// output suppresses the fallback and becomes `None` rather than being
+	/// returned.
 	fn unwrap_or_else_async<F: Future<Output = T> + Send>(
 		self,
 		f: impl FnOnce() -> F + Send,

--- a/src/core/utils/future/option_stream.rs
+++ b/src/core/utils/future/option_stream.rs
@@ -2,7 +2,16 @@ use futures::{FutureExt, Stream, StreamExt, future::OptionFuture};
 
 use super::super::IterStream;
 
+/// Converts an optional future of initial and trailing items into a stream.
+///
+/// A present future yields its iterable items before chaining its trailing
+/// stream. An absent future becomes an empty stream.
 pub trait OptionStream<T> {
+	/// Flattens the optional future into one ordered stream.
+	///
+	/// Items from the returned iterable are emitted before the accompanying
+	/// stream is polled. No items are emitted when the optional future is
+	/// absent.
 	fn stream(self) -> impl Stream<Item = T> + Send;
 }
 

--- a/src/core/utils/future/ready_bool_ext.rs
+++ b/src/core/utils/future/ready_bool_ext.rs
@@ -2,13 +2,25 @@
 
 use super::ReadyEqExt;
 
+/// Tests the Boolean output of a future without awaiting it early.
+///
+/// The helpers attach equality comparisons to the future. Each returned future
+/// resolves to the requested truth-state test.
 pub trait ReadyBoolExt
 where
 	Self: Future<Output = bool> + ReadyEqExt<bool> + Send,
 {
+	/// Reports whether the future resolves to false.
+	///
+	/// The receiver is consumed, then its output is compared with `false` after
+	/// completion.
 	#[inline]
 	fn is_false(self) -> impl Future<Output = bool> + Send { self.eq(&false) }
 
+	/// Reports whether the future resolves to true.
+	///
+	/// The receiver is consumed, then its output is compared with `true` after
+	/// completion.
 	#[inline]
 	fn is_true(self) -> impl Future<Output = bool> + Send { self.eq(&true) }
 }

--- a/src/core/utils/future/ready_eq_ext.rs
+++ b/src/core/utils/future/ready_eq_ext.rs
@@ -2,13 +2,25 @@
 
 use futures::FutureExt;
 
+/// Compares a future's output with a borrowed value.
+///
+/// The comparison is attached to the future and runs when it resolves. Both
+/// equality and inequality forms preserve asynchronous composition.
 pub trait ReadyEqExt<T>
 where
 	Self: Future<Output = T> + Send + Sized,
 	T: PartialEq + Send + Sync,
 {
+	/// Tests whether the future's output equals `t`.
+	///
+	/// The comparison borrows the supplied value until the returned future
+	/// completes. The output value is consumed after comparison.
 	fn eq(self, t: &T) -> impl Future<Output = bool> + Send;
 
+	/// Tests whether the future's output differs from `t`.
+	///
+	/// The comparison borrows the supplied value until the returned future
+	/// completes. The output value is consumed after comparison.
 	fn ne(self, t: &T) -> impl Future<Output = bool> + Send;
 }
 

--- a/src/core/utils/future/try_ext_ext.rs
+++ b/src/core/utils/future/try_ext_ext.rs
@@ -9,17 +9,29 @@ use futures::{
 	future::{MapOkOrElse, TrySelect, UnwrapOrElse},
 };
 
-/// This interface is not necessarily complete; feel free to add as-needed.
+/// Adds result-like combinators to fallible futures.
+///
+/// The adapters transform the eventual success or error without awaiting the
+/// future early. Inspection helpers reduce either result branch to a Boolean
+/// and discard its payload.
 pub trait TryExtExt<T, E>
 where
 	Self: TryFuture<Ok = T, Error = E> + Send,
 {
+	/// Reports whether the future resolves to an error.
+	///
+	/// Both output payloads are discarded after the future completes. The
+	/// returned future preserves only the error-state Boolean.
 	fn is_err(
 		self,
 	) -> MapOkOrElse<Self, impl FnOnce(Self::Ok) -> bool, impl FnOnce(Self::Error) -> bool>
 	where
 		Self: Sized;
 
+	/// Reports whether the future resolves successfully.
+	///
+	/// Both output payloads are discarded after the future completes. The
+	/// returned future preserves only the success-state Boolean.
 	#[expect(clippy::wrong_self_convention)]
 	fn is_ok(
 		self,
@@ -27,6 +39,10 @@ where
 	where
 		Self: Sized;
 
+	/// Maps a successful output or returns an eager fallback for errors.
+	///
+	/// The mapping closure runs only for the success branch. The original error
+	/// is discarded, and the fallback is dropped when mapping succeeds.
 	fn map_ok_or<U, F>(
 		self,
 		default: U,
@@ -36,6 +52,10 @@ where
 		F: FnOnce(Self::Ok) -> U,
 		Self: Send + Sized;
 
+	/// Converts the fallible future's output into an option.
+	///
+	/// A successful value becomes `Some`, while any error becomes `None`. The
+	/// original error value is discarded.
 	fn ok(
 		self,
 	) -> MapOkOrElse<
@@ -46,6 +66,11 @@ where
 	where
 		Self: Sized;
 
+	/// Races the receiver against a fallible unit-output stopping future.
+	///
+	/// `f` constructs the stopping future when the selector is created. The
+	/// returned [`TrySelect`] preserves the winning result and unfinished
+	/// future.
 	fn try_until<A, B, F>(self, f: F) -> TrySelect<A, B>
 	where
 		Self: Sized,
@@ -53,6 +78,10 @@ where
 		A: TryFuture<Ok = Self::Ok> + From<Self> + Send + Unpin,
 		B: TryFuture<Ok = (), Error = Self::Error> + Send + Unpin;
 
+	/// Returns a successful output or an eager fallback for errors.
+	///
+	/// The original error is discarded after the future resolves. The fallback
+	/// is dropped when the future succeeds.
 	fn unwrap_or(
 		self,
 		default: Self::Ok,
@@ -60,6 +89,10 @@ where
 	where
 		Self: Sized;
 
+	/// Returns a successful output or its type's default for errors.
+	///
+	/// The default is constructed eagerly when the adapter is created and is
+	/// dropped when the future succeeds. The original error value is discarded.
 	fn unwrap_or_default(self) -> UnwrapOrElse<Self, impl FnOnce(Self::Error) -> Self::Ok>
 	where
 		Self: Sized,

--- a/src/core/utils/hash/sha256.rs
+++ b/src/core/utils/hash/sha256.rs
@@ -3,6 +3,10 @@ use ring::{
 	digest::{Context, SHA256, SHA256_OUTPUT_LEN},
 };
 
+/// Fixed-size output of a SHA-256 digest operation.
+///
+/// The array contains the algorithm's 32 output bytes in digest order. It can
+/// be encoded or compared without an additional allocation.
 pub type Digest = [u8; SHA256_OUTPUT_LEN];
 
 /// Sha256 hash (input gather joined by 0xFF bytes)

--- a/src/core/utils/math/expect_into.rs
+++ b/src/core/utils/math/expect_into.rs
@@ -1,4 +1,16 @@
+/// Converts values through [`TryFrom`] and expects conversion to succeed.
+///
+/// The destination type is selected by the caller or inferred from context.
+/// Conversion failures are treated as violated program invariants.
 pub trait ExpectInto {
+	/// Converts the value into `Dst` and returns the successful result.
+	///
+	/// The implementation delegates to the shared checked conversion helper. It
+	/// discards the conversion error after using a fixed expectation message.
+	///
+	/// # Panics
+	///
+	/// Panics when `Dst::try_from` rejects the source value.
 	#[inline]
 	#[must_use]
 	fn expect_into<Dst: TryFrom<Self>>(self) -> Dst

--- a/src/core/utils/math/expected.rs
+++ b/src/core/utils/math/expected.rs
@@ -2,7 +2,18 @@ use num_traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, C
 
 use crate::expected;
 
+/// Provides checked arithmetic for operations expected to succeed.
+///
+/// Each method delegates to the corresponding `Checked*` trait. A failed check
+/// is treated as a violated program invariant and panics.
 pub trait Expected {
+	/// Adds `rhs` with an expectation that the operation is valid.
+	///
+	/// A successful checked addition returns its value unchanged.
+	///
+	/// # Panics
+	///
+	/// Panics when the underlying [`CheckedAdd`] operation returns `None`.
 	#[inline]
 	#[must_use]
 	fn expected_add(self, rhs: Self) -> Self
@@ -12,6 +23,13 @@ pub trait Expected {
 		expected!(self + rhs)
 	}
 
+	/// Subtracts `rhs` with an expectation that the operation is valid.
+	///
+	/// A successful checked subtraction returns its value unchanged.
+	///
+	/// # Panics
+	///
+	/// Panics when the underlying [`CheckedSub`] operation returns `None`.
 	#[inline]
 	#[must_use]
 	fn expected_sub(self, rhs: Self) -> Self
@@ -21,6 +39,13 @@ pub trait Expected {
 		expected!(self - rhs)
 	}
 
+	/// Multiplies by `rhs` with an expectation that the operation is valid.
+	///
+	/// A successful checked multiplication returns its value unchanged.
+	///
+	/// # Panics
+	///
+	/// Panics when the underlying [`CheckedMul`] operation returns `None`.
 	#[inline]
 	#[must_use]
 	fn expected_mul(self, rhs: Self) -> Self
@@ -30,6 +55,13 @@ pub trait Expected {
 		expected!(self * rhs)
 	}
 
+	/// Divides by `rhs` with an expectation that the operation is valid.
+	///
+	/// A successful checked division returns its value unchanged.
+	///
+	/// # Panics
+	///
+	/// Panics when the underlying [`CheckedDiv`] operation returns `None`.
 	#[inline]
 	#[must_use]
 	fn expected_div(self, rhs: Self) -> Self
@@ -39,6 +71,13 @@ pub trait Expected {
 		expected!(self / rhs)
 	}
 
+	/// Computes the remainder with an expectation that the operation is valid.
+	///
+	/// A successful checked remainder returns its value unchanged.
+	///
+	/// # Panics
+	///
+	/// Panics when the underlying [`CheckedRem`] operation returns `None`.
 	#[inline]
 	#[must_use]
 	fn expected_rem(self, rhs: Self) -> Self

--- a/src/core/utils/math/tried.rs
+++ b/src/core/utils/math/tried.rs
@@ -2,7 +2,16 @@ use num_traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, C
 
 use crate::{Result, checked};
 
+/// Provides checked arithmetic that reports overflow and invalid operations.
+///
+/// Each method delegates to the corresponding `Checked*` trait. A successful
+/// operation returns its value through the crate's result type.
 pub trait Tried {
+	/// Adds `rhs` with checked arithmetic.
+	///
+	/// Values that the underlying [`CheckedAdd`] implementation accepts are
+	/// returned unchanged. Overflow is represented by the crate's arithmetic
+	/// error.
 	#[inline]
 	fn try_add(self, rhs: Self) -> Result<Self>
 	where
@@ -11,6 +20,11 @@ pub trait Tried {
 		checked!(self + rhs)
 	}
 
+	/// Subtracts `rhs` with checked arithmetic.
+	///
+	/// Values that the underlying [`CheckedSub`] implementation accepts are
+	/// returned unchanged. Overflow is represented by the crate's arithmetic
+	/// error.
 	#[inline]
 	fn try_sub(self, rhs: Self) -> Result<Self>
 	where
@@ -19,6 +33,11 @@ pub trait Tried {
 		checked!(self - rhs)
 	}
 
+	/// Multiplies by `rhs` with checked arithmetic.
+	///
+	/// Values that the underlying [`CheckedMul`] implementation accepts are
+	/// returned unchanged. Overflow is represented by the crate's arithmetic
+	/// error.
 	#[inline]
 	fn try_mul(self, rhs: Self) -> Result<Self>
 	where
@@ -27,6 +46,11 @@ pub trait Tried {
 		checked!(self * rhs)
 	}
 
+	/// Divides by `rhs` with checked arithmetic.
+	///
+	/// Values that the underlying [`CheckedDiv`] implementation accepts are
+	/// returned unchanged. Division by zero or overflow becomes the crate's
+	/// arithmetic error.
 	#[inline]
 	fn try_div(self, rhs: Self) -> Result<Self>
 	where
@@ -35,6 +59,11 @@ pub trait Tried {
 		checked!(self / rhs)
 	}
 
+	/// Computes the remainder by `rhs` with checked arithmetic.
+	///
+	/// Values that the underlying [`CheckedRem`] implementation accepts are
+	/// returned unchanged. A failed checked remainder, including a zero divisor
+	/// or overflow, becomes the crate's arithmetic error.
 	#[inline]
 	fn try_rem(self, rhs: Self) -> Result<Self>
 	where

--- a/src/core/utils/mod.rs
+++ b/src/core/utils/mod.rs
@@ -4,12 +4,28 @@
 //! common utilities shared across workspace crates. Frequently used helpers are
 //! re-exported through a single import path.
 
+/// Extensions for fixed-capacity `ArrayVec` values.
+///
+/// The module adds fluent slice extension while preserving the collection's
+/// fixed storage budget. Capacity exhaustion remains explicit through a panic.
 pub mod arrayvec;
 pub mod bool;
+/// Byte-size parsing, display, and integer encoding helpers.
+///
+/// The module handles human-readable sizes alongside fixed-width big-endian
+/// counters. Its size deserializers integrate human-readable values with Serde.
 pub mod bytes;
+/// HTTP content-disposition selection and filename sanitization.
+///
+/// Media types are checked against the safe-inline list before selecting a
+/// disposition. Optional filenames are sanitized before header construction.
 pub mod content_disposition;
 pub mod debug;
 pub mod defer;
+/// Additional combinators for futures and optional futures.
+///
+/// The extensions compose Boolean, optional, and fallible outputs without
+/// awaiting them early. Comparison and selection helpers are included.
 pub mod future;
 pub mod hash;
 pub mod html;
@@ -18,10 +34,26 @@ pub mod math;
 pub mod mutex_map;
 pub mod option;
 pub mod rand;
+/// Result aliases and composable result extensions.
+///
+/// The module covers filtering, inspection, logging, flattening, and
+/// expectation helpers. Most adapters preserve the original result type.
 pub mod result;
+/// Configuration-secret storage and resolution helpers.
+///
+/// Secrets may come from files or inline configuration. The storage type does
+/// not redact output or erase memory when dropped.
 pub mod secret;
 pub mod set;
+/// Stream adapters for synchronous, concurrent, and fallible transformations.
+///
+/// The module extends futures streams with ordered and completion-ordered
+/// concurrency, ready closures, aggregation, and result handling.
 pub mod stream;
+/// String conversion, serialization, and formatting helpers.
+///
+/// The module includes borrowed unquoted views, serde adapters, chunking, and
+/// UTF-8 conversion utilities. Specialized display wrappers avoid allocation.
 pub mod string;
 pub mod sys;
 #[cfg(test)]

--- a/src/core/utils/result.rs
+++ b/src/core/utils/result.rs
@@ -32,4 +32,8 @@ pub use self::{
 	unwrap_or_err::UnwrapOrErr,
 };
 
+/// Standard result type for core operations.
+///
+/// The success type defaults to `()`, while the error type defaults to the
+/// crate's [`crate::Error`]. Callers may override either type parameter.
 pub type Result<T = (), E = crate::Error> = std::result::Result<T, E>;

--- a/src/core/utils/result/and_then_ref.rs
+++ b/src/core/utils/result/and_then_ref.rs
@@ -1,6 +1,14 @@
 use super::Result;
 
+/// Chains a fallible operation over a shared reference to a success value.
+///
+/// The owned value is borrowed only while the callback runs. An existing error
+/// is forwarded without invoking the callback.
 pub trait AndThenRef<T, E> {
+	/// Applies `op` to a shared reference inside an `Ok` result.
+	///
+	/// The callback may replace the success type or return the same error type.
+	/// The original success value is dropped after the callback completes.
 	fn and_then_ref<U, F>(self, op: F) -> Result<U, E>
 	where
 		F: FnOnce(&T) -> Result<U, E>;

--- a/src/core/utils/result/expect_unchecked.rs
+++ b/src/core/utils/result/expect_unchecked.rs
@@ -2,14 +2,24 @@ use std::fmt::Debug;
 
 use super::Result;
 
+/// Extracts successful values through an unchecked result assertion.
+///
+/// Debug builds retain an assertion for the error branch. Release builds rely
+/// entirely on the caller's safety guarantee.
 pub trait ExpectUnchecked<T> {
-	/// Returns the contained Ok value, consuming self. In debug-mode an Err
-	/// panics with msg; in release-mode the check is elided and an Err is
-	/// undefined behavior.
+	/// Returns the contained `Ok` value without a release-mode branch check.
+	///
+	/// Debug builds use `msg` when asserting that the result is successful.
+	/// Release builds treat an `Err` value as unreachable.
+	///
+	/// # Panics
+	///
+	/// Panics in debug builds when the result is `Err`.
 	///
 	/// # Safety
 	///
-	/// The caller guarantees the Result is not Err.
+	/// The caller must guarantee the result is not `Err`; violating this in
+	/// release builds causes undefined behavior.
 	unsafe fn expect_unchecked(self, msg: &str) -> T;
 }
 

--- a/src/core/utils/result/filter.rs
+++ b/src/core/utils/result/filter.rs
@@ -1,7 +1,15 @@
 use super::Result;
 
+/// Adds fallible predicate filtering to successful results.
+///
+/// Existing errors bypass the predicate unchanged. Predicate failures are
+/// converted into the result's error type.
 pub trait Filter<T, E> {
-	/// Similar to Option::filter
+	/// Retains an `Ok` value when `predicate` succeeds.
+	///
+	/// The predicate receives a shared reference to the success value. Its
+	/// error is converted into `E`, while an existing `Err` bypasses the
+	/// predicate.
 	#[must_use]
 	fn filter<P, U>(self, predicate: P) -> Self
 	where

--- a/src/core/utils/result/flat_ok.rs
+++ b/src/core/utils/result/flat_ok.rs
@@ -1,5 +1,10 @@
 use super::Result;
 
+/// Flattens optional and fallible values while discarding their original error.
+///
+/// Implementations cover both `Option<Result<T, E>>` and
+/// `Result<Option<T>, E>`. Missing values and errors both become absence before
+/// an optional replacement error is applied.
 pub trait FlatOk<T> {
 	/// Equivalent to .transpose().ok().flatten()
 	fn flat_ok(self) -> Option<T>;

--- a/src/core/utils/result/inspect_log.rs
+++ b/src/core/utils/result/inspect_log.rs
@@ -5,13 +5,25 @@ use tracing::Level;
 use super::Result;
 use crate::error;
 
+/// Logs display-formatted errors while preserving their result.
+///
+/// Successful values pass through without producing a log record. Error
+/// values are inspected at the requested tracing level and remain unchanged.
 pub trait ErrLog<T, E>
 where
 	E: fmt::Display,
 {
+	/// Logs an error at `level` and returns the original result.
+	///
+	/// The error is formatted with [`fmt::Display`]. An `Ok` value produces no
+	/// record and is returned unchanged.
 	#[must_use]
 	fn log_err(self, level: Level) -> Self;
 
+	/// Logs an error at the error tracing level.
+	///
+	/// [`ErrLog::log_err`] supplies this convenience form with
+	/// [`Level::ERROR`]. The original result is returned after inspection.
 	#[inline]
 	#[must_use]
 	fn err_log(self) -> Self
@@ -22,13 +34,25 @@ where
 	}
 }
 
+/// Logs debug-formatted errors while preserving their result.
+///
+/// Successful values pass through without producing a log record. Error
+/// values are inspected at the requested tracing level and remain unchanged.
 pub trait ErrDebugLog<T, E>
 where
 	E: fmt::Debug,
 {
+	/// Logs an error at `level` and returns the original result.
+	///
+	/// The error is formatted with [`fmt::Debug`]. An `Ok` value produces no
+	/// record and is returned unchanged.
 	#[must_use]
 	fn log_err_debug(self, level: Level) -> Self;
 
+	/// Logs a debug-formatted error at the error tracing level.
+	///
+	/// [`ErrDebugLog::log_err_debug`] supplies this convenience form with
+	/// [`Level::ERROR`]. The original result is returned after inspection.
 	#[inline]
 	#[must_use]
 	fn err_debug_log(self) -> Self

--- a/src/core/utils/result/into_is_ok.rs
+++ b/src/core/utils/result/into_is_ok.rs
@@ -1,6 +1,14 @@
 use super::Result;
 
+/// Consumes a result and reduces it to success or failure.
+///
+/// Both contained values are discarded. The returned Boolean records only
+/// whether the original result was `Ok`.
 pub trait IntoIsOk<T, E> {
+	/// Reports whether the consumed result is `Ok`.
+	///
+	/// The success value and error are both discarded. No conversion or logging
+	/// is performed for either branch.
 	fn into_is_ok(self) -> bool;
 }
 

--- a/src/core/utils/result/is_err_or.rs
+++ b/src/core/utils/result/is_err_or.rs
@@ -2,7 +2,15 @@
 
 use super::Result;
 
+/// Tests whether a result is an error or its success value matches a predicate.
+///
+/// Every `Err` result returns true without exposing the error. An `Ok` result
+/// is consumed and passed to the predicate.
 pub trait IsErrOr<T> {
+	/// Returns true for any error or a matching success value.
+	///
+	/// The predicate is called only for the `Ok` branch. Both the success value
+	/// and any error are consumed.
 	fn is_err_or<F: FnOnce(T) -> bool>(self, f: F) -> bool;
 }
 

--- a/src/core/utils/result/log_debug_err.rs
+++ b/src/core/utils/result/log_debug_err.rs
@@ -5,10 +5,23 @@ use tracing::Level;
 use super::{DebugInspect, Result};
 use crate::error;
 
+/// Logs debug-formatted errors when debug assertions are enabled.
+///
+/// Successful values pass through without producing a record. With debug
+/// assertions disabled, errors also pass through without producing a record.
 pub trait LogDebugErr<T, E: Debug> {
+	/// Logs a debug-formatted error at `level` and returns the original result.
+	///
+	/// The error is formatted with [`Debug`] when debug assertions are enabled.
+	/// Successful values always produce no log record.
 	#[must_use]
 	fn err_debug_log(self, level: Level) -> Self;
 
+	/// Logs a debug-formatted error at the error tracing level.
+	///
+	/// [`LogDebugErr::err_debug_log`] supplies this convenience form with
+	/// [`Level::ERROR`]. Logging occurs only when debug assertions are enabled,
+	/// and the original result is returned after inspection.
 	#[must_use]
 	fn log_debug_err(self) -> Self
 	where

--- a/src/core/utils/result/log_err.rs
+++ b/src/core/utils/result/log_err.rs
@@ -5,10 +5,22 @@ use tracing::Level;
 use super::Result;
 use crate::error;
 
+/// Logs display-formatted errors without changing their result.
+///
+/// Successful values pass through without producing a record. Errors remain
+/// available to the caller after being logged.
 pub trait LogErr<T, E: Display> {
+	/// Logs an error at `level` and returns the original result.
+	///
+	/// The error is formatted with [`Display`]. Successful values produce no
+	/// log record.
 	#[must_use]
 	fn err_log(self, level: Level) -> Self;
 
+	/// Logs an error at the error tracing level.
+	///
+	/// [`LogErr::err_log`] supplies this convenience form with
+	/// [`Level::ERROR`]. The original result is returned after inspection.
 	#[must_use]
 	fn log_err(self) -> Self
 	where

--- a/src/core/utils/result/map_expect.rs
+++ b/src/core/utils/result/map_expect.rs
@@ -2,10 +2,19 @@ use std::fmt::Debug;
 
 use super::Result;
 
+/// Applies an expectation to a nested optional or fallible value.
+///
+/// Implementations cover `Option<Result<T, E>>` and `Result<Option<T>, E>`.
+/// Only the nested value is unwrapped, preserving the outer container.
 pub trait MapExpect<'a, T> {
-	/// Calls expect(msg) on the mapped Result value. This is similar to
-	/// map(Result::unwrap) but composes an expect call and message without
-	/// requiring a closure.
+	/// Unwraps the nested value with the supplied expectation message.
+	///
+	/// The outer `Option` or `Result` is preserved. The message is used only
+	/// when the nested value is absent or failed.
+	///
+	/// # Panics
+	///
+	/// Panics when the nested value does not contain a success value.
 	fn map_expect(self, msg: &'a str) -> T;
 }
 

--- a/src/core/utils/result/map_ref.rs
+++ b/src/core/utils/result/map_ref.rs
@@ -1,6 +1,14 @@
 use super::Result;
 
+/// Maps a successful result through a shared reference to its value.
+///
+/// The operation borrows the owned success value for the duration of the
+/// callback. An existing error is forwarded unchanged.
 pub trait MapRef<T, E> {
+	/// Applies `op` to a shared reference inside an `Ok` result.
+	///
+	/// The original success value is dropped after the callback returns. An
+	/// `Err` result bypasses the callback and preserves its error.
 	fn map_ref<U, F>(self, op: F) -> Result<U, E>
 	where
 		F: FnOnce(&T) -> U;

--- a/src/core/utils/result/not_found.rs
+++ b/src/core/utils/result/not_found.rs
@@ -1,7 +1,15 @@
 use super::Result;
 use crate::Error;
 
+/// Classifies results that contain the crate's not-found error family.
+///
+/// Successful results and unrelated errors are not classified as missing.
+/// Classification delegates to `Error::is_not_found`.
 pub trait NotFound<T> {
+	/// Reports whether the result contains a not-found error.
+	///
+	/// An `Ok` value always returns false. Other error variants also return
+	/// false without changing the result.
 	#[must_use]
 	fn is_not_found(&self) -> bool;
 }

--- a/src/core/utils/result/unwrap_infallible.rs
+++ b/src/core/utils/result/unwrap_infallible.rs
@@ -3,7 +3,15 @@ use std::convert::Infallible;
 use super::{DebugInspect, Result};
 use crate::error;
 
+/// Extracts the value from a result whose error type is uninhabited.
+///
+/// Only the `Ok` branch can be constructed for `Result<T, Infallible>`. The
+/// implementation uses an unchecked unwrap after a debug assertion.
 pub trait UnwrapInfallible<T> {
+	/// Returns the only constructible value from the result.
+	///
+	/// The uninhabited error type makes the `Err` branch unreachable. Consuming
+	/// the result requires no fallback value or closure.
 	fn unwrap_infallible(self) -> T;
 }
 

--- a/src/core/utils/result/unwrap_or_err.rs
+++ b/src/core/utils/result/unwrap_or_err.rs
@@ -7,6 +7,10 @@ use super::Result;
 /// Unlike `unwrap_or_default`, the `Err` branch retains its value instead of
 /// constructing `T::default()`.
 pub trait UnwrapOrErr<T> {
+	/// Returns the value carried by either result variant.
+	///
+	/// Both variants contain the same type, so neither branch needs conversion.
+	/// The result is consumed without constructing a fallback value.
 	fn unwrap_or_err(self) -> T;
 }
 

--- a/src/core/utils/secret.rs
+++ b/src/core/utils/secret.rs
@@ -5,16 +5,12 @@ use std::{fs::read_to_string, path::Path};
 
 use crate::{error, smallstr::SmallString};
 
+/// Owned string used for secret configuration values.
+///
+/// The type provides 64 bytes of inline capacity and spills to the heap when
+/// needed. It does not redact formatting or erase its contents on drop.
 pub type Secret = SmallString<[u8; 64]>;
 
-/// Resolves a secret configured either in `file` or inline.
-///
-/// The file is preferred, and its contents are trimmed because an editor or a
-/// systemd credential commonly leaves a trailing newline which the peer holding
-/// the other copy of the secret does not have. An inline value is taken as
-/// written. An unset or unreadable file falls back to `inline`; one which is
-/// present but blank resolves to nothing instead. `name` labels the read
-/// failure in the log.
 /// Whether a secret is configured at all.
 ///
 /// Answered without opening the file, so an unauthenticated caller cannot drive
@@ -25,6 +21,11 @@ pub fn is_set(file: Option<&Path>, inline: Option<&str>) -> bool {
 	file.is_some() || inline.is_some_and(|inline| !inline.is_empty())
 }
 
+/// Resolves a configured secret from a file or an inline value.
+///
+/// A successfully read file takes precedence and is trimmed; an empty file
+/// yields `None` instead of falling back inline. Read failures are logged and
+/// permit the inline value to be used, while empty values are discarded.
 #[must_use]
 pub fn resolve(file: Option<&Path>, inline: Option<&str>, name: &str) -> Option<Secret> {
 	let from_file = file.and_then(|path| {

--- a/src/core/utils/stream/broadband.rs
+++ b/src/core/utils/stream/broadband.rs
@@ -6,25 +6,41 @@ use futures::stream::{Stream, StreamExt};
 
 use super::{ReadyExt, automatic_width};
 
-/// Concurrency extensions to augment futures::StreamExt. broad_ combinators
-/// produce out-of-order
+/// Adds concurrent transformations with completion-ordered output.
+///
+/// Item futures may run ahead of downstream demand. Outputs are yielded as they
+/// become ready rather than in source order.
 pub trait BroadbandExt<Item>
 where
 	Self: Stream<Item = Item> + Send + Sized,
 {
+	/// Tests all items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight predicates, while `None` selects the automatic
+	/// width. An explicit zero cannot make progress. False short-circuits the
+	/// operation, and an empty stream resolves true.
 	fn broadn_all<F, Fut, N>(self, n: N, f: F) -> impl Future<Output = bool> + Send
 	where
 		N: Into<Option<usize>>,
 		F: Fn(Item) -> Fut + Send,
 		Fut: Future<Output = bool> + Send;
 
+	/// Tests items concurrently for any match with an explicit width.
+	///
+	/// `n` limits in-flight predicates, while `None` selects the automatic
+	/// width. An explicit zero cannot make progress. True short-circuits the
+	/// operation, and an empty stream resolves false.
 	fn broadn_any<F, Fut, N>(self, n: N, f: F) -> impl Future<Output = bool> + Send
 	where
 		N: Into<Option<usize>>,
 		F: Fn(Item) -> Fut + Send,
 		Fut: Future<Output = bool> + Send;
 
-	/// Concurrent filter_map(); unordered results
+	/// Maps and filters items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width. An explicit zero cannot make progress. Present outputs are
+	/// yielded in completion order and absent outputs are omitted.
 	fn broadn_filter_map<F, Fut, U, N>(self, n: N, f: F) -> impl Stream<Item = U> + Send
 	where
 		N: Into<Option<usize>>,
@@ -32,7 +48,11 @@ where
 		Fut: Future<Output = Option<U>> + Send,
 		U: Send;
 
-	/// Concurrent find_map(); unordered result
+	/// Finds the first concurrently completed mapped value.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width. An explicit zero cannot make progress. The first completed `Some`
+	/// wins, which may differ from the earliest matching source item.
 	fn broadn_find_map<'a, F, Fut, U, N>(
 		self,
 		n: N,
@@ -45,6 +65,11 @@ where
 		U: Send + 'a,
 		Self: Unpin + 'a;
 
+	/// Flattens mapped streams concurrently with an explicit width.
+	///
+	/// A nonzero `n` limits active inner streams, zero disables the limit, and
+	/// `None` selects the automatic width. Inner outputs are interleaved
+	/// according to readiness rather than source order.
 	fn broadn_flat_map<F, Fut, U, N>(self, n: N, f: F) -> impl Stream<Item = U> + Send
 	where
 		N: Into<Option<usize>>,
@@ -52,6 +77,11 @@ where
 		Fut: Stream<Item = U> + Send + Unpin,
 		U: Send;
 
+	/// Maps items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width. An explicit zero cannot make progress. Outputs are yielded in
+	/// completion order.
 	fn broadn_then<F, Fut, U, N>(self, n: N, f: F) -> impl Stream<Item = U> + Send
 	where
 		N: Into<Option<usize>>,
@@ -59,6 +89,10 @@ where
 		Fut: Future<Output = U> + Send,
 		U: Send;
 
+	/// Tests all items concurrently with the automatic width.
+	///
+	/// False short-circuits the operation, while true requires every predicate
+	/// to return true. An empty stream resolves true.
 	#[inline]
 	fn broad_all<F, Fut>(self, f: F) -> impl Future<Output = bool> + Send
 	where
@@ -68,6 +102,10 @@ where
 		self.broadn_all(None, f)
 	}
 
+	/// Tests items concurrently for any match with the automatic width.
+	///
+	/// True short-circuits the operation, while false requires every predicate
+	/// to return false. An empty stream resolves false.
 	#[inline]
 	fn broad_any<F, Fut>(self, f: F) -> impl Future<Output = bool> + Send
 	where
@@ -77,6 +115,10 @@ where
 		self.broadn_any(None, f)
 	}
 
+	/// Maps and filters items concurrently with the automatic width.
+	///
+	/// Present outputs are yielded in completion order rather than source
+	/// order. Absent outputs are omitted.
 	#[inline]
 	fn broad_filter_map<F, Fut, U>(self, f: F) -> impl Stream<Item = U> + Send
 	where
@@ -87,6 +129,10 @@ where
 		self.broadn_filter_map(None, f)
 	}
 
+	/// Finds the first mapped value to complete with `Some`.
+	///
+	/// Item futures run at the automatic width. Completion order determines the
+	/// winner rather than source order.
 	#[inline]
 	fn broad_find_map<'a, F, Fut, U>(self, f: F) -> impl Future<Output = Option<U>> + Send
 	where
@@ -98,6 +144,10 @@ where
 		self.broadn_find_map(None, f)
 	}
 
+	/// Flattens mapped streams concurrently with the automatic width.
+	///
+	/// Inner streams are polled together and their outputs are interleaved by
+	/// readiness. Source ordering is not preserved.
 	#[inline]
 	fn broad_flat_map<F, Fut, U>(self, f: F) -> impl Stream<Item = U> + Send
 	where
@@ -108,6 +158,10 @@ where
 		self.broadn_flat_map(None, f)
 	}
 
+	/// Maps items concurrently with the automatic width.
+	///
+	/// Item futures may run ahead of downstream demand. Outputs are yielded in
+	/// completion order rather than source order.
 	#[inline]
 	fn broad_then<F, Fut, U>(self, f: F) -> impl Stream<Item = U> + Send
 	where

--- a/src/core/utils/stream/cloned.rs
+++ b/src/core/utils/stream/cloned.rs
@@ -1,10 +1,18 @@
 use futures::{Stream, StreamExt, stream::Map};
 
+/// Clones items yielded by a stream of shared references.
+///
+/// Each referenced value is cloned only when its stream item is polled. Item
+/// order and readiness follow the source stream unchanged.
 pub trait Cloned<'a, T, S>
 where
 	S: Stream<Item = &'a T>,
 	T: Clone + 'a,
 {
+	/// Returns a stream of owned clones from the borrowed items.
+	///
+	/// The adapter uses [`Clone::clone`] for each yielded reference. It
+	/// performs no eager collection or buffering.
 	fn cloned(self) -> Map<S, fn(&T) -> T>;
 }
 

--- a/src/core/utils/stream/expect.rs
+++ b/src/core/utils/stream/expect.rs
@@ -2,13 +2,33 @@ use futures::{Stream, StreamExt, TryStream};
 
 use crate::Result;
 
+/// Converts fallible stream items into values by expecting success.
+///
+/// Successful items pass through in source order. Errors terminate the current
+/// poll by panicking with either a default or caller-supplied message.
 pub trait TryExpect<Item>
 where
 	Item: Send,
 	Self: Send + Sized,
 {
+	/// Expects every stream item with the default failure message.
+	///
+	/// Successful values are unwrapped lazily as the stream is polled. The
+	/// default message identifies a stream expectation failure.
+	///
+	/// # Panics
+	///
+	/// Panics when the source stream yields an error.
 	fn expect_ok(self) -> impl Stream<Item = Item> + Send;
 
+	/// Expects every stream item with `msg` as the failure message.
+	///
+	/// Successful values are unwrapped lazily as the stream is polled. The
+	/// supplied message is used for every failing item.
+	///
+	/// # Panics
+	///
+	/// Panics when the source stream yields an error.
 	fn map_expect(self, msg: &str) -> impl Stream<Item = Item> + Send;
 }
 

--- a/src/core/utils/stream/ignore.rs
+++ b/src/core/utils/stream/ignore.rs
@@ -2,13 +2,31 @@ use futures::{Stream, StreamExt, TryStream, future::ready};
 
 use crate::{Error, Result, utils::stream::TryExpect};
 
+/// Selects successful or failed items from a result stream.
+///
+/// Success selection asserts error-free input when debug assertions are enabled
+/// and filters errors when they are disabled. Error selection always discards
+/// successful items.
 pub trait TryIgnore<Item>
 where
 	Item: Send,
 	Self: Send + Sized,
 {
+	/// Yields successful values while conditionally ignoring errors.
+	///
+	/// Errors are filtered when debug assertions are disabled. When they are
+	/// enabled, each item is expected to be successful so accidental error loss
+	/// remains visible.
+	///
+	/// # Panics
+	///
+	/// Panics when debug assertions are enabled and the source yields an error.
 	fn ignore_err(self) -> impl Stream<Item = Item> + Send;
 
+	/// Yields errors while ignoring successful values.
+	///
+	/// Successful items are filtered out as the stream is polled. Errors retain
+	/// their source order and value.
 	fn ignore_ok(self) -> impl Stream<Item = Error> + Send;
 }
 

--- a/src/core/utils/stream/iter_stream.rs
+++ b/src/core/utils/stream/iter_stream.rs
@@ -5,11 +5,21 @@ use futures::{
 
 use crate::{Error, Result};
 
+/// Converts synchronous iterables into immediately ready streams.
+///
+/// Source iteration order is preserved. The fallible form wraps each item in a
+/// successful result using the crate's error type.
 pub trait IterStream<I: IntoIterator + Send> {
-	/// Convert an Iterator into a Stream
+	/// Converts the iterable into a stream of its items.
+	///
+	/// Items are yielded in the source iterator's order. Polling requires no
+	/// asynchronous work beyond advancing that iterator.
 	fn stream(self) -> impl Stream<Item = <I as IntoIterator>::Item> + Send;
 
-	/// Convert an Iterator into a TryStream
+	/// Converts the iterable into a stream of successful results.
+	///
+	/// Every source item is wrapped in `Ok` with [`Error`] as the error type.
+	/// The adapter itself never produces an error.
 	fn try_stream(
 		self,
 	) -> impl TryStream<

--- a/src/core/utils/stream/ready.rs
+++ b/src/core/utils/stream/ready.rs
@@ -16,20 +16,36 @@ pub trait ReadyExt<Item>
 where
 	Self: Stream<Item = Item> + Sized,
 {
+	/// Tests whether every item satisfies a synchronous predicate.
+	///
+	/// Evaluation stops at the first false result. An empty stream resolves to
+	/// true.
 	fn ready_all<F>(self, f: F) -> All<Self, Ready<bool>, impl FnMut(Item) -> Ready<bool>>
 	where
 		F: Fn(Item) -> bool;
 
+	/// Tests whether any item satisfies a synchronous predicate.
+	///
+	/// Evaluation stops at the first true result. An empty stream resolves to
+	/// false.
 	fn ready_any<F>(self, f: F) -> Any<Self, Ready<bool>, impl FnMut(Item) -> Ready<bool>>
 	where
 		F: Fn(Item) -> bool;
 
+	/// Finds the first item satisfying a synchronous predicate.
+	///
+	/// Items are tested in source order and the first match is returned. The
+	/// future resolves to `None` when the stream ends without a match.
 	fn ready_find<'a, F>(self, f: F) -> impl Future<Output = Option<Item>> + Send
 	where
 		Self: Send + Unpin + 'a,
 		F: Fn(&Item) -> bool + Send + 'a,
 		Item: Send;
 
+	/// Finds the first value produced by a synchronous mapping predicate.
+	///
+	/// Items are mapped in source order until `f` returns `Some`. The future
+	/// resolves to `None` when every item maps to absence.
 	fn ready_find_map<'a, F, U>(self, f: F) -> impl Future<Output = Option<U>> + Send
 	where
 		Self: Send + Unpin + 'a,
@@ -37,6 +53,10 @@ where
 		Item: Send,
 		U: Send;
 
+	/// Retains items accepted by a synchronous predicate.
+	///
+	/// The predicate borrows each item as it is polled. Accepted items preserve
+	/// their source order and value.
 	fn ready_filter<'a, F>(
 		self,
 		f: F,
@@ -44,6 +64,10 @@ where
 	where
 		F: Fn(&Item) -> bool + 'a;
 
+	/// Maps items synchronously while filtering absent results.
+	///
+	/// Values returned in `Some` are yielded in source order. Items mapped to
+	/// `None` are discarded.
 	fn ready_filter_map<F, U>(
 		self,
 		f: F,
@@ -51,6 +75,10 @@ where
 	where
 		F: Fn(Item) -> Option<U>;
 
+	/// Folds items synchronously from an explicit initial accumulator.
+	///
+	/// `f` receives the accumulator and each item in source order. The future
+	/// resolves to the final accumulator after the stream ends.
 	fn ready_fold<T, F>(
 		self,
 		init: T,
@@ -59,6 +87,10 @@ where
 	where
 		F: Fn(T, Item) -> T;
 
+	/// Folds items synchronously from `T::default()`.
+	///
+	/// `f` receives the accumulator and each item in source order. An empty
+	/// stream resolves to the default accumulator unchanged.
 	fn ready_fold_default<T, F>(
 		self,
 		f: F,
@@ -67,10 +99,18 @@ where
 		F: Fn(T, Item) -> T,
 		T: Default;
 
+	/// Applies a synchronous closure to every stream item.
+	///
+	/// Items are consumed in source order. The returned future resolves after
+	/// the stream ends and carries no output value.
 	fn ready_for_each<F>(self, f: F) -> ForEach<Self, Ready<()>, impl FnMut(Item) -> Ready<()>>
 	where
 		F: FnMut(Item);
 
+	/// Yields the leading items accepted by a synchronous predicate.
+	///
+	/// Evaluation stops at the first false result, and that boundary item is
+	/// not yielded. Accepted items retain source order.
 	fn ready_take_while<'a, F>(
 		self,
 		f: F,
@@ -78,6 +118,10 @@ where
 	where
 		F: Fn(&Item) -> bool + 'a;
 
+	/// Transforms items with mutable state and a synchronous scan closure.
+	///
+	/// Each `Some` result is yielded while `None` terminates the stream. State
+	/// is initialized once and retained between items.
 	fn ready_scan<B, T, F>(
 		self,
 		init: T,
@@ -86,6 +130,10 @@ where
 	where
 		F: Fn(&mut T, Item) -> Option<B>;
 
+	/// Observes each item with mutable state and yields it unchanged.
+	///
+	/// The closure receives the persistent state and a shared reference to each
+	/// item. Every source item is then emitted in order.
 	fn ready_scan_each<T, F>(
 		self,
 		init: T,
@@ -94,6 +142,10 @@ where
 	where
 		F: Fn(&mut T, &Item);
 
+	/// Skips the leading items accepted by a synchronous predicate.
+	///
+	/// The first false item and every later item are yielded in source order.
+	/// The predicate is no longer called after the first false result.
 	fn ready_skip_while<'a, F>(
 		self,
 		f: F,

--- a/src/core/utils/stream/tools.rs
+++ b/src/core/utils/stream/tools.rs
@@ -8,23 +8,50 @@ use futures::{Stream, StreamExt};
 use super::ReadyExt;
 use crate::{expected, utils::rand::index};
 
-/// StreamTools
+/// Adds aggregation, sampling, and folding operations to streams.
 ///
-/// This interface is not necessarily complete; feel free to add as-needed.
+/// Counting adapters consume the source into hash maps, while folding avoids an
+/// intermediate collection. Reservoir sampling retains a uniform subset of up
+/// to a fixed size in one pass.
 pub trait Tools<Item>
 where
 	Self: Stream<Item = Item> + Send + Sized,
 	<Self as Stream>::Item: Send,
 {
+	/// Counts occurrences of each distinct stream item.
+	///
+	/// The entire stream is consumed into a hash map that starts at zero
+	/// capacity and grows as needed. Equal items share one incrementing
+	/// counter.
+	///
+	/// # Panics
+	///
+	/// Panics if an item's occurrence count overflows `usize`.
 	fn counts(self) -> impl Future<Output = HashMap<Item, usize>> + Send
 	where
 		<Self as Stream>::Item: Eq + Hash;
 
+	/// Counts occurrences of keys derived from stream items.
+	///
+	/// `f` is applied once to every item before counting. The result map starts
+	/// at zero capacity and grows as needed.
+	///
+	/// # Panics
+	///
+	/// Panics if a derived key's occurrence count overflows `usize`.
 	fn counts_by<K, F>(self, f: F) -> impl Future<Output = HashMap<K, usize>> + Send
 	where
 		F: Fn(Item) -> K + Send,
 		K: Eq + Hash + Send;
 
+	/// Counts derived keys into a map with initial capacity `CAP`.
+	///
+	/// `f` is applied once to every stream item. The map initially reserves
+	/// space for at least `CAP` distinct keys and grows as needed.
+	///
+	/// # Panics
+	///
+	/// Panics if a derived key's occurrence count overflows `usize`.
 	fn counts_by_with_cap<const CAP: usize, K, F>(
 		self,
 		f: F,
@@ -33,21 +60,39 @@ where
 		F: Fn(Item) -> K + Send,
 		K: Eq + Hash + Send;
 
+	/// Counts items into a map with initial capacity `CAP`.
+	///
+	/// Equal items share one counter as the entire stream is consumed. The map
+	/// initially reserves space for at least `CAP` distinct items and grows as
+	/// needed.
+	///
+	/// # Panics
+	///
+	/// Panics if an item's occurrence count overflows `usize`.
 	fn counts_with_cap<const CAP: usize>(
 		self,
 	) -> impl Future<Output = HashMap<Item, usize>> + Send
 	where
 		<Self as Stream>::Item: Eq + Hash;
 
-	/// Reservoir-samples up to `N` items uniformly at random in a single
-	/// pass, applying `f` only to the items retained. Items are drawn
-	/// without replacement; the keys `f` derives may still repeat, so a key
-	/// produced by twice as many items is twice as likely to appear.
+	/// Reservoir-samples up to `N` items uniformly without replacement.
+	///
+	/// The stream is consumed in one pass, and `f` is applied only when an item
+	/// enters the reservoir, including entries later replaced. Rejected items
+	/// do not invoke it, and derived keys may repeat.
+	///
+	/// # Panics
+	///
+	/// Panics if the number of observed stream items overflows `usize`.
 	fn sample_by<const N: usize, K, F>(self, f: F) -> impl Future<Output = ArrayVec<K, N>> + Send
 	where
 		F: Fn(Item) -> K + Send,
 		K: Send;
 
+	/// Folds the stream from `T::default()` with an asynchronous accumulator.
+	///
+	/// Each item is processed in source order after the previous fold future
+	/// resolves. The final accumulator is returned when the stream ends.
 	fn fold_default<T, F, Fut>(self, f: F) -> impl Future<Output = T> + Send
 	where
 		F: Fn(T, Item) -> Fut + Send,

--- a/src/core/utils/stream/try_broadband.rs
+++ b/src/core/utils/stream/try_broadband.rs
@@ -5,12 +5,21 @@ use futures::{TryFuture, TryStream, TryStreamExt};
 use super::automatic_width;
 use crate::Result;
 
-/// Concurrency extensions to augment futures::TryStreamExt. broad_ combinators
-/// produce out-of-order
+/// Adds bounded concurrent transformations with completion-ordered outputs.
+///
+/// Successful item futures may run ahead of downstream demand, and their
+/// results are yielded as they complete. Source errors bypass the transform and
+/// may overtake queued item futures.
 pub trait TryBroadbandExt<T, E>
 where
 	Self: TryStream<Ok = T, Error = E, Item = Result<T, E>> + Send + Sized,
 {
+	/// Transforms successful items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width; an explicit zero cannot make progress. Transformation results are
+	/// completion ordered, while source errors bypass `f` and may overtake
+	/// them.
 	fn broadn_and_then<U, F, Fut, N>(
 		self,
 		n: N,
@@ -21,6 +30,11 @@ where
 		F: Fn(Self::Ok) -> Fut + Send,
 		Fut: TryFuture<Ok = U, Error = E, Output = Result<U, E>> + Send;
 
+	/// Transforms successful items concurrently with the automatic width.
+	///
+	/// Transformation results are yielded in completion order rather than
+	/// source order. Existing source errors bypass `f` and may overtake queued
+	/// futures.
 	fn broad_and_then<U, F, Fut>(
 		self,
 		f: F,

--- a/src/core/utils/stream/try_parallel.rs
+++ b/src/core/utils/stream/try_parallel.rs
@@ -17,6 +17,16 @@ where
 	E: From<JoinError> + From<Error> + Send + 'static,
 	T: Send + 'static,
 {
+	/// Runs a synchronous fallible transform on the blocking pool.
+	///
+	/// `n` controls concurrent jobs and defaults to available parallelism; an
+	/// explicit zero cannot make progress. Job results are completion ordered,
+	/// while source errors bypass `f` and may overtake queued jobs. Spawned
+	/// jobs can continue after the adapter is dropped.
+	///
+	/// # Panics
+	///
+	/// Panics when no handle is supplied outside a Tokio runtime context.
 	fn paralleln_and_then<U, F, N, H>(
 		self,
 		h: H,
@@ -29,6 +39,16 @@ where
 		F: Fn(Self::Ok) -> Result<U, E> + Clone + Send + 'static,
 		U: Send + 'static;
 
+	/// Runs a synchronous fallible transform at the default parallelism.
+	///
+	/// The optional handle defaults to the current Tokio runtime. Job results
+	/// are completion ordered, while source errors may overtake them; join
+	/// failures convert into `E`. Spawned jobs can continue after the adapter
+	/// is dropped.
+	///
+	/// # Panics
+	///
+	/// Panics when no handle is supplied outside a Tokio runtime context.
 	fn parallel_and_then<U, F, H>(
 		self,
 		h: H,

--- a/src/core/utils/stream/try_ready.rs
+++ b/src/core/utils/stream/try_ready.rs
@@ -11,14 +11,19 @@ use futures::{
 
 use crate::Result;
 
-/// Synchronous combinators to augment futures::TryStreamExt.
+/// Adds synchronous combinators to fallible streams.
 ///
-/// This interface is not necessarily complete; feel free to add as-needed.
+/// Closures run immediately when a successful item is polled, avoiding an async
+/// block around non-async work. Source errors retain the stream's error type.
 pub trait TryReadyExt<T, E, S>
 where
 	S: TryStream<Ok = T, Error = E, Item = Result<T, E>> + ?Sized,
 	Self: TryStream + Sized,
 {
+	/// Applies a synchronous fallible transform to successful items.
+	///
+	/// Existing source errors bypass `f`. Successful transformed values and
+	/// closure errors remain in source order.
 	fn ready_and_then<U, F>(
 		self,
 		f: F,
@@ -26,6 +31,10 @@ where
 	where
 		F: Fn(S::Ok) -> Result<U, E>;
 
+	/// Retains successful items accepted by a synchronous predicate.
+	///
+	/// The predicate borrows only successful values. Source errors pass through
+	/// without invoking it.
 	fn ready_try_filter<F>(
 		self,
 		f: F,
@@ -33,6 +42,10 @@ where
 	where
 		F: Fn(&S::Ok) -> bool;
 
+	/// Maps successful items through a synchronous fallible filter.
+	///
+	/// `Ok(Some(value))` yields a value and `Ok(None)` discards the item.
+	/// Source errors and closure errors remain in the result stream.
 	fn ready_try_filter_map<F, U>(
 		self,
 		f: F,
@@ -44,6 +57,10 @@ where
 	where
 		F: Fn(S::Ok) -> Result<Option<U>, E>;
 
+	/// Folds successful items with a synchronous fallible accumulator.
+	///
+	/// Folding begins from `init` and processes values in source order. A
+	/// source or closure error ends the returned future with that error.
 	fn ready_try_fold<U, F>(
 		self,
 		init: U,
@@ -52,6 +69,10 @@ where
 	where
 		F: Fn(U, S::Ok) -> Result<U, E>;
 
+	/// Folds successful items from `U::default()` with a fallible accumulator.
+	///
+	/// Values are processed in source order. An empty stream returns the
+	/// default, while a source or closure error ends the fold.
 	fn ready_try_fold_default<U, F>(
 		self,
 		f: F,
@@ -60,6 +81,10 @@ where
 		F: Fn(U, S::Ok) -> Result<U, E>,
 		U: Default;
 
+	/// Applies a synchronous fallible closure to each successful item.
+	///
+	/// Values are processed in source order. A source or closure error ends the
+	/// returned future before later items are visited.
 	fn ready_try_for_each<F>(
 		self,
 		f: F,
@@ -67,6 +92,11 @@ where
 	where
 		F: FnMut(S::Ok) -> Result<(), E>;
 
+	/// Skips leading successful items accepted by a fallible predicate.
+	///
+	/// The first false item and later items are yielded without further
+	/// predicate calls. Source and predicate errors remain in the result
+	/// stream.
 	fn ready_try_skip_while<F>(
 		self,
 		f: F,
@@ -74,6 +104,11 @@ where
 	where
 		F: Fn(&S::Ok) -> Result<bool, E>;
 
+	/// Yields leading successful items accepted by a fallible predicate.
+	///
+	/// The first false item ends the stream and is not yielded. Source and
+	/// predicate errors are yielded without terminating the adapter, and a
+	/// predicate error discards the tested item.
 	fn ready_try_take_while<F>(
 		self,
 		f: F,

--- a/src/core/utils/stream/try_tools.rs
+++ b/src/core/utils/stream/try_tools.rs
@@ -5,12 +5,20 @@ use futures::{TryStream, TryStreamExt, future, future::Ready, stream::TryTakeWhi
 
 use crate::Result;
 
-/// TryStreamTools
+/// Adds general-purpose operations to fallible streams.
+///
+/// The adapters preserve the source error type and successful item order. They
+/// operate lazily without collecting the stream.
 pub trait TryTools<T, E, S>
 where
 	S: TryStream<Ok = T, Error = E, Item = Result<T, E>> + ?Sized,
 	Self: TryStream + Sized,
 {
+	/// Limits the stream to at most `n` successful items.
+	///
+	/// After yielding `n` successes, the adapter consumes one additional
+	/// success to detect the limit. Earlier source errors are still forwarded;
+	/// with zero, they precede consumption of the first unyielded success.
 	fn try_take(
 		self,
 		n: usize,

--- a/src/core/utils/stream/try_wideband.rs
+++ b/src/core/utils/stream/try_wideband.rs
@@ -5,12 +5,20 @@ use futures::{TryFuture, TryStream, TryStreamExt};
 use super::automatic_width;
 use crate::Result;
 
-/// Concurrency extensions to augment futures::TryStreamExt. wide_ combinators
-/// produce in-order results
+/// Adds bounded concurrent transformations with ordered transform results.
+///
+/// Successful item futures may run ahead of downstream demand, and their
+/// results retain queue order. Source errors are propagated immediately and may
+/// overtake queued transformation futures.
 pub trait TryWidebandExt<T, E>
 where
 	Self: TryStream<Ok = T, Error = E, Item = Result<T, E>> + Send + Sized,
 {
+	/// Transforms successful items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width; an explicit zero cannot make progress. Transformation results
+	/// retain queue order, while source errors may overtake them.
 	fn widen_and_then<U, F, Fut, N>(
 		self,
 		n: N,
@@ -22,6 +30,11 @@ where
 		Fut: TryFuture<Ok = U, Error = E, Output = Result<U, E>> + Send,
 		U: Send;
 
+	/// Transforms successful items concurrently with the automatic width.
+	///
+	/// Item futures may run ahead, but transformation results retain queue
+	/// order. Existing source errors bypass `f` and may overtake queued
+	/// futures.
 	fn wide_and_then<U, F, Fut>(
 		self,
 		f: F,

--- a/src/core/utils/stream/wideband.rs
+++ b/src/core/utils/stream/wideband.rs
@@ -6,13 +6,19 @@ use futures::stream::{Stream, StreamExt};
 
 use super::{ReadyExt, automatic_width};
 
-/// Concurrency extensions to augment futures::StreamExt. wideband_ combinators
-/// produce in-order.
+/// Adds bounded concurrent transformations that preserve stream order.
+///
+/// Multiple item futures may run ahead of downstream demand. Completed outputs
+/// are held until every earlier input has produced its output.
 pub trait WidebandExt<Item>
 where
 	Self: Stream<Item = Item> + Send + Sized,
 {
-	/// Concurrent filter_map(); ordered results
+	/// Maps and filters items concurrently with an explicit width.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width; an explicit zero cannot make progress. Present outputs retain
+	/// source order and absent outputs are omitted.
 	fn widen_filter_map<F, Fut, U, N>(self, n: N, f: F) -> impl Stream<Item = U> + Send
 	where
 		N: Into<Option<usize>>,
@@ -20,6 +26,11 @@ where
 		Fut: Future<Output = Option<U>> + Send,
 		U: Send;
 
+	/// Maps items concurrently with an explicit width while preserving order.
+	///
+	/// `n` limits in-flight item futures, while `None` selects the automatic
+	/// width; an explicit zero cannot make progress. Item futures may run
+	/// ahead, but outputs retain source order.
 	fn widen_then<F, Fut, U, N>(self, n: N, f: F) -> impl Stream<Item = U> + Send
 	where
 		N: Into<Option<usize>>,
@@ -27,6 +38,10 @@ where
 		Fut: Future<Output = U> + Send,
 		U: Send;
 
+	/// Maps and filters items concurrently with the automatic width.
+	///
+	/// Present outputs retain source order even when their futures complete out
+	/// of order. Absent outputs are omitted.
 	#[inline]
 	fn wide_filter_map<F, Fut, U>(self, f: F) -> impl Stream<Item = U> + Send
 	where
@@ -37,6 +52,10 @@ where
 		self.widen_filter_map(None, f)
 	}
 
+	/// Maps items concurrently with the automatic width while preserving order.
+	///
+	/// Item futures may run ahead of downstream demand. Completed outputs wait
+	/// for every earlier input before being yielded.
 	#[inline]
 	fn wide_then<F, Fut, U>(self, f: F) -> impl Stream<Item = U> + Send
 	where

--- a/src/core/utils/string/de.rs
+++ b/src/core/utils/string/de.rs
@@ -4,6 +4,10 @@ use serde::de::{Deserializer, Error, Visitor};
 
 struct ToLowercase;
 
+/// Deserializes a string and converts it to Unicode lowercase.
+///
+/// The adapter applies [`str::to_lowercase`] to the deserialized value. This is
+/// ordinary lowercasing rather than full Unicode case folding.
 #[inline]
 pub fn to_lowercase<'de, D>(deserializer: D) -> Result<String, D::Error>
 where

--- a/src/core/utils/string/unquoted.rs
+++ b/src/core/utils/string/unquoted.rs
@@ -13,6 +13,10 @@ use crate::{Result, err};
 pub struct Unquoted(str);
 
 impl<'a> Unquoted {
+	/// Returns the underlying string view without surrounding quotes.
+	///
+	/// The returned slice borrows the transparent wrapper and performs no
+	/// allocation or copy. Its lifetime is tied to the wrapper reference.
 	#[inline]
 	#[must_use]
 	pub fn as_str(&'a self) -> &'a str { &self.0 }

--- a/src/core/utils/sys/compute.rs
+++ b/src/core/utils/sys/compute.rs
@@ -145,6 +145,10 @@ pub fn is_core_available(id: Id) -> bool { cores_available().any(is_equal_to!(id
 #[inline]
 pub fn cores_available() -> impl Iterator<Item = Id> { from_mask(*CORES_AVAILABLE) }
 
+/// Returns the logical CPU currently executing the calling thread.
+///
+/// The value is a point-in-time scheduler observation and may become stale on
+/// the next instruction boundary. Linux obtains it through `sched_getcpu()`.
 #[cfg(target_os = "linux")]
 #[inline]
 pub fn getcpu() -> Result<usize> {
@@ -170,6 +174,10 @@ pub fn getcpu() -> Result<usize> {
 	math::try_into(ret)
 }
 
+/// Reports that current-CPU queries are unsupported on this platform.
+///
+/// No scheduler observation is attempted. The result contains an I/O error with
+/// the unsupported error kind.
 #[cfg(not(target_os = "linux"))]
 #[inline]
 pub fn getcpu() -> Result<usize> { Err(crate::Error::Io(std::io::ErrorKind::Unsupported.into())) }

--- a/src/core/utils/sys/limits.rs
+++ b/src/core/utils/sys/limits.rs
@@ -56,6 +56,14 @@ pub fn maximize_thread_limit() -> Result {
 #[cfg(any(not(unix), target_os = "macos"))]
 pub fn maximize_thread_limit() -> Result { Ok(()) }
 
+/// Returns the soft and hard file-descriptor limits.
+///
+/// The tuple is ordered as the current soft limit followed by the maximum hard
+/// limit. Values come from `RLIMIT_NOFILE`.
+///
+/// # Panics
+///
+/// Panics when either platform limit cannot be represented as `usize`.
 #[cfg(unix)]
 #[inline]
 pub fn max_file_descriptors() -> Result<(usize, usize)> {
@@ -64,10 +72,22 @@ pub fn max_file_descriptors() -> Result<(usize, usize)> {
 		.map_err(Into::into)
 }
 
+/// Returns sentinel file-descriptor limits on unsupported platforms.
+///
+/// Both tuple elements are `usize::MAX`, representing no known finite limit.
+/// No operating-system query is performed.
 #[cfg(not(unix))]
 #[inline]
 pub fn max_file_descriptors() -> Result<(usize, usize)> { Ok((usize::MAX, usize::MAX)) }
 
+/// Returns the soft and hard process stack-size limits.
+///
+/// The tuple is ordered as the current soft limit followed by the maximum hard
+/// limit. Values come from `RLIMIT_STACK`.
+///
+/// # Panics
+///
+/// Panics when either platform limit cannot be represented as `usize`.
 #[cfg(unix)]
 #[inline]
 pub fn max_stack_size() -> Result<(usize, usize)> {
@@ -76,10 +96,22 @@ pub fn max_stack_size() -> Result<(usize, usize)> {
 		.map_err(Into::into)
 }
 
+/// Returns sentinel stack-size limits on unsupported platforms.
+///
+/// Both tuple elements are `usize::MAX`, representing no known finite limit.
+/// No operating-system query is performed.
 #[cfg(not(unix))]
 #[inline]
 pub fn max_stack_size() -> Result<(usize, usize)> { Ok((usize::MAX, usize::MAX)) }
 
+/// Returns the soft and hard locked-memory limits.
+///
+/// The tuple is ordered as the current soft limit followed by the maximum hard
+/// limit. Values come from `RLIMIT_MEMLOCK`.
+///
+/// # Panics
+///
+/// Panics when either platform limit cannot be represented as `usize`.
 #[cfg(all(unix, not(target_os = "macos")))]
 #[inline]
 pub fn max_memory_locked() -> Result<(usize, usize)> {
@@ -88,10 +120,23 @@ pub fn max_memory_locked() -> Result<(usize, usize)> {
 		.map_err(Into::into)
 }
 
+/// Returns sentinel locked-memory limits on unsupported platforms.
+///
+/// Both tuple elements are zero, the module's unsupported-platform sentinel.
+/// No operating-system query is performed.
 #[cfg(any(not(unix), target_os = "macos"))]
 #[inline]
 pub fn max_memory_locked() -> Result<(usize, usize)> { Ok((usize::MIN, usize::MIN)) }
 
+/// Returns the soft and hard per-user process-count limits.
+///
+/// The tuple is ordered as the current soft limit followed by the maximum hard
+/// limit. Values come from `RLIMIT_NPROC`; on Linux, it counts extant threads
+/// for the caller's real user ID.
+///
+/// # Panics
+///
+/// Panics when either platform limit cannot be represented as `usize`.
 #[cfg(all(unix, not(target_os = "macos")))]
 #[inline]
 pub fn max_threads() -> Result<(usize, usize)> {
@@ -100,6 +145,10 @@ pub fn max_threads() -> Result<(usize, usize)> {
 		.map_err(Into::into)
 }
 
+/// Returns sentinel thread limits on unsupported platforms.
+///
+/// Both tuple elements are `usize::MAX`, representing no known finite limit.
+/// No operating-system query is performed.
 #[cfg(any(not(unix), target_os = "macos"))]
 #[inline]
 pub fn max_threads() -> Result<(usize, usize)> { Ok((usize::MAX, usize::MAX)) }

--- a/src/core/utils/sys/usage.rs
+++ b/src/core/utils/sys/usage.rs
@@ -11,40 +11,104 @@ use crate::{Result, expected};
 #[cfg(unix)]
 pub type Usage = NixUsage;
 
+/// Portable resource-usage stub for platforms without `getrusage()`.
+///
+/// The zero-field value keeps tracing and call sites portable. It contains no
+/// process or thread measurements.
 #[cfg(not(unix))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Usage;
 
+/// Returns the process's virtual memory size in bytes, or zero outside Linux.
+///
+/// The value is the first field of Linux `/proc/self/statm`, scaled by the
+/// system page size. It is sampled separately from the other memory fields.
+///
+/// # Panics
+///
+/// On Linux, panics if `statm` is malformed, exceeds parser capacity, or lacks
+/// the requested field. Panics if converting that page count overflows `usize`
+/// bytes.
 pub fn virt() -> Result<usize> {
 	Ok(statm_bytes()?
 		.next()
 		.expect("incomplete statm contents"))
 }
 
+/// Returns the process's resident memory size in bytes, or zero outside Linux.
+///
+/// The value is the second field of Linux `/proc/self/statm`, scaled by the
+/// system page size. It is sampled separately from the other memory fields.
+///
+/// # Panics
+///
+/// On Linux, panics if `statm` is malformed, exceeds parser capacity, or lacks
+/// the requested field. Panics if converting that page count overflows `usize`
+/// bytes.
 pub fn res() -> Result<usize> {
 	Ok(statm_bytes()?
 		.nth(1)
 		.expect("incomplete statm contents"))
 }
 
+/// Returns shared resident memory size in bytes, or zero outside Linux.
+///
+/// The value is the third field of Linux `/proc/self/statm`, scaled by the
+/// system page size. It is sampled separately from the other memory fields.
+///
+/// # Panics
+///
+/// On Linux, panics if `statm` is malformed, exceeds parser capacity, or lacks
+/// the requested field. Panics if converting that page count overflows `usize`
+/// bytes.
 pub fn shm() -> Result<usize> {
 	Ok(statm_bytes()?
 		.nth(2)
 		.expect("incomplete statm contents"))
 }
 
+/// Returns the process's resident code size in bytes, or zero outside Linux.
+///
+/// The value is the fourth field of Linux `/proc/self/statm`, scaled by the
+/// system page size. It represents the resident text segment.
+///
+/// # Panics
+///
+/// On Linux, panics if `statm` is malformed, exceeds parser capacity, or lacks
+/// the requested field. Panics if converting that page count overflows `usize`
+/// bytes.
 pub fn code() -> Result<usize> {
 	Ok(statm_bytes()?
 		.nth(3)
 		.expect("incomplete statm contents"))
 }
 
+/// Returns the process's data and stack size in bytes, or zero outside Linux.
+///
+/// The value is the sixth field of Linux `/proc/self/statm`, scaled by the
+/// system page size. It is sampled separately from the other memory fields.
+///
+/// # Panics
+///
+/// On Linux, panics if `statm` is malformed, exceeds parser capacity, or lacks
+/// the requested field. Panics if converting that page count overflows `usize`
+/// bytes.
 pub fn data() -> Result<usize> {
 	Ok(statm_bytes()?
 		.nth(5)
 		.expect("incomplete statm contents"))
 }
 
+/// Returns the `statm` page counts converted to bytes.
+///
+/// Each page count is multiplied by the system page size as the iterator is
+/// consumed. The field order remains the Linux `statm` order.
+///
+/// # Panics
+///
+/// On Linux, panics before returning if `statm` is malformed or exceeds parser
+/// capacity. Panics while iterating if converting a page count overflows
+/// `usize` bytes.
 #[inline]
 pub fn statm_bytes() -> Result<impl Iterator<Item = usize>> {
 	let page_size = super::page_size()?;
@@ -52,6 +116,15 @@ pub fn statm_bytes() -> Result<impl Iterator<Item = usize>> {
 	Ok(statm()?.map(move |pages| expected!(pages * page_size)))
 }
 
+/// Returns process memory statistics as page counts.
+///
+/// Linux parses a snapshot of `/proc/self/statm` in kernel field order. The
+/// returned iterator owns the parsed counts.
+///
+/// # Panics
+///
+/// Panics when `statm` contains non-UTF-8 or non-integer data, or more than 12
+/// fields.
 #[cfg(target_os = "linux")]
 #[inline]
 pub fn statm() -> Result<impl Iterator<Item = usize>> {
@@ -77,26 +150,38 @@ pub fn statm() -> Result<impl Iterator<Item = usize>> {
 		})
 }
 
+/// Returns process memory statistics as page counts.
+///
+/// Non-Linux platforms return six zero counts in Linux `statm` field order. No
+/// operating-system query is performed.
 #[cfg(not(target_os = "linux"))]
 #[inline]
 pub fn statm() -> Result<impl Iterator<Item = usize>> { Ok([0, 0, 0, 0, 0, 0].into_iter()) }
 
+/// Returns resource usage for the current process.
+///
+/// Unix platforms obtain a fresh `RUSAGE_SELF` snapshot from `getrusage()`.
+/// The measurement includes resources consumed by the process at call time.
 #[cfg(unix)]
 pub fn usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_SELF).map_err(Into::into) }
 
+/// Returns the portable process resource-usage stub.
+///
+/// Platforms without `getrusage()` expose no measurements through this API.
+/// The returned zero-field value keeps callers platform-independent.
 #[cfg(not(unix))]
 pub fn usage() -> Result<Usage> { Ok(Usage) }
 
-/// Returns resource usage for the current thread when the platform supports it.
-///
-/// Linux, FreeBSD, and OpenBSD report thread-specific usage. Other Unix
-/// platforms fall back to process-wide usage. Platforms without `getrusage()`
-/// return the zero-field [`Usage`] stub.
 #[cfg(any(
 	target_os = "linux",
 	target_os = "freebsd",
 	target_os = "openbsd"
 ))]
+/// Returns resource usage for the current thread when the platform supports it.
+///
+/// Linux, FreeBSD, and OpenBSD report thread-specific usage. Other Unix
+/// platforms fall back to process-wide usage. Platforms without `getrusage()`
+/// return the zero-field [`Usage`] stub.
 pub fn thread_usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_THREAD).map_err(Into::into) }
 
 #[cfg(all(
@@ -107,7 +192,17 @@ pub fn thread_usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_THREAD).map_
 		target_os = "openbsd"
 	))
 ))]
+/// Returns resource usage for the current thread when the platform supports it.
+///
+/// Linux, FreeBSD, and OpenBSD report thread-specific usage. Other Unix
+/// platforms fall back to process-wide usage. Platforms without `getrusage()`
+/// return the zero-field [`Usage`] stub.
 pub fn thread_usage() -> Result<Usage> { getrusage(UsageWho::RUSAGE_SELF).map_err(Into::into) }
 
 #[cfg(not(unix))]
+/// Returns resource usage for the current thread when the platform supports it.
+///
+/// Linux, FreeBSD, and OpenBSD report thread-specific usage. Other Unix
+/// platforms fall back to process-wide usage. Platforms without `getrusage()`
+/// return the zero-field [`Usage`] stub.
 pub fn thread_usage() -> Result<Usage> { Ok(Usage) }

--- a/src/core/utils/two_phase_counter.rs
+++ b/src/core/utils/two_phase_counter.rs
@@ -48,6 +48,11 @@ pub struct State<F: Fn(u64) -> Result + Send + Sync> {
 }
 
 #[clippy::has_significant_drop]
+/// Holds a dispatched sequence number until its write operation retires.
+///
+/// The permit dereferences to its unique sequence number and records the
+/// retirement frontier sampled at dispatch. Dropping it retires the sequence
+/// through the shared counter so the retirement frontier advances in order.
 pub struct Permit<F: Fn(u64) -> Result + Send + Sync> {
 	/// Link back to the shared-state.
 	state: Arc<Counter<F>>,

--- a/src/database/maps.rs
+++ b/src/database/maps.rs
@@ -5,7 +5,9 @@ use tuwunel_core::Result;
 
 use crate::{
 	Engine, Map,
-	engine::descriptor::{self, CacheDisp, Descriptor},
+	engine::descriptor::{
+		self, CacheDisp, Descriptor, RANDOM_SMALL as PRIVATE_READ_SYNC_DESCRIPTOR,
+	},
 };
 
 pub(super) type Maps = BTreeMap<MapsKey, MapsVal>;
@@ -357,6 +359,12 @@ pub(super) static MAPS: &[Descriptor] = &[
 	Descriptor {
 		name: "roomuserid_privateread",
 		..descriptor::RANDOM_SMALL
+	},
+	// Aliased: importing RANDOM_SMALL unaliased makes every qualified sibling
+	// an unused_qualifications error.
+	Descriptor {
+		name: "roomuserid_privatereadsync",
+		..PRIVATE_READ_SYNC_DESCRIPTOR
 	},
 	Descriptor {
 		name: "roomuseroncejoinedids",

--- a/src/macros/rustc.rs
+++ b/src/macros/rustc.rs
@@ -13,6 +13,10 @@ pub(super) fn flags_capture(args: TokenStream) -> TokenStream {
 	let flag = std::env::args().collect::<Vec<_>>();
 	let flag_len = flag.len();
 	let ret = quote! {
+		/// Stores the compiler arguments captured while building this crate.
+		///
+		/// A load-time constructor registers the flags for build diagnostics. The
+		/// public static remains available for inspection while the crate is loaded.
 		pub static RUSTC_FLAGS: [&str; #flag_len] = [#( #flag ),*];
 
 		#[tuwunel_core::ctor(unsafe)]

--- a/src/main/tests/receipt_replay.rs
+++ b/src/main/tests/receipt_replay.rs
@@ -62,12 +62,23 @@ async fn exercise(services: &Services) -> Result {
 	let receipts = &services.read_receipt;
 	let first = receipt_event(room, user, event_id!("$receipt-replay-first:localhost"));
 	let second = receipt_event(room, user, event_id!("$receipt-replay-second:localhost"));
+	let missing = receipts
+		.last_receipt_count(room, None, None)
+		.await;
+
+	if !matches!(missing, Err(error) if error.is_not_found()) {
+		return Err!("empty room did not report a missing receipt count");
+	}
 
 	let stored = receipts
 		.readreceipt_update(user, room, &first)
 		.await;
 
 	let after_store = receipt_counts(services, room).await;
+	let first_count = receipts
+		.last_receipt_count(room, Some(user), None)
+		.await?;
+
 	let replayed = receipts
 		.readreceipt_update(user, room, &first)
 		.await;
@@ -83,6 +94,10 @@ async fn exercise(services: &Services) -> Result {
 		return Err!("first receipt did not store exactly one row");
 	}
 
+	if first_count != after_store[0] {
+		return Err!("latest receipt query did not return the stored row");
+	}
+
 	if replayed || after_replay != after_store {
 		return Err!("replayed receipt moved the receipt stream");
 	}
@@ -91,7 +106,49 @@ async fn exercise(services: &Services) -> Result {
 		return Err!("receipt naming another event did not take a new position");
 	}
 
+	last_receipt_queries(services, room, user, after_advance[0]).await?;
+
 	private_read_replay(services, room, user).await
+}
+
+async fn last_receipt_queries(
+	services: &Services,
+	room: &RoomId,
+	user: &UserId,
+	user_count: u64,
+) -> Result {
+	let other = user_id!("@receipt-replay-other:localhost");
+	let event = receipt_event(room, other, event_id!("$receipt-replay-other:localhost"));
+	let receipts = &services.read_receipt;
+	let stored = receipts
+		.readreceipt_update(other, room, &event)
+		.await;
+
+	let other_count = receipts
+		.last_receipt_count(room, Some(other), None)
+		.await?;
+
+	let filtered = receipts
+		.last_receipt_count(room, Some(user), None)
+		.await?;
+
+	let bounded = receipts
+		.last_receipt_count(room, None, Some(other_count))
+		.await?;
+
+	if !stored || other_count <= user_count {
+		return Err!("second user's receipt did not advance the receipt stream");
+	}
+
+	if filtered != user_count {
+		return Err!("newer receipt hid the requested user's receipt");
+	}
+
+	if bounded != user_count {
+		return Err!("exclusive receipt bound did not return the prior row");
+	}
+
+	Ok(())
 }
 
 fn receipt_event(room: &RoomId, user: &UserId, event: &EventId) -> ReceiptEvent {

--- a/src/main/tests/receipt_replay.rs
+++ b/src/main/tests/receipt_replay.rs
@@ -214,6 +214,10 @@ async fn private_read_unannounced(services: &Services, room: &RoomId, user: &Use
 		.read_receipt
 		.last_privateread_update(user, room)
 		.await;
+	let (published_before, _) = services
+		.read_receipt
+		.private_read_sync_get_count(room, user)
+		.await?;
 
 	let stored = set_private_read(services, room, user, 7, false).await;
 	let after = services
@@ -225,6 +229,10 @@ async fn private_read_unannounced(services: &Services, room: &RoomId, user: &Use
 		.read_receipt
 		.private_read_get_count(room, user)
 		.await?;
+	let (published_after, _) = services
+		.read_receipt
+		.private_read_sync_get_count(room, user)
+		.await?;
 
 	if !stored || position != 7 {
 		return Err!("unannounced private marker did not store its position");
@@ -232,6 +240,83 @@ async fn private_read_unannounced(services: &Services, room: &RoomId, user: &Use
 
 	if after != before {
 		return Err!("unannounced private marker moved the update token");
+	}
+
+	if published_after != published_before {
+		return Err!("unannounced private marker changed the announced snapshot");
+	}
+
+	let announced = set_private_read(services, room, user, 8, true).await;
+	let (published, _) = services
+		.read_receipt
+		.private_read_sync_get_count(room, user)
+		.await?;
+
+	if !announced || published != 8 {
+		return Err!("announced private marker did not advance the sync snapshot");
+	}
+
+	private_read_premirror(services, room, user).await
+}
+
+/// A database predating the announced mirror holds gate rows with no mirror
+/// rows.
+///
+/// The bounded reader must fall back to the active state rather than fail the
+/// room range until the next announced write. A marker naming a resolvable
+/// event is served; one naming an unknown event is skipped, not an error.
+async fn private_read_premirror(services: &Services, room: &RoomId, user: &UserId) -> Result {
+	// Prime the short room id so the fallible reader can resolve the room.
+	services
+		.short
+		.get_or_create_shortroomid(room)
+		.await;
+
+	let gate = services
+		.read_receipt
+		.last_privateread_update(user, room)
+		.await;
+
+	let mirror = &services.db["roomuserid_privatereadsync"];
+
+	mirror.del((room, user));
+	mirror.del((room, user, ""));
+
+	let events = services
+		.read_receipt
+		.private_read_get_fallible(room, user, gate)
+		.await?;
+
+	if !events.is_empty() {
+		return Err!("pre-mirror fallback should skip markers without a resolvable event");
+	}
+
+	let admin_room = services.admin.get_admin_room().await?;
+	let position = services
+		.timeline
+		.last_timeline_count(None, &admin_room, None)
+		.await?
+		.into_unsigned();
+
+	if !set_private_read(services, &admin_room, user, position, true).await {
+		return Err!("admin-room private marker did not store");
+	}
+
+	let gate = services
+		.read_receipt
+		.last_privateread_update(user, &admin_room)
+		.await;
+
+	mirror.del((&admin_room, user));
+	mirror.del((&admin_room, user, ""));
+
+	let served = services
+		.read_receipt
+		.private_read_get_fallible(&admin_room, user, gate)
+		.await?;
+
+	if served.len() != 1 {
+		return Err!("pre-mirror fallback did not serve the active marker");
 	}
 
 	Ok(())

--- a/src/main/tests/receipt_replay.rs
+++ b/src/main/tests/receipt_replay.rs
@@ -62,22 +62,12 @@ async fn exercise(services: &Services) -> Result {
 	let receipts = &services.read_receipt;
 	let first = receipt_event(room, user, event_id!("$receipt-replay-first:localhost"));
 	let second = receipt_event(room, user, event_id!("$receipt-replay-second:localhost"));
-	let missing = receipts
-		.last_receipt_count(room, None, None)
-		.await;
-
-	if !matches!(missing, Err(error) if error.is_not_found()) {
-		return Err!("empty room did not report a missing receipt count");
-	}
 
 	let stored = receipts
 		.readreceipt_update(user, room, &first)
 		.await;
 
 	let after_store = receipt_counts(services, room).await;
-	let first_count = receipts
-		.last_receipt_count(room, Some(user), None)
-		.await?;
 
 	let replayed = receipts
 		.readreceipt_update(user, room, &first)
@@ -94,10 +84,6 @@ async fn exercise(services: &Services) -> Result {
 		return Err!("first receipt did not store exactly one row");
 	}
 
-	if first_count != after_store[0] {
-		return Err!("latest receipt query did not return the stored row");
-	}
-
 	if replayed || after_replay != after_store {
 		return Err!("replayed receipt moved the receipt stream");
 	}
@@ -106,49 +92,7 @@ async fn exercise(services: &Services) -> Result {
 		return Err!("receipt naming another event did not take a new position");
 	}
 
-	last_receipt_queries(services, room, user, after_advance[0]).await?;
-
 	private_read_replay(services, room, user).await
-}
-
-async fn last_receipt_queries(
-	services: &Services,
-	room: &RoomId,
-	user: &UserId,
-	user_count: u64,
-) -> Result {
-	let other = user_id!("@receipt-replay-other:localhost");
-	let event = receipt_event(room, other, event_id!("$receipt-replay-other:localhost"));
-	let receipts = &services.read_receipt;
-	let stored = receipts
-		.readreceipt_update(other, room, &event)
-		.await;
-
-	let other_count = receipts
-		.last_receipt_count(room, Some(other), None)
-		.await?;
-
-	let filtered = receipts
-		.last_receipt_count(room, Some(user), None)
-		.await?;
-
-	let bounded = receipts
-		.last_receipt_count(room, None, Some(other_count))
-		.await?;
-
-	if !stored || other_count <= user_count {
-		return Err!("second user's receipt did not advance the receipt stream");
-	}
-
-	if filtered != user_count {
-		return Err!("newer receipt hid the requested user's receipt");
-	}
-
-	if bounded != user_count {
-		return Err!("exclusive receipt bound did not return the prior row");
-	}
-
-	Ok(())
 }
 
 fn receipt_event(room: &RoomId, user: &UserId, event: &EventId) -> ReceiptEvent {
@@ -214,6 +158,7 @@ async fn private_read_unannounced(services: &Services, room: &RoomId, user: &Use
 		.read_receipt
 		.last_privateread_update(user, room)
 		.await;
+
 	let (published_before, _) = services
 		.read_receipt
 		.private_read_sync_get_count(room, user)
@@ -229,6 +174,7 @@ async fn private_read_unannounced(services: &Services, room: &RoomId, user: &Use
 		.read_receipt
 		.private_read_get_count(room, user)
 		.await?;
+
 	let (published_after, _) = services
 		.read_receipt
 		.private_read_sync_get_count(room, user)

--- a/src/service/account_data/mod.rs
+++ b/src/service/account_data/mod.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tuwunel_core::{
 	Err, Result, at, err, implement,
-	utils::{ReadyExt, result::LogErr, stream::TryIgnore},
+	utils::{ReadyExt, TryReadyExt, result::LogErr, stream::TryIgnore},
 };
 use tuwunel_database::{Deserialized, Handle, Ignore, Interfix, Json, Map};
 
@@ -158,6 +158,24 @@ pub fn changes_since<'a>(
 	since: u64,
 	to: Option<u64>,
 ) -> impl Stream<Item = AnyRawAccountDataEvent> + Send + 'a {
+	self.changes_since_fallible(room_id, user_id, since, to)
+		.map(LogErr::log_err)
+		.ignore_err()
+}
+
+/// Returns bounded account-data changes without suppressing failures.
+///
+/// The lower bound is exclusive and the optional upper bound is inclusive.
+/// Cursor, decode, and deserialization failures remain in the stream for an
+/// atomic caller to handle.
+#[implement(Service)]
+pub fn changes_since_fallible<'a>(
+	&'a self,
+	room_id: Option<&'a RoomId>,
+	user_id: &'a UserId,
+	since: u64,
+	to: Option<u64>,
+) -> impl Stream<Item = Result<AnyRawAccountDataEvent>> + Send + 'a {
 	type Key<'a> = (Option<&'a RoomId>, &'a UserId, u64, Ignore);
 
 	// Skip the data that's exactly at since, because we sent that last time
@@ -166,11 +184,10 @@ pub fn changes_since<'a>(
 	self.db
 		.roomuserdataid_accountdata
 		.stream_from(&first_possible)
-		.ignore_err()
-		.ready_take_while(move |((room_id_, user_id_, count, _), _): &(Key<'_>, _)| {
-			room_id == *room_id_ && user_id == *user_id_ && to.is_none_or(|to| *count <= to)
+		.ready_try_take_while(move |((room_id_, user_id_, count, _), _): &(Key<'_>, _)| {
+			Ok(room_id == *room_id_ && user_id == *user_id_ && to.is_none_or(|to| *count <= to))
 		})
-		.map(move |(_, v)| {
+		.ready_and_then(move |(_, v)| {
 			match room_id {
 				| Some(_) => serde_json::from_slice::<Raw<AnyRoomAccountDataEvent>>(v)
 					.map(AnyRawAccountDataEvent::Room),
@@ -178,9 +195,7 @@ pub fn changes_since<'a>(
 					.map(AnyRawAccountDataEvent::Global),
 			}
 			.map_err(|e| err!(Database("Database contains invalid account data: {e}")))
-			.log_err()
 		})
-		.ignore_err()
 }
 
 /// MSC4025: erase all account data for a user in the given namespace

--- a/src/service/admin/console.rs
+++ b/src/service/admin/console.rs
@@ -243,7 +243,7 @@ fn configure_output_err(mut output: MadSkin) -> MadSkin {
 	use termimad::{Alignment, CompoundStyle, LineStyle, crossterm::style::Color};
 
 	let code_style = CompoundStyle::with_fgbg(Color::AnsiValue(196), Color::AnsiValue(234));
-	output.inline_code = code_style.clone();
+	output.inline_code = code_style;
 	output.code_block = LineStyle {
 		left_margin: 0,
 		right_margin: 0,
@@ -258,7 +258,7 @@ fn configure_output(mut output: MadSkin) -> MadSkin {
 	use termimad::{Alignment, CompoundStyle, LineStyle, crossterm::style::Color};
 
 	let code_style = CompoundStyle::with_fgbg(Color::AnsiValue(40), Color::AnsiValue(234));
-	output.inline_code = code_style.clone();
+	output.inline_code = code_style;
 	output.code_block = LineStyle {
 		left_margin: 0,
 		right_margin: 0,

--- a/src/service/membership/knock.rs
+++ b/src/service/membership/knock.rs
@@ -26,6 +26,7 @@ use crate::{
 	membership::join::get_servers_for_room,
 	rooms::{
 		state::RoomMutexGuard,
+		state_cache::MembershipUpdate,
 		state_compressor::{CompressedState, HashSetCompressStateEvent},
 	},
 };
@@ -255,26 +256,28 @@ async fn finalize_knock_membership(
 
 	info!("Updating membership locally to knock state with provided stripped state events");
 	let count = self.services.globals.next_count();
+	let membership_event = parsed_knock_pdu
+		.get_content::<RoomMemberEventContent>()
+		.expect("we just created this");
+
+	let last_state = send_knock_response
+		.knock_room_state
+		.into_iter()
+		.filter_map(|state| into_client_stripped(room_id, state))
+		.collect();
+
 	self.services
 		.state_cache
-		.update_membership(
+		.update_membership(MembershipUpdate {
 			room_id,
-			sender_user,
-			parsed_knock_pdu
-				.get_content::<RoomMemberEventContent>()
-				.expect("we just created this"),
-			sender_user,
-			Some(
-				send_knock_response
-					.knock_room_state
-					.into_iter()
-					.filter_map(|state| into_client_stripped(room_id, state))
-					.collect(),
-			),
-			None,
-			false,
-			PduCount::Normal(*count),
-		)
+			user_id: sender_user,
+			membership_event,
+			sender: sender_user,
+			last_state: Some(last_state),
+			invite_via: None,
+			update_joined_count: false,
+			count: PduCount::Normal(*count),
+		})
 		.await?;
 
 	info!("Appending room knock event locally");
@@ -352,26 +355,28 @@ async fn knock_room_helper_remote(
 
 	info!("Updating membership locally to knock state with provided stripped state events");
 	let count = self.services.globals.next_count();
+	let membership_event = parsed_knock_pdu
+		.get_content::<RoomMemberEventContent>()
+		.expect("we just created this");
+
+	let last_state = send_knock_response
+		.knock_room_state
+		.into_iter()
+		.filter_map(|state| into_client_stripped(room_id, state))
+		.collect();
+
 	self.services
 		.state_cache
-		.update_membership(
+		.update_membership(MembershipUpdate {
 			room_id,
-			sender_user,
-			parsed_knock_pdu
-				.get_content::<RoomMemberEventContent>()
-				.expect("we just created this"),
-			sender_user,
-			Some(
-				send_knock_response
-					.knock_room_state
-					.into_iter()
-					.filter_map(|state| into_client_stripped(room_id, state))
-					.collect(),
-			),
-			None,
-			false,
-			PduCount::Normal(*count),
-		)
+			user_id: sender_user,
+			membership_event,
+			sender: sender_user,
+			last_state: Some(last_state),
+			invite_via: None,
+			update_joined_count: false,
+			count: PduCount::Normal(*count),
+		})
 		.await?;
 
 	info!("Appending room knock event locally");

--- a/src/service/membership/leave.rs
+++ b/src/service/membership/leave.rs
@@ -20,7 +20,7 @@ use tuwunel_core::{
 };
 
 use super::Service;
-use crate::rooms::timeline::RoomMutexGuard;
+use crate::rooms::{state_cache::MembershipUpdate, timeline::RoomMutexGuard};
 
 #[implement(Service)]
 #[async_noinline]
@@ -233,16 +233,16 @@ async fn clear_local_leave(
 	let count = self.services.globals.next_count();
 	self.services
 		.state_cache
-		.update_membership(
+		.update_membership(MembershipUpdate {
 			room_id,
 			user_id,
-			leave_content,
-			user_id,
+			membership_event: leave_content,
+			sender: user_id,
 			last_state,
-			None,
-			true,
-			PduCount::Normal(*count),
-		)
+			invite_via: None,
+			update_joined_count: true,
+			count: PduCount::Normal(*count),
+		})
 		.await
 }
 

--- a/src/service/rooms/event_handler/handle_incoming_pdu.rs
+++ b/src/service/rooms/event_handler/handle_incoming_pdu.rs
@@ -24,7 +24,7 @@ use tuwunel_core::{
 };
 
 use super::backoff::{Context, Disposition};
-use crate::rooms::timeline::RawPduId;
+use crate::rooms::{state_cache::MembershipUpdate, timeline::RawPduId};
 
 type PrevResultsHandled = SmallVec<[PrevHandled; MAX_PREV_EVENTS]>;
 type PrevHandled = (OwnedEventId, Handled);
@@ -319,16 +319,16 @@ async fn handle_rescinded_invite(
 	let count = self.services.globals.next_count();
 	self.services
 		.state_cache
-		.update_membership(
+		.update_membership(MembershipUpdate {
 			room_id,
-			&target,
-			RoomMemberEventContent::new(MembershipState::Leave),
-			&sender,
-			None,
-			None,
-			false,
-			PduCount::Normal(*count),
-		)
+			user_id: &target,
+			membership_event: RoomMemberEventContent::new(MembershipState::Leave),
+			sender: &sender,
+			last_state: None,
+			invite_via: None,
+			update_joined_count: false,
+			count: PduCount::Normal(*count),
+		})
 		.await?;
 
 	debug!(%room_id, %target, %sender, "Applied a federated invite rescission.");

--- a/src/service/rooms/read_receipt/data.rs
+++ b/src/service/rooms/read_receipt/data.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use futures::{
-	Stream, StreamExt, TryStreamExt,
+	Stream, TryStreamExt,
 	future::{join, try_join},
 };
 use ruma::{
@@ -11,7 +11,7 @@ use ruma::{
 };
 use serde::{Deserialize, de::IgnoredAny};
 use tuwunel_core::{
-	Result, err, error, is_equal_to,
+	Result, error,
 	matrix::pdu::PduCount,
 	smallvec::SmallVec,
 	trace,
@@ -206,32 +206,6 @@ impl Data {
 
 				Ok((user_id, count, Raw::from_json(event)))
 			})
-	}
-
-	#[inline]
-	pub(super) async fn last_receipt_count<'a>(
-		&'a self,
-		room_id: &'a RoomId,
-		upper: Option<u64>,
-		user_id: Option<&'a UserId>,
-	) -> Result<u64> {
-		// 4-tuple key: pre-MSC3771 rows deserialize with `&str` tail empty.
-		type Key<'a> = (&'a RoomId, u64, &'a UserId, &'a str);
-
-		let key = (room_id, upper.unwrap_or(u64::MAX));
-
-		self.readreceiptid_readreceipt
-			.rev_keys_from(&key)
-			.ignore_err()
-			.ready_take_while(|(room_id_, ..): &Key<'_>| *room_id_ == room_id)
-			.ready_filter(|(_, _, user_id_, _): &Key<'_>| {
-				user_id.is_none_or(is_equal_to!(*user_id_))
-			})
-			.map(|(_, count, ..): Key<'_>| count)
-			.boxed()
-			.next()
-			.await
-			.ok_or_else(|| err!(Request(NotFound("No receipts found in room"))))
 	}
 
 	/// Sets the private read marker for `(room, user, thread)`, reporting

--- a/src/service/rooms/read_receipt/data.rs
+++ b/src/service/rooms/read_receipt/data.rs
@@ -195,20 +195,22 @@ impl Data {
 	pub(super) async fn last_receipt_count<'a>(
 		&'a self,
 		room_id: &'a RoomId,
-		since: Option<u64>,
+		upper: Option<u64>,
 		user_id: Option<&'a UserId>,
 	) -> Result<u64> {
 		// 4-tuple key: pre-MSC3771 rows deserialize with `&str` tail empty.
 		type Key<'a> = (&'a RoomId, u64, &'a UserId, &'a str);
 
-		let key = (room_id, u64::MAX);
+		let key = (room_id, upper.unwrap_or(u64::MAX));
+
 		self.readreceiptid_readreceipt
-			.rev_keys_prefix(&key)
+			.rev_keys_from(&key)
 			.ignore_err()
-			.ready_take_while(|(_, c, u, _): &Key<'_>| {
-				since.is_none_or(|since| since > *c) && user_id.is_none_or(is_equal_to!(*u))
+			.ready_take_while(|(room_id_, ..): &Key<'_>| *room_id_ == room_id)
+			.ready_filter(|(_, _, user_id_, _): &Key<'_>| {
+				user_id.is_none_or(is_equal_to!(*user_id_))
 			})
-			.map(|(_, c, ..): Key<'_>| c)
+			.map(|(_, count, ..): Key<'_>| count)
 			.boxed()
 			.next()
 			.await

--- a/src/service/rooms/read_receipt/data.rs
+++ b/src/service/rooms/read_receipt/data.rs
@@ -1,6 +1,9 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use futures::{Stream, StreamExt, future::join};
+use futures::{
+	Stream, StreamExt, TryStreamExt,
+	future::{join, try_join},
+};
 use ruma::{
 	CanonicalJsonObject, EventId, OwnedEventId, RoomId, UserId,
 	events::{AnySyncEphemeralRoomEvent, receipt::ReceiptEvent},
@@ -8,11 +11,11 @@ use ruma::{
 };
 use serde::{Deserialize, de::IgnoredAny};
 use tuwunel_core::{
-	Result, err, is_equal_to,
+	Result, err, error, is_equal_to,
 	matrix::pdu::PduCount,
 	smallvec::SmallVec,
 	trace,
-	utils::{ReadyExt, stream::TryIgnore},
+	utils::{ReadyExt, TryReadyExt, stream::TryIgnore},
 };
 use tuwunel_database::{Deserialized, Interfix, Json, KeyBuf, Map, Txn, serialize_key};
 
@@ -21,11 +24,15 @@ use super::{PrivateRead, ThreadKind};
 pub(super) struct Data {
 	roomuserid_privateread: Arc<Map>,
 	roomuserid_lastprivatereadupdate: Arc<Map>,
+	roomuserid_privatereadsync: Arc<Map>,
 	services: Arc<crate::services::OnceServices>,
 	readreceiptid_readreceipt: Arc<Map>,
 }
 
 pub(super) type ReceiptItem<'a> = (&'a UserId, u64, Raw<AnySyncEphemeralRoomEvent>);
+
+/// Row shape shared by the active and mirrored private read maps.
+type RowKv<'a> = ((&'a RoomId, &'a UserId, &'a str), (u64, Option<u64>));
 
 /// Receipt rows an accepted update replaces.
 ///
@@ -50,6 +57,7 @@ impl Data {
 		Self {
 			roomuserid_privateread: db["roomuserid_privateread"].clone(),
 			roomuserid_lastprivatereadupdate: db["roomuserid_lastprivatereadupdate"].clone(),
+			roomuserid_privatereadsync: db["roomuserid_privatereadsync"].clone(),
 			readreceiptid_readreceipt: db["readreceiptid_readreceipt"].clone(),
 			services: args.services.clone(),
 		}
@@ -168,6 +176,17 @@ impl Data {
 		since: u64,
 		to: Option<u64>,
 	) -> impl Stream<Item = ReceiptItem<'_>> + Send + 'a {
+		self.readreceipts_since_fallible(room_id, since, to)
+			.ignore_err()
+	}
+
+	#[inline]
+	pub(super) fn readreceipts_since_fallible<'a>(
+		&'a self,
+		room_id: &'a RoomId,
+		since: u64,
+		to: Option<u64>,
+	) -> impl Stream<Item = Result<ReceiptItem<'_>>> + Send + 'a {
 		// 4-tuple key: pre-MSC3771 rows deserialize with `&str` tail empty.
 		type Key<'a> = (&'a RoomId, u64, &'a UserId, &'a str);
 		type KeyVal<'a> = (Key<'a>, CanonicalJsonObject);
@@ -177,18 +196,16 @@ impl Data {
 
 		self.readreceiptid_readreceipt
 			.stream_from(&first_possible_edu)
-			.ignore_err()
-			.ready_take_while(move |((r, c, ..), _): &KeyVal<'_>| {
-				*r == room_id && to.is_none_or(|to| *c <= to)
+			.ready_try_take_while(move |((r, c, ..), _): &KeyVal<'_>| {
+				Ok(*r == room_id && to.is_none_or(|to| *c <= to))
 			})
-			.map(move |((_, count, user_id, _), mut json): KeyVal<'_>| {
+			.ready_and_then(move |((_, count, user_id, _), mut json): KeyVal<'_>| {
 				json.remove("room_id");
 
 				let event = serde_json::value::to_raw_value(&json)?;
 
 				Ok((user_id, count, Raw::from_json(event)))
 			})
-			.ignore_err()
 	}
 
 	#[inline]
@@ -226,7 +243,9 @@ impl Data {
 	/// use a 3-tuple `(room, user, thread_kind)` key disjoint from the
 	/// legacy row by trailing separator. The sync gate
 	/// (`roomuserid_lastprivatereadupdate`) stays 2-tuple and bumps only when
-	/// `announce` is set, keeping it a single point query.
+	/// `announce` is set, keeping it a single point query. Announced state is
+	/// mirrored separately so notification-only writes cannot alter a sync
+	/// snapshot without changing its version.
 	#[inline]
 	pub(super) async fn private_read_set(
 		&self,
@@ -249,18 +268,60 @@ impl Data {
 			return false;
 		}
 
-		let mut txn = self
-			.sweep_thread_private_reads(room_id, user_id, thread_kind, self.services.db.txn())
+		let reset_sync = if announce && !thread_kind.is_empty() {
+			let versions = try_join(
+				self.last_privateread_update_fallible(user_id, room_id),
+				self.private_read_sync_update_fallible(user_id, room_id),
+			)
 			.await;
+
+			match versions {
+				| Ok((gate, snapshot)) => gate != snapshot,
+				| Err(error) => {
+					error!(?error, "Failed to inspect the private read sync snapshot.");
+					return false;
+				},
+			}
+		} else {
+			false
+		};
+
+		let mut txn = self
+			.sweep_thread_private_reads(
+				&self.roomuserid_privateread,
+				room_id,
+				user_id,
+				thread_kind,
+				self.services.db.txn(),
+			)
+			.await;
+
+		if announce && (thread_kind.is_empty() || reset_sync) {
+			txn = match self
+				.sweep_private_read_sync(room_id, user_id, txn)
+				.await
+			{
+				| Ok(txn) => txn,
+				| Err(error) => {
+					error!(?error, "Failed to reset the private read sync snapshot.");
+					return false;
+				},
+			};
+		}
 
 		// The permit retires the sequence number on drop, so it outlives execute().
 		let next_count = announce.then(|| self.services.globals.next_count());
+		let ts = u64::from(ts.get());
 
 		if let Some(next_count) = next_count.as_deref() {
 			txn.put(&self.roomuserid_lastprivatereadupdate, (room_id, user_id), *next_count);
+			txn.put(&self.roomuserid_privatereadsync, (room_id, user_id), *next_count);
+			txn.put(
+				&self.roomuserid_privatereadsync,
+				(room_id, user_id, thread_kind),
+				(count, ts),
+			);
 		}
-
-		let ts = u64::from(ts.get());
 
 		// Additive value tail: ts (millis); old bare-count rows read back None.
 		match thread_kind.is_empty() {
@@ -315,23 +376,26 @@ impl Data {
 			.deserialized()
 	}
 
-	/// Stream of `(thread_kind, pdu_count)` for the per-thread (3-tuple)
-	/// private read rows for this `(room, user)`. The legacy 2-tuple row is
-	/// excluded by the trailing-separator prefix; query it via
-	/// `private_read_get_count`.
+	#[inline]
+	pub(super) async fn private_read_sync_get_count(
+		&self,
+		room_id: &RoomId,
+		user_id: &UserId,
+	) -> Result<(u64, Option<u64>)> {
+		let key = (room_id, user_id, "");
+		self.roomuserid_privatereadsync
+			.qry(&key)
+			.await
+			.deserialized()
+	}
+
 	#[inline]
 	pub(super) fn private_read_threaded_stream<'a>(
 		&'a self,
 		room_id: &'a RoomId,
 		user_id: &'a UserId,
 	) -> impl Stream<Item = (ThreadKind, u64, Option<u64>)> + Send + 'a {
-		type ThreadKv<'a> = ((&'a RoomId, &'a UserId, &'a str), (u64, Option<u64>));
-
-		let prefix = (room_id, user_id, Interfix);
-		self.roomuserid_privateread
-			.stream_prefix(&prefix)
-			.ignore_err()
-			.map(|((_, _, kind), (count, ts)): ThreadKv<'_>| (ThreadKind::from(kind), count, ts))
+		private_read_row_stream(&self.roomuserid_privateread, room_id, user_id).ignore_err()
 	}
 
 	/// Queues deletion of the per-thread private read rows for `(room, user)`.
@@ -341,6 +405,7 @@ impl Data {
 	#[inline]
 	async fn sweep_thread_private_reads(
 		&self,
+		map: &Arc<Map>,
 		room_id: &RoomId,
 		user_id: &UserId,
 		thread_kind: &str,
@@ -352,14 +417,54 @@ impl Data {
 
 		let prefix = (room_id, user_id, Interfix);
 
-		self.roomuserid_privateread
-			.keys_prefix_raw(&prefix)
+		map.keys_prefix_raw(&prefix)
 			.ignore_err()
 			.ready_fold(txn, |mut txn, key| {
-				txn.del_raw(&self.roomuserid_privateread, key);
+				txn.del_raw(map, key);
 				txn
 			})
 			.await
+	}
+
+	#[inline]
+	async fn sweep_private_read_sync(
+		&self,
+		room_id: &RoomId,
+		user_id: &UserId,
+		txn: Txn,
+	) -> Result<Txn> {
+		let prefix = (room_id, user_id, Interfix);
+
+		self.roomuserid_privatereadsync
+			.keys_prefix_raw(&prefix)
+			.ready_try_fold(txn, |mut txn, key| {
+				txn.del_raw(&self.roomuserid_privatereadsync, key);
+				Ok(txn)
+			})
+			.await
+	}
+
+	#[inline]
+	pub(super) fn private_read_sync_stream_fallible<'a>(
+		&'a self,
+		room_id: &'a RoomId,
+		user_id: &'a UserId,
+	) -> impl Stream<Item = Result<(ThreadKind, u64, Option<u64>)>> + Send + 'a {
+		private_read_row_stream(&self.roomuserid_privatereadsync, room_id, user_id)
+	}
+
+	#[inline]
+	pub(super) async fn private_read_sync_update_fallible(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+	) -> Result<u64> {
+		let key = (room_id, user_id);
+		self.roomuserid_privatereadsync
+			.qry(&key)
+			.await
+			.deserialized()
+			.or_else(|error| error.is_not_found().then_some(0).ok_or(error))
 	}
 
 	#[inline]
@@ -368,12 +473,23 @@ impl Data {
 		user_id: &UserId,
 		room_id: &RoomId,
 	) -> u64 {
+		self.last_privateread_update_fallible(user_id, room_id)
+			.await
+			.unwrap_or_default()
+	}
+
+	#[inline]
+	pub(super) async fn last_privateread_update_fallible(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+	) -> Result<u64> {
 		let key = (room_id, user_id);
 		self.roomuserid_lastprivatereadupdate
 			.qry(&key)
 			.await
 			.deserialized()
-			.unwrap_or(0)
+			.or_else(|error| error.is_not_found().then_some(0).ok_or(error))
 	}
 
 	#[inline]
@@ -398,6 +514,15 @@ impl Data {
 			})
 			.await;
 
+		self.roomuserid_privatereadsync
+			.keys_prefix_raw(&prefix)
+			.ignore_err()
+			.ready_for_each(|key| {
+				trace!("Removing key: {key:?}");
+				self.roomuserid_privatereadsync.remove(key);
+			})
+			.await;
+
 		self.readreceiptid_readreceipt
 			.keys_prefix_raw(&prefix)
 			.ignore_err()
@@ -409,6 +534,21 @@ impl Data {
 
 		Ok(())
 	}
+}
+
+/// Per-thread marker rows under `(room, user)` in `map`.
+///
+/// Active markers in the live store and announced markers in the sync mirror
+/// share one row shape, keyed by thread kind.
+fn private_read_row_stream<'a>(
+	map: &'a Arc<Map>,
+	room_id: &'a RoomId,
+	user_id: &'a UserId,
+) -> impl Stream<Item = Result<(ThreadKind, u64, Option<u64>)>> + Send + 'a {
+	let prefix = (room_id, user_id, Interfix);
+
+	map.stream_prefix(&prefix)
+		.map_ok(|((_, _, kind), (count, ts)): RowKv<'_>| (ThreadKind::from(kind), count, ts))
 }
 
 /// Tag string used in the storage key to discriminate receipts per thread.

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -278,10 +278,10 @@ impl Service {
 		&self,
 		room_id: &RoomId,
 		user_id: Option<&UserId>,
-		since: Option<u64>,
+		upper: Option<u64>,
 	) -> Result<u64> {
 		self.db
-			.last_receipt_count(room_id, since, user_id)
+			.last_receipt_count(room_id, upper, user_id)
 			.await
 	}
 

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -4,7 +4,7 @@ mod tests;
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use ruma::{
 	MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, RoomId, UInt, UserId,
 	api::appservice::event::push_events::v1::EphemeralData,
@@ -16,6 +16,7 @@ use ruma::{
 	},
 	serde::Raw,
 };
+use serde_json::value::to_raw_value;
 use tuwunel_core::{
 	Result, debug,
 	debug::INFO_SPAN_LEVEL,
@@ -27,7 +28,7 @@ use tuwunel_core::{
 	smallstr::SmallString,
 	smallvec::SmallVec,
 	trace,
-	utils::{BoolExt, IterStream},
+	utils::{BoolExt, IterStream, stream::TryBroadbandExt},
 	warn,
 };
 
@@ -173,6 +174,74 @@ impl Service {
 		Ok(events)
 	}
 
+	/// Gets the complete announced private read snapshot for `update` without
+	/// suppressing malformed rows or failed point reads.
+	///
+	/// A snapshot older than the gate predates this durable mirror, so those
+	/// rows fall back to the tolerant active-state read they always published
+	/// rather than withholding the whole room after an upgrade. A newer
+	/// snapshot means a concurrent announce; that fails the bounded room range
+	/// so its cursor remains pinned.
+	#[tracing::instrument(skip(self), level = "debug", name = "get_private_fallible")]
+	pub async fn private_read_get_fallible(
+		&self,
+		room_id: &RoomId,
+		user_id: &UserId,
+		update: u64,
+	) -> Result<PrivateReadEvents> {
+		let snapshot = self
+			.db
+			.private_read_sync_update_fallible(user_id, room_id)
+			.await?;
+
+		if snapshot < update {
+			debug!(%room_id, %user_id, "Serving pre-mirror private read from the active store.");
+			return self.private_read_get(room_id, user_id).await;
+		}
+
+		if snapshot > update {
+			return Err(err!(Database(
+				"Private read snapshot advanced while assembling a bounded sync range."
+			)));
+		}
+
+		let shortroomid = async {
+			self.services
+				.short
+				.get_shortroomid(room_id)
+				.await
+				.map_err(|e| {
+					err!(Database(warn!(
+						"Short room ID does not exist in database for {room_id}: {e}"
+					)))
+				})
+		};
+
+		let shortroomid = shortroomid.await?;
+		let events = self
+			.db
+			.private_read_sync_stream_fallible(room_id, user_id)
+			.broad_and_then(async |(kind, count, ts)| {
+				self.build_private_read_event_fallible(shortroomid, count, ts, user_id, &kind)
+					.await
+			})
+			.try_collect()
+			.await?;
+
+		let confirmed = self
+			.db
+			.private_read_sync_update_fallible(user_id, room_id)
+			.await?;
+
+		if confirmed != update {
+			return Err(err!(Database(
+				"Private read snapshot changed while assembling a bounded sync range."
+			)));
+		}
+
+		Ok(events)
+	}
+
 	async fn build_private_read_event(
 		&self,
 		shortroomid: u64,
@@ -181,6 +250,45 @@ impl Service {
 		user_id: &UserId,
 		thread_kind: &str,
 	) -> Option<Raw<AnySyncEphemeralRoomEvent>> {
+		let thread = thread_kind_to_receipt(thread_kind).unwrap_or(ReceiptThread::Unthreaded);
+		let ts = ts
+			.and_then(UInt::new)
+			.map(MilliSecondsSinceUnixEpoch);
+
+		self.build_private_read_event_from(shortroomid, count, ts, user_id, thread)
+			.await
+			.ok()
+	}
+
+	async fn build_private_read_event_fallible(
+		&self,
+		shortroomid: u64,
+		count: u64,
+		ts: Option<u64>,
+		user_id: &UserId,
+		thread_kind: &str,
+	) -> Result<Raw<AnySyncEphemeralRoomEvent>> {
+		let thread = thread_kind_to_receipt(thread_kind)?;
+		let ts = ts
+			.map(|ts| {
+				UInt::new(ts)
+					.map(MilliSecondsSinceUnixEpoch)
+					.ok_or_else(|| err!(Database("Invalid private receipt timestamp {ts}.")))
+			})
+			.transpose()?;
+
+		self.build_private_read_event_from(shortroomid, count, ts, user_id, thread)
+			.await
+	}
+
+	async fn build_private_read_event_from(
+		&self,
+		shortroomid: u64,
+		count: u64,
+		ts: Option<MilliSecondsSinceUnixEpoch>,
+		user_id: &UserId,
+		thread: ReceiptThread,
+	) -> Result<Raw<AnySyncEphemeralRoomEvent>> {
 		let pdu_id: RawPduId = PduId {
 			shortroomid,
 			count: PduCount::Normal(count),
@@ -190,13 +298,7 @@ impl Service {
 			.services
 			.timeline
 			.get_pdu_from_id(&pdu_id)
-			.await
-			.ok()?;
-
-		let thread = thread_kind_to_receipt(thread_kind);
-		let ts = ts
-			.and_then(UInt::new)
-			.map(MilliSecondsSinceUnixEpoch);
+			.await?;
 
 		let event_id: OwnedEventId = pdu.event_id().to_owned();
 		let user_id: OwnedUserId = user_id.to_owned();
@@ -210,10 +312,9 @@ impl Service {
 
 		let receipt_event_content = ReceiptEventContent(content);
 		let receipt_sync_event = SyncEphemeralRoomEvent { content: receipt_event_content };
-		let event = serde_json::value::to_raw_value(&receipt_sync_event)
-			.expect("receipt created manually");
+		let event = to_raw_value(&receipt_sync_event)?;
 
-		Some(Raw::from_json(event))
+		Ok(Raw::from_json(event))
 	}
 
 	/// Returns an iterator over the most recent read_receipts in a room that
@@ -226,6 +327,23 @@ impl Service {
 		to: Option<u64>,
 	) -> impl Stream<Item = ReceiptItem<'_>> + Send + 'a {
 		self.db.readreceipts_since(room_id, since, to)
+	}
+
+	/// Returns read receipts in a bounded room range without suppressing
+	/// failures.
+	///
+	/// The lower bound is exclusive and the optional upper bound is inclusive.
+	/// Cursor, decode, and serialization failures remain in the stream for an
+	/// atomic caller to handle.
+	#[tracing::instrument(skip(self), level = "debug")]
+	pub fn readreceipts_since_fallible<'a>(
+		&'a self,
+		room_id: &'a RoomId,
+		since: u64,
+		to: Option<u64>,
+	) -> impl Stream<Item = Result<ReceiptItem<'_>>> + Send + 'a {
+		self.db
+			.readreceipts_since_fallible(room_id, since, to)
 	}
 
 	/// Sets a private read marker at PDU `count` for the given thread.
@@ -255,7 +373,28 @@ impl Service {
 			.await
 	}
 
-	/// Returns the PDU count of the last typing update in this room.
+	/// Returns the announced unthreaded private read marker PDU count.
+	#[tracing::instrument(
+		name = "get_private_sync_count",
+		level = "debug",
+		skip(self),
+		ret(level = "trace")
+	)]
+	pub async fn private_read_sync_get_count(
+		&self,
+		room_id: &RoomId,
+		user_id: &UserId,
+	) -> Result<(u64, Option<u64>)> {
+		self.db
+			.private_read_sync_get_count(room_id, user_id)
+			.await
+	}
+
+	/// Returns the PDU count of the last private read update in this room.
+	///
+	/// Missing or unreadable update rows return zero for legacy callers.
+	/// Bounded sync callers use the fallible variant below so failures retain
+	/// the room cursor.
 	#[tracing::instrument(
 		name = "get_private_last",
 		level = "debug",
@@ -265,6 +404,27 @@ impl Service {
 	pub async fn last_privateread_update(&self, user_id: &UserId, room_id: &RoomId) -> u64 {
 		self.db
 			.last_privateread_update(user_id, room_id)
+			.await
+	}
+
+	/// Returns the bounded-sync token for the last private read update.
+	///
+	/// A missing token is returned as zero. Database and decode failures are
+	/// preserved so a caller can retain its room cursor and retry the complete
+	/// range.
+	#[tracing::instrument(
+		name = "get_private_last_fallible",
+		level = "debug",
+		skip(self),
+		ret(level = "trace")
+	)]
+	pub async fn last_privateread_update_fallible(
+		&self,
+		user_id: &UserId,
+		room_id: &RoomId,
+	) -> Result<u64> {
+		self.db
+			.last_privateread_update_fallible(user_id, room_id)
 			.await
 	}
 
@@ -291,16 +451,45 @@ impl Service {
 }
 
 /// Reverse of `ReceiptThread::as_str`: parse a stored thread tag into the
-/// enum. Empty string maps to `Unthreaded`; `"main"` to `Main`; anything
-/// starting with `$` to `Thread(event_id)` if parseable.
-fn thread_kind_to_receipt(thread_kind: &str) -> ReceiptThread {
+/// enum. Empty string maps to `Unthreaded`; `"main"` to `Main`; all other
+/// values must be valid event IDs.
+fn thread_kind_to_receipt(thread_kind: &str) -> Result<ReceiptThread> {
 	match thread_kind {
-		| "" => ReceiptThread::Unthreaded,
-		| "main" => ReceiptThread::Main,
+		| "" => Ok(ReceiptThread::Unthreaded),
+		| "main" => Ok(ReceiptThread::Main),
 		| _ => OwnedEventId::try_from(thread_kind)
 			.map(ReceiptThread::Thread)
-			.unwrap_or(ReceiptThread::Unthreaded),
+			.map_err(|error| err!(Database("Invalid private receipt thread: {error}"))),
 	}
+}
+
+/// Packs read receipts into one sync event without suppressing malformed input.
+///
+/// Every input must deserialize as a receipt event. The caller receives any
+/// parse or serialization failure and can retain the bounded room cursor
+/// instead of publishing a partial event.
+pub fn pack_receipts_fallible<I>(
+	mut receipts: I,
+) -> Result<Raw<SyncEphemeralRoomEvent<ReceiptEventContent>>>
+where
+	I: Iterator<Item = Raw<AnySyncEphemeralRoomEvent>>,
+{
+	let json = receipts.try_fold(BTreeMap::new(), |mut json, value| -> Result<_> {
+		let value = serde_json::from_str::<SyncEphemeralRoomEvent<ReceiptEventContent>>(
+			value.json().get(),
+		)?;
+
+		for (event, receipt) in value.content {
+			json.insert(event, receipt);
+		}
+
+		Ok(json)
+	})?;
+
+	let content = ReceiptEventContent(json);
+	let event = to_raw_value(&SyncEphemeralRoomEvent { content })?;
+
+	Ok(Raw::from_json(event))
 }
 
 #[must_use]
@@ -328,7 +517,6 @@ where
 
 	trace!(?content);
 	Raw::from_json(
-		serde_json::value::to_raw_value(&SyncEphemeralRoomEvent { content })
-			.expect("received valid json"),
+		to_raw_value(&SyncEphemeralRoomEvent { content }).expect("received valid json"),
 	)
 }

--- a/src/service/rooms/read_receipt/mod.rs
+++ b/src/service/rooms/read_receipt/mod.rs
@@ -27,7 +27,6 @@ use tuwunel_core::{
 	},
 	smallstr::SmallString,
 	smallvec::SmallVec,
-	trace,
 	utils::{BoolExt, IterStream, stream::TryBroadbandExt},
 	warn,
 };
@@ -428,23 +427,6 @@ impl Service {
 			.await
 	}
 
-	#[tracing::instrument(
-		name = "get_receipt_last",
-		level = "debug",
-		skip(self),
-		ret(level = "trace")
-	)]
-	pub async fn last_receipt_count(
-		&self,
-		room_id: &RoomId,
-		user_id: Option<&UserId>,
-		upper: Option<u64>,
-	) -> Result<u64> {
-		self.db
-			.last_receipt_count(room_id, upper, user_id)
-			.await
-	}
-
 	pub async fn delete_all_read_receipts(&self, room_id: &RoomId) -> Result {
 		self.db.delete_all_read_receipts(room_id).await
 	}
@@ -490,33 +472,4 @@ where
 	let event = to_raw_value(&SyncEphemeralRoomEvent { content })?;
 
 	Ok(Raw::from_json(event))
-}
-
-#[must_use]
-pub fn pack_receipts<I>(receipts: I) -> Raw<SyncEphemeralRoomEvent<ReceiptEventContent>>
-where
-	I: Iterator<Item = Raw<AnySyncEphemeralRoomEvent>>,
-{
-	let mut json = BTreeMap::new();
-	for value in receipts {
-		let receipt = serde_json::from_str::<SyncEphemeralRoomEvent<ReceiptEventContent>>(
-			value.json().get(),
-		);
-		match receipt {
-			| Ok(value) =>
-				for (event, receipt) in value.content {
-					json.insert(event, receipt);
-				},
-			| _ => {
-				debug!("failed to parse receipt: {:?}", receipt);
-			},
-		}
-	}
-
-	let content = ReceiptEventContent::from_iter(json);
-
-	trace!(?content);
-	Raw::from_json(
-		to_raw_value(&SyncEphemeralRoomEvent { content }).expect("received valid json"),
-	)
 }

--- a/src/service/rooms/read_receipt/tests.rs
+++ b/src/service/rooms/read_receipt/tests.rs
@@ -4,7 +4,7 @@ use ruma::{RoomId, UserId};
 use tuwunel_core::matrix::pdu::PduCount;
 use tuwunel_database::{Interfix, SEP, serialize_to_vec};
 
-use super::data::position_advances;
+use super::{data::position_advances, thread_kind_to_receipt};
 
 const ROOM: &str = "!room:example.com";
 const USER: &str = "@user:example.com";
@@ -122,6 +122,12 @@ fn position_advance_matrix() {
 	assert!(!position_advances(normal(1), backfilled(-1)), "backfilled sorts below normal");
 }
 
+#[test]
+fn invalid_thread_kind_is_rejected() {
+	thread_kind_to_receipt("not-an-event-id")
+		.expect_err("invalid private receipt thread must fail");
+}
+
 /// MSC3771 per-thread `m.read.private` storage. `roomuserid_privateread`
 /// stores the unthreaded marker as a 2-tuple `(room, user)` (legacy shape,
 /// unchanged) and per-thread markers as 3-tuple `(room, user, kind)` rows.
@@ -145,9 +151,11 @@ mod private_read {
 	#[test]
 	fn legacy_2tuple_and_3tuple_are_byte_distinct() {
 		let legacy = legacy_2tuple();
+		let unthreaded = thread_3tuple("");
 		let main = thread_3tuple("main");
 		let thread = thread_3tuple(THREAD_ROOT);
 
+		assert_ne!(legacy, unthreaded);
 		assert_ne!(legacy, main);
 		assert_ne!(legacy, thread);
 		assert_eq!(&main[..legacy.len()], &*legacy);
@@ -172,6 +180,7 @@ mod private_read {
 	fn interfix_prefix_includes_thread_rows() {
 		let prefix = thread_prefix();
 
+		assert!(thread_3tuple("").starts_with(&prefix));
 		assert!(thread_3tuple("main").starts_with(&prefix));
 		assert!(thread_3tuple(THREAD_ROOT).starts_with(&prefix));
 	}

--- a/src/service/rooms/state/mod.rs
+++ b/src/service/rooms/state/mod.rs
@@ -33,6 +33,7 @@ use tuwunel_database::{Deserialized, Ignore, Interfix, Map, Txn};
 use crate::{
 	rooms::{
 		short::{ShortEventId, ShortStateHash, ShortStateKey},
+		state_cache::MembershipUpdate,
 		state_compressor::{CompressedState, parse_compressed_state_event},
 		state_res::{StateMap, auth_types_for_event},
 	},
@@ -136,16 +137,16 @@ pub async fn force_state(
 				let count = self.services.globals.next_count();
 				self.services
 					.state_cache
-					.update_membership(
+					.update_membership(MembershipUpdate {
 						room_id,
-						&user_id,
+						user_id: &user_id,
 						membership_event,
-						&pdu.sender,
-						None,
-						None,
-						false,
-						PduCount::Normal(*count),
-					)
+						sender: &pdu.sender,
+						last_state: None,
+						invite_via: None,
+						update_joined_count: false,
+						count: PduCount::Normal(*count),
+					})
 					.await
 			},
 			| _ => Ok(()),

--- a/src/service/rooms/state_cache/mod.rs
+++ b/src/service/rooms/state_cache/mod.rs
@@ -26,6 +26,7 @@ use tuwunel_core::{
 	warn,
 };
 use tuwunel_database::{Deserialized, Ignore, Interfix, Map};
+pub use update::{MembershipUpdate, StrippedRoomState};
 
 use crate::appservice::RegistrationInfo;
 

--- a/src/service/rooms/state_cache/update.rs
+++ b/src/service/rooms/state_cache/update.rs
@@ -15,7 +15,58 @@ use ruma::{
 	serde::Raw,
 };
 use tuwunel_core::{Result, implement, is_not_empty, matrix::PduCount, utils::ReadyExt, warn};
-use tuwunel_database::{Json, serialize_key};
+use tuwunel_database::{Json, serialize_key, serialize_val};
+
+/// Optional stripped room state attached to invite and knock transitions.
+pub type StrippedRoomState = Option<Vec<Raw<AnyStrippedStateEvent>>>;
+
+/// Parameters for one membership cache transition.
+///
+/// Borrowed identifiers remain valid only for the duration of the update. Owned
+/// event data is consumed by the selected transition.
+pub struct MembershipUpdate<'a> {
+	/// Room whose membership changed.
+	///
+	/// Membership indexes and aggregate counts are updated for this room.
+	pub room_id: &'a RoomId,
+
+	/// User whose membership changed.
+	///
+	/// Both local and remote users are represented in the membership indexes.
+	pub user_id: &'a UserId,
+
+	/// Membership event content driving the transition.
+	///
+	/// The membership state selects which indexes are written and cleared.
+	pub membership_event: RoomMemberEventContent,
+
+	/// User who sent the membership event.
+	///
+	/// Invite handling uses the sender when applying the ignored-user policy.
+	pub sender: &'a UserId,
+
+	/// Stripped room state associated with an invite or knock.
+	///
+	/// Other membership transitions leave this value unused.
+	pub last_state: StrippedRoomState,
+
+	/// Servers supplied as routing hints for an invite.
+	///
+	/// Invite handling stores non-empty lists after committing the membership
+	/// indexes.
+	pub invite_via: Option<Vec<OwnedServerName>>,
+
+	/// Whether to rebuild the room's aggregate membership counts.
+	///
+	/// Bulk state updates can defer this rebuild until all transitions are
+	/// applied.
+	pub update_joined_count: bool,
+
+	/// Stream position associated with the membership event.
+	///
+	/// Count-indexed membership rows store its unsigned representation.
+	pub count: PduCount,
+}
 
 /// Update current membership data.
 #[implement(super::Service)]
@@ -30,105 +81,28 @@ use tuwunel_database::{Json, serialize_key};
 			?membership_event,
 		),
 	)]
-#[expect(clippy::too_many_arguments)]
 pub async fn update_membership(
 	&self,
-	room_id: &RoomId,
-	user_id: &UserId,
-	membership_event: RoomMemberEventContent,
-	sender: &UserId,
-	last_state: Option<Vec<Raw<AnyStrippedStateEvent>>>,
-	invite_via: Option<Vec<OwnedServerName>>,
-	update_joined_count: bool,
-	count: PduCount,
+	MembershipUpdate {
+		room_id,
+		user_id,
+		membership_event,
+		sender,
+		last_state,
+		invite_via,
+		update_joined_count,
+		count,
+	}: MembershipUpdate<'_>,
 ) -> Result {
 	let membership = membership_event.membership;
 
-	// Keep track what remote users exist by adding them as "deactivated" users
-	//
-	// TODO: use futures to update remote profiles without blocking the membership
-	// update
-	#[expect(clippy::collapsible_if)]
-	if !self.services.globals.user_is_local(user_id) {
-		if !self.services.users.exists(user_id).await {
-			self.services
-				.users
-				.create(user_id, None, None)
-				.await?;
-		}
-	}
+	self.ensure_remote_user(user_id).await?;
 
-	match &membership {
+	match membership {
 		| MembershipState::Join => {
-			// Check if the user never joined this room
-			if !self.once_joined(user_id, room_id).await {
-				// Add the user ID to the join list then
-				self.mark_as_once_joined(user_id, room_id);
-
-				// Check if the room has a predecessor
-				if let Ok(Some(predecessor)) = self
-					.services
-					.state_accessor
-					.room_state_get_content(room_id, &StateEventType::RoomCreate, "")
-					.await
-					.map(|content: RoomCreateEventContent| content.predecessor)
-				{
-					// Copy old tags to new room
-					if let Ok(tag_event) = self
-						.services
-						.account_data
-						.get_room(&predecessor.room_id, user_id, RoomAccountDataEventType::Tag)
-						.await
-					{
-						self.services
-							.account_data
-							.update(
-								Some(room_id),
-								user_id,
-								RoomAccountDataEventType::Tag,
-								&tag_event,
-							)
-							.await
-							.ok();
-					}
-
-					// Copy direct chat flag
-					if let Ok(mut direct_event) = self
-						.services
-						.account_data
-						.get_global::<DirectEvent>(user_id, GlobalAccountDataEventType::Direct)
-						.await
-					{
-						let mut room_ids_updated = false;
-						for room_ids in direct_event.content.0.values_mut() {
-							if room_ids.iter().any(|r| r == &predecessor.room_id) {
-								room_ids.push(room_id.to_owned());
-								room_ids_updated = true;
-							}
-						}
-
-						if room_ids_updated {
-							self.services
-								.account_data
-								.update(
-									None,
-									user_id,
-									GlobalAccountDataEventType::Direct
-										.to_string()
-										.into(),
-									&serde_json::to_value(&direct_event)
-										.expect("to json always works"),
-								)
-								.await?;
-						}
-					}
-				}
-			}
-
-			self.mark_as_joined(user_id, room_id, count);
+			self.handle_join(room_id, user_id, count).await?;
 		},
 		| MembershipState::Invite => {
-			// We want to know if the sender is ignored by the receiver
 			if self
 				.services
 				.users
@@ -142,15 +116,7 @@ pub async fn update_membership(
 				.await;
 		},
 		| MembershipState::Leave | MembershipState::Ban => {
-			self.mark_as_left(user_id, room_id, count);
-
-			if self.services.globals.user_is_local(user_id)
-				&& (self.services.config.forget_forced_upon_leave
-					|| self.services.metadata.is_banned(room_id).await
-					|| self.services.metadata.is_disabled(room_id).await)
-			{
-				self.forget(room_id, user_id);
-			}
+			self.handle_leave(room_id, user_id, count).await;
 		},
 		| MembershipState::Knock => {
 			self.mark_as_knocked(user_id, room_id, count, last_state);
@@ -196,15 +162,14 @@ pub async fn update_joined_count(&self, room_id: &RoomId) {
 			.unwrap_or(0),
 	);
 
-	self.db
-		.roomid_joinedcount
-		.raw_put(room_id, joinedcount);
-	self.db
-		.roomid_invitedcount
-		.raw_put(room_id, invitedcount);
-	self.db
-		.roomid_knockedcount
-		.raw_put(room_id, knockedcount);
+	let joinedcount = joinedcount.to_be_bytes();
+	let invitedcount = invitedcount.to_be_bytes();
+	let knockedcount = knockedcount.to_be_bytes();
+	let mut txn = self.services.db.txn();
+
+	txn.insert_raw(&self.db.roomid_joinedcount, room_id, joinedcount);
+	txn.insert_raw(&self.db.roomid_invitedcount, room_id, invitedcount);
+	txn.insert_raw(&self.db.roomid_knockedcount, room_id, knockedcount);
 
 	self.room_servers(room_id)
 		.ready_for_each(|old_joined_server| {
@@ -216,8 +181,8 @@ pub async fn update_joined_count(&self, room_id: &RoomId) {
 			let roomserver_id = (room_id, old_joined_server);
 			let serverroom_id = (old_joined_server, room_id);
 
-			self.db.roomserverids.del(roomserver_id);
-			self.db.serverroomids.del(serverroom_id);
+			txn.del(&self.db.roomserverids, roomserver_id);
+			txn.del(&self.db.serverroomids, serverroom_id);
 		})
 		.await;
 
@@ -225,10 +190,17 @@ pub async fn update_joined_count(&self, room_id: &RoomId) {
 	for server in &joined_servers {
 		let roomserver_id = (room_id, server);
 		let serverroom_id = (server, room_id);
+		let roomserver_id =
+			serialize_key(roomserver_id).expect("failed to serialize roomserver_id");
 
-		self.db.roomserverids.put_raw(roomserver_id, []);
-		self.db.serverroomids.put_raw(serverroom_id, []);
+		let serverroom_id =
+			serialize_key(serverroom_id).expect("failed to serialize serverroom_id");
+
+		txn.insert_raw(&self.db.roomserverids, roomserver_id, []);
+		txn.insert_raw(&self.db.serverroomids, serverroom_id, []);
 	}
+
+	txn.execute();
 
 	self.appservice_in_room_cache
 		.write()
@@ -248,29 +220,18 @@ pub(crate) fn mark_as_joined(&self, user_id: &UserId, room_id: &RoomId, count: P
 	let roomuser_id = (room_id, user_id);
 	let roomuser_id = serialize_key(roomuser_id).expect("failed to serialize roomuser_id");
 
-	self.db
-		.userroomid_joinedcount
-		.raw_aput::<8, _, _>(&userroom_id, count.into_unsigned());
-	self.db
-		.roomuserid_joinedcount
-		.raw_aput::<8, _, _>(&roomuser_id, count.into_unsigned());
+	let count = count.into_unsigned().to_be_bytes();
+	let mut txn = self.services.db.txn();
 
-	self.db
-		.userroomid_invitestate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_invitecount
-		.remove(&roomuser_id);
-
-	self.db.userroomid_leftstate.remove(&userroom_id);
-	self.db.roomuserid_leftcount.remove(&roomuser_id);
-
-	self.db
-		.userroomid_knockedstate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_knockedcount
-		.remove(&roomuser_id);
+	txn.insert_raw(&self.db.userroomid_joinedcount, &userroom_id, count);
+	txn.insert_raw(&self.db.roomuserid_joinedcount, &roomuser_id, count);
+	txn.del_raw(&self.db.userroomid_invitestate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_invitecount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_leftstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_leftcount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_knockedstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_knockedcount, &roomuser_id);
+	txn.execute();
 }
 
 /// Direct DB function to directly mark a user as left. It is not
@@ -285,36 +246,21 @@ pub(crate) fn mark_as_left(&self, user_id: &UserId, room_id: &RoomId, count: Pdu
 	let roomuser_id = (room_id, user_id);
 	let roomuser_id = serialize_key(roomuser_id).expect("failed to serialize roomuser_id");
 
-	// (timo) TODO
-	let leftstate = Vec::<Raw<AnySyncStateEvent>>::new();
+	let leftstate = serialize_val(Json(Vec::<Raw<AnySyncStateEvent>>::new()))
+		.expect("failed to serialize left state");
 
-	self.db
-		.userroomid_leftstate
-		.raw_put(&userroom_id, Json(leftstate));
-	self.db
-		.roomuserid_leftcount
-		.raw_aput::<8, _, _>(&roomuser_id, count.into_unsigned());
+	let count = count.into_unsigned().to_be_bytes();
+	let mut txn = self.services.db.txn();
 
-	self.db
-		.userroomid_joinedcount
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_joinedcount
-		.remove(&roomuser_id);
-
-	self.db
-		.userroomid_invitestate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_invitecount
-		.remove(&roomuser_id);
-
-	self.db
-		.userroomid_knockedstate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_knockedcount
-		.remove(&roomuser_id);
+	txn.insert_raw(&self.db.userroomid_leftstate, &userroom_id, leftstate);
+	txn.insert_raw(&self.db.roomuserid_leftcount, &roomuser_id, count);
+	txn.del_raw(&self.db.userroomid_joinedcount, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_joinedcount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_invitestate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_invitecount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_knockedstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_knockedcount, &roomuser_id);
+	txn.execute();
 }
 
 /// Direct DB function to directly mark a user as knocked. It is not
@@ -327,7 +273,7 @@ pub(crate) fn mark_as_knocked(
 	user_id: &UserId,
 	room_id: &RoomId,
 	count: PduCount,
-	knocked_state: Option<Vec<Raw<AnyStrippedStateEvent>>>,
+	knocked_state: StrippedRoomState,
 ) {
 	let userroom_id = (user_id, room_id);
 	let userroom_id = serialize_key(userroom_id).expect("failed to serialize userroom_id");
@@ -335,29 +281,21 @@ pub(crate) fn mark_as_knocked(
 	let roomuser_id = (room_id, user_id);
 	let roomuser_id = serialize_key(roomuser_id).expect("failed to serialize roomuser_id");
 
-	self.db
-		.userroomid_knockedstate
-		.raw_put(&userroom_id, Json(knocked_state.unwrap_or_default()));
-	self.db
-		.roomuserid_knockedcount
-		.raw_aput::<8, _, _>(&roomuser_id, count.into_unsigned());
+	let knocked_state = serialize_val(Json(knocked_state.unwrap_or_default()))
+		.expect("failed to serialize knocked state");
 
-	self.db
-		.userroomid_joinedcount
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_joinedcount
-		.remove(&roomuser_id);
+	let count = count.into_unsigned().to_be_bytes();
+	let mut txn = self.services.db.txn();
 
-	self.db
-		.userroomid_invitestate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_invitecount
-		.remove(&roomuser_id);
-
-	self.db.userroomid_leftstate.remove(&userroom_id);
-	self.db.roomuserid_leftcount.remove(&roomuser_id);
+	txn.insert_raw(&self.db.userroomid_knockedstate, &userroom_id, knocked_state);
+	txn.insert_raw(&self.db.roomuserid_knockedcount, &roomuser_id, count);
+	txn.del_raw(&self.db.userroomid_joinedcount, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_joinedcount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_invitestate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_invitecount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_leftstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_leftcount, &roomuser_id);
+	txn.execute();
 }
 
 /// Makes a user forget a room.
@@ -366,16 +304,22 @@ pub(crate) fn mark_as_knocked(
 pub fn forget(&self, room_id: &RoomId, user_id: &UserId) {
 	let userroom_id = (user_id, room_id);
 	let roomuser_id = (room_id, user_id);
+	let mut txn = self.services.db.txn();
 
-	self.db.userroomid_leftstate.del(userroom_id);
-	self.db.roomuserid_leftcount.del(roomuser_id);
+	txn.del(&self.db.userroomid_leftstate, userroom_id);
+	txn.del(&self.db.roomuserid_leftcount, roomuser_id);
+	txn.execute();
 }
 
 #[implement(super::Service)]
 #[tracing::instrument(level = "debug", skip(self))]
 fn mark_as_once_joined(&self, user_id: &UserId, room_id: &RoomId) {
 	let key = (user_id, room_id);
-	self.db.roomuseroncejoinedids.put_raw(key, []);
+	let key = serialize_key(key).expect("failed to serialize roomuseroncejoinedid");
+	let mut txn = self.services.db.txn();
+
+	txn.insert_raw(&self.db.roomuseroncejoinedids, key, []);
+	txn.execute();
 }
 
 #[implement(super::Service)]
@@ -385,41 +329,163 @@ pub(crate) async fn mark_as_invited(
 	user_id: &UserId,
 	room_id: &RoomId,
 	count: PduCount,
-	last_state: Option<Vec<Raw<AnyStrippedStateEvent>>>,
+	last_state: StrippedRoomState,
 	invite_via: Option<Vec<OwnedServerName>>,
 ) {
-	let roomuser_id = (room_id, user_id);
-	let roomuser_id = serialize_key(roomuser_id).expect("failed to serialize roomuser_id");
-
 	let userroom_id = (user_id, room_id);
 	let userroom_id = serialize_key(userroom_id).expect("failed to serialize userroom_id");
 
-	self.db
-		.userroomid_invitestate
-		.raw_put(&userroom_id, Json(last_state.unwrap_or_default()));
-	self.db
-		.roomuserid_invitecount
-		.raw_aput::<8, _, _>(&roomuser_id, count.into_unsigned());
+	let roomuser_id = (room_id, user_id);
+	let roomuser_id = serialize_key(roomuser_id).expect("failed to serialize roomuser_id");
 
-	self.db
-		.userroomid_joinedcount
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_joinedcount
-		.remove(&roomuser_id);
+	let invite_state = serialize_val(Json(last_state.unwrap_or_default()))
+		.expect("failed to serialize invite state");
 
-	self.db.userroomid_leftstate.remove(&userroom_id);
-	self.db.roomuserid_leftcount.remove(&roomuser_id);
+	let count = count.into_unsigned().to_be_bytes();
+	let mut txn = self.services.db.txn();
 
-	self.db
-		.userroomid_knockedstate
-		.remove(&userroom_id);
-	self.db
-		.roomuserid_knockedcount
-		.remove(&roomuser_id);
+	txn.insert_raw(&self.db.userroomid_invitestate, &userroom_id, invite_state);
+	txn.insert_raw(&self.db.roomuserid_invitecount, &roomuser_id, count);
+	txn.del_raw(&self.db.userroomid_joinedcount, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_joinedcount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_leftstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_leftcount, &roomuser_id);
+	txn.del_raw(&self.db.userroomid_knockedstate, &userroom_id);
+	txn.del_raw(&self.db.roomuserid_knockedcount, &roomuser_id);
+	txn.execute();
 
 	if let Some(servers) = invite_via.filter(is_not_empty!()) {
 		self.add_servers_invite_via(room_id, servers)
 			.await;
+	}
+}
+
+#[implement(super::Service)]
+#[tracing::instrument(skip(self), level = "debug")]
+async fn ensure_remote_user(&self, user_id: &UserId) -> Result {
+	if self.services.globals.user_is_local(user_id) || self.services.users.exists(user_id).await {
+		return Ok(());
+	}
+
+	self.services
+		.users
+		.create(user_id, None, None)
+		.await
+}
+
+#[implement(super::Service)]
+async fn handle_join(&self, room_id: &RoomId, user_id: &UserId, count: PduCount) -> Result {
+	if !self.once_joined(user_id, room_id).await {
+		self.mark_as_once_joined(user_id, room_id);
+		self.copy_predecessor_data(room_id, user_id)
+			.await?;
+	}
+
+	self.mark_as_joined(user_id, room_id, count);
+
+	Ok(())
+}
+
+#[implement(super::Service)]
+async fn copy_predecessor_data(&self, room_id: &RoomId, user_id: &UserId) -> Result {
+	let predecessor = self
+		.services
+		.state_accessor
+		.room_state_get_content(room_id, &StateEventType::RoomCreate, "")
+		.await
+		.map(|content: RoomCreateEventContent| content.predecessor);
+
+	let Ok(Some(predecessor)) = predecessor else {
+		return Ok(());
+	};
+
+	self.copy_predecessor_tags(room_id, user_id, &predecessor.room_id)
+		.await;
+
+	self.copy_predecessor_direct(room_id, user_id, &predecessor.room_id)
+		.await
+}
+
+#[implement(super::Service)]
+#[tracing::instrument(skip(self), level = "debug")]
+async fn copy_predecessor_tags(&self, room_id: &RoomId, user_id: &UserId, predecessor: &RoomId) {
+	let Ok(tag_event) = self
+		.services
+		.account_data
+		.get_room(predecessor, user_id, RoomAccountDataEventType::Tag)
+		.await
+	else {
+		return;
+	};
+
+	self.services
+		.account_data
+		.update(Some(room_id), user_id, RoomAccountDataEventType::Tag, &tag_event)
+		.await
+		.ok();
+}
+
+#[implement(super::Service)]
+#[tracing::instrument(skip(self), level = "debug")]
+async fn copy_predecessor_direct(
+	&self,
+	room_id: &RoomId,
+	user_id: &UserId,
+	predecessor: &RoomId,
+) -> Result {
+	let Ok(mut direct_event) = self
+		.services
+		.account_data
+		.get_global::<DirectEvent>(user_id, GlobalAccountDataEventType::Direct)
+		.await
+	else {
+		return Ok(());
+	};
+
+	let room_ids_updated =
+		direct_event
+			.content
+			.0
+			.values_mut()
+			.fold(false, |updated, room_ids| {
+				if !room_ids
+					.iter()
+					.any(|direct_room_id| direct_room_id == predecessor)
+				{
+					return updated;
+				}
+
+				room_ids.push(room_id.to_owned());
+
+				true
+			});
+
+	if !room_ids_updated {
+		return Ok(());
+	}
+
+	let event_type = GlobalAccountDataEventType::Direct
+		.to_string()
+		.into();
+
+	let direct_event = serde_json::to_value(&direct_event).expect("to json always works");
+
+	self.services
+		.account_data
+		.update(None, user_id, event_type, &direct_event)
+		.await
+}
+
+#[implement(super::Service)]
+#[tracing::instrument(skip(self), level = "debug")]
+async fn handle_leave(&self, room_id: &RoomId, user_id: &UserId, count: PduCount) {
+	self.mark_as_left(user_id, room_id, count);
+
+	if self.services.globals.user_is_local(user_id)
+		&& (self.services.config.forget_forced_upon_leave
+			|| self.services.metadata.is_banned(room_id).await
+			|| self.services.metadata.is_disabled(room_id).await)
+	{
+		self.forget(room_id, user_id);
 	}
 }

--- a/src/service/rooms/timeline/append.rs
+++ b/src/service/rooms/timeline/append.rs
@@ -27,7 +27,7 @@ use tuwunel_database::Json;
 use super::{ExtractBody, ExtractRelatesTo, ExtractRelatesToEventId, RoomMutexGuard, bias_count};
 use crate::rooms::{
 	read_receipt::PrivateRead, short::ShortRoomId, state_accessor::plain_text_topic,
-	state_compressor::CompressedState,
+	state_cache::MembershipUpdate, state_compressor::CompressedState,
 };
 
 type Band<'a> = SmallVec<[&'a EventId; 1]>;
@@ -297,16 +297,16 @@ async fn append_pdu_effects(
 				// knock event for auth
 				self.services
 					.state_cache
-					.update_membership(
-						pdu.room_id(),
-						&target_user_id,
-						content,
-						pdu.sender(),
-						stripped_state,
-						None,
-						true,
+					.update_membership(MembershipUpdate {
+						room_id: pdu.room_id(),
+						user_id: &target_user_id,
+						membership_event: content,
+						sender: pdu.sender(),
+						last_state: stripped_state,
+						invite_via: None,
+						update_joined_count: true,
 						count,
-					)
+					})
 					.await?;
 			}
 		},

--- a/src/service/rooms/typing/mod.rs
+++ b/src/service/rooms/typing/mod.rs
@@ -1,20 +1,23 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use futures::{FutureExt, StreamExt, TryStreamExt, future::try_join};
+use futures::{FutureExt, TryStreamExt, future::try_join};
 use ruma::{
 	OwnedRoomId, OwnedUserId, RoomId, UserId,
 	api::{
 		appservice::event::push_events::v1::EphemeralData,
 		federation::transactions::edu::{Edu, TypingContent},
 	},
-	events::{EphemeralRoomEvent, typing::TypingEventContent},
+	events::{
+		EphemeralRoomEvent, GlobalAccountDataEventType, ignored_user_list::IgnoredUserListEvent,
+		typing::TypingEventContent,
+	},
 };
 use tokio::sync::{RwLock, broadcast};
 use tuwunel_core::{
 	Result, Server,
 	debug::INFO_SPAN_LEVEL,
 	debug_info, trace,
-	utils::{self, BoolExt, IterStream},
+	utils::{BoolExt, IterStream, millis_since_unix_epoch},
 };
 
 use crate::sending::EduBuf;
@@ -22,11 +25,17 @@ use crate::sending::EduBuf;
 pub struct Service {
 	server: Arc<Server>,
 	services: Arc<crate::services::OnceServices>,
-	/// u64 is unix timestamp of timeout
-	pub typing: RwLock<BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, u64>>>,
-	/// timestamp of the last change to typing users
-	pub last_typing_update: RwLock<BTreeMap<OwnedRoomId, u64>>,
+	typing: RwLock<BTreeMap<OwnedRoomId, RoomTyping>>,
 	pub typing_update_sender: broadcast::Sender<OwnedRoomId>,
+}
+
+#[derive(Default)]
+struct RoomTyping {
+	// Unix epoch millisecond timestamp when each typing indicator expires.
+	users: BTreeMap<OwnedUserId, u64>,
+	// Global stream position of the last change to this room. The count permit must
+	// retire only after releasing the typing state lock.
+	update: u64,
 }
 
 impl crate::Service for Service {
@@ -35,7 +44,6 @@ impl crate::Service for Service {
 			server: args.server.clone(),
 			services: args.services.clone(),
 			typing: RwLock::new(BTreeMap::new()),
-			last_typing_update: RwLock::new(BTreeMap::new()),
 			typing_update_sender: broadcast::channel(100).0,
 		}))
 	}
@@ -60,20 +68,15 @@ impl Service {
 		debug_info!("typing started {user_id:?} in {room_id:?} timeout:{timeout:?}");
 
 		// update clients
-		self.typing
-			.write()
-			.await
-			.entry(room_id.to_owned())
-			.or_default()
-			.insert(user_id.to_owned(), timeout);
+		let mut typing = self.typing.write().await;
+		let room = typing.entry(room_id.to_owned()).or_default();
+		room.users.insert(user_id.to_owned(), timeout);
 
 		let count = self.services.globals.next_count();
 
-		self.last_typing_update
-			.write()
-			.await
-			.insert(room_id.to_owned(), *count);
+		room.update = *count;
 
+		drop(typing);
 		drop(count);
 
 		if self
@@ -114,20 +117,15 @@ impl Service {
 		debug_info!("typing stopped {user_id:?} in {room_id:?}");
 
 		// update clients
-		self.typing
-			.write()
-			.await
-			.entry(room_id.to_owned())
-			.or_default()
-			.remove(user_id);
+		let mut typing = self.typing.write().await;
+		let room = typing.entry(room_id.to_owned()).or_default();
+		room.users.remove(user_id);
 
 		let count = self.services.globals.next_count();
 
-		self.last_typing_update
-			.write()
-			.await
-			.insert(room_id.to_owned(), *count);
+		room.update = *count;
 
+		drop(typing);
 		drop(count);
 
 		if self
@@ -165,43 +163,51 @@ impl Service {
 
 	/// Makes sure that typing events with old timestamps get removed.
 	async fn typings_maintain(&self, room_id: &RoomId) -> Result {
-		let current_timestamp = utils::millis_since_unix_epoch();
-		let mut removable = Vec::new();
-
+		let current_timestamp = millis_since_unix_epoch();
 		let typing = self.typing.read().await;
-		let Some(room) = typing.get(room_id) else {
+		let has_expired = typing.get(room_id).is_some_and(|room| {
+			room.users
+				.values()
+				.any(|timeout| *timeout < current_timestamp)
+		});
+
+		drop(typing);
+
+		if !has_expired {
+			return Ok(());
+		}
+
+		let current_timestamp = millis_since_unix_epoch();
+		let mut removable = Vec::new();
+		let mut typing = self.typing.write().await;
+		let Some(room) = typing.get_mut(room_id) else {
 			return Ok(());
 		};
 
-		for (user, timeout) in room {
-			if *timeout < current_timestamp {
+		room.users.retain(|user, timeout| {
+			let expired = *timeout < current_timestamp;
+			if expired {
 				removable.push(user.clone());
 			}
-		}
 
-		drop(typing);
+			expired.is_false()
+		});
 
 		if removable.is_empty() {
 			return Ok(());
 		}
 
-		let mut typing = self.typing.write().await;
-		let room = typing.entry(room_id.to_owned()).or_default();
-		for user in &removable {
-			debug_info!("typing timeout {user:?} in {room_id:?}");
-			room.remove(user);
-		}
-
-		drop(typing);
-
 		// update clients
 		let count = self.services.globals.next_count();
-		self.last_typing_update
-			.write()
-			.await
-			.insert(room_id.to_owned(), *count);
 
+		room.update = *count;
+
+		drop(typing);
 		drop(count);
+
+		for user in &removable {
+			debug_info!("typing timeout {user:?} in {room_id:?}");
+		}
 
 		if self
 			.typing_update_sender
@@ -231,26 +237,25 @@ impl Service {
 	pub async fn last_typing_update(&self, room_id: &RoomId) -> Result<u64> {
 		self.typings_maintain(room_id).await?;
 
-		self.last_typing_update
+		self.typing
 			.read()
 			.await
 			.get(room_id)
-			.copied()
+			.map(|room| room.update)
 			.map(Ok)
 			.unwrap_or(Ok(0))
 	}
 
 	/// Returns the typing content with all typing users in the room.
 	async fn typings_content(&self, room_id: &RoomId) -> TypingEventContent {
-		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
+		let typing = self.typing.read().await;
+		let user_ids = typing
+			.get(room_id)
+			.into_iter()
+			.flat_map(|room| room.users.keys().cloned())
+			.collect();
 
-		let Some(typing_indicators) = room_typing_indicators else {
-			return TypingEventContent { user_ids: Vec::new() };
-		};
-
-		TypingEventContent {
-			user_ids: typing_indicators.into_keys().collect(),
-		}
+		TypingEventContent { user_ids }
 	}
 
 	/// Sends a typing EDU to all appservices interested in the room.
@@ -276,27 +281,84 @@ impl Service {
 		room_id: &RoomId,
 		sender_user: &UserId,
 	) -> Result<Vec<OwnedUserId>> {
-		let room_typing_indicators = self.typing.read().await.get(room_id).cloned();
+		let typing = self.typing.read().await;
+		let user_ids = typing
+			.get(room_id)
+			.into_iter()
+			.flat_map(|room| room.users.keys().cloned())
+			.collect();
+		drop(typing);
 
-		let Some(typing_indicators) = room_typing_indicators else {
-			return Ok(Vec::new());
-		};
+		Ok(self
+			.filter_typing_users(user_ids, sender_user)
+			.await)
+	}
 
-		let user_ids: Vec<_> = typing_indicators
-			.into_keys()
-			.stream()
-			.filter_map(async |typing_user_id| {
-				self.services
-					.users
-					.user_is_ignored(&typing_user_id, sender_user)
-					.await
-					.eq(&false)
-					.then_some(typing_user_id)
-			})
-			.collect()
+	/// Returns one coherent typing update token and visible user snapshot.
+	///
+	/// The predicate checks the token under the same lock and can skip cloning
+	/// stale users. Selected user IDs are captured before ignored users are
+	/// filtered after releasing the lock.
+	pub async fn typing_snapshot_for_user<Select>(
+		&self,
+		room_id: &RoomId,
+		sender_user: &UserId,
+		select: Select,
+	) -> Result<Option<(u64, Vec<OwnedUserId>)>>
+	where
+		Select: FnOnce(u64) -> bool + Send,
+	{
+		self.typings_maintain(room_id).await?;
+
+		let typing = self.typing.read().await;
+		let room = typing.get(room_id);
+		let update = room.map_or(0, |room| room.update);
+
+		if !select(update) {
+			return Ok(None);
+		}
+
+		let user_ids = room
+			.into_iter()
+			.flat_map(|room| room.users.keys().cloned())
+			.collect();
+
+		drop(typing);
+
+		let user_ids = self
+			.filter_typing_users(user_ids, sender_user)
 			.await;
 
-		Ok(user_ids)
+		Ok(Some((update, user_ids)))
+	}
+
+	async fn filter_typing_users(
+		&self,
+		user_ids: Vec<OwnedUserId>,
+		sender_user: &UserId,
+	) -> Vec<OwnedUserId> {
+		if user_ids.is_empty() {
+			return user_ids;
+		}
+
+		let ignored: Option<IgnoredUserListEvent> = self
+			.services
+			.account_data
+			.get_global(sender_user, GlobalAccountDataEventType::IgnoredUserList)
+			.await
+			.ok();
+
+		user_ids
+			.into_iter()
+			.filter(|user_id| {
+				ignored.as_ref().is_none_or(|ignored| {
+					!ignored
+						.content
+						.ignored_users
+						.contains_key::<UserId>(user_id.as_ref())
+				})
+			})
+			.collect()
 	}
 
 	async fn federation_send(&self, room_id: &RoomId, user_id: &UserId, typing: bool) -> Result {

--- a/src/service/sync/mod.rs
+++ b/src/service/sync/mod.rs
@@ -258,21 +258,27 @@ pub fn update_rooms_prologue(&mut self, retard_since: Option<u64>) {
 	});
 }
 
-/// Advance the per-room cursor for each room delivered in a response.
+/// Advance the per-room cursor for each complete bounded room range.
 ///
-/// `roomsince` is the lower bound of every content query for its room, so
-/// only rooms whose payload was returned may advance. A failed or dropped
-/// room keeps its cursor and replays the same range in a later response.
+/// `roomsince` is the lower bound of every content query for its room. Only
+/// rooms whose complete range was safely assembled may advance. A failed room
+/// keeps its cursor and retries the same range after a later wake.
 #[implement(Connection)]
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn update_rooms_epilogue<'a, Delivered>(&mut self, delivered: Delivered)
+pub fn update_rooms_epilogue<'a, Complete>(&mut self, complete: Complete)
 where
-	Delivered: Iterator<Item = &'a RoomId> + Send + 'a,
+	Complete: Iterator<Item = &'a RoomId> + Send + 'a,
 {
-	delivered.for_each(|room_id| {
-		let room = self.rooms.entry(room_id.into()).or_default();
-
-		room.roomsince = self.next_batch;
+	let next_batch = self.next_batch;
+	complete.for_each(|room_id| {
+		if let Some(room) = self.rooms.get_mut(room_id) {
+			room.roomsince = next_batch;
+		} else {
+			self.rooms
+				.entry(room_id.into())
+				.or_default()
+				.roomsince = next_batch;
+		}
 	});
 }
 

--- a/src/service/sync/mod.rs
+++ b/src/service/sync/mod.rs
@@ -258,13 +258,18 @@ pub fn update_rooms_prologue(&mut self, retard_since: Option<u64>) {
 	});
 }
 
+/// Advance the per-room cursor for each room delivered in a response.
+///
+/// `roomsince` is the lower bound of every content query for its room, so
+/// only rooms whose payload was returned may advance. A failed or dropped
+/// room keeps its cursor and replays the same range in a later response.
 #[implement(Connection)]
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn update_rooms_epilogue<'a, Rooms>(&mut self, window: Rooms)
+pub fn update_rooms_epilogue<'a, Delivered>(&mut self, delivered: Delivered)
 where
-	Rooms: Iterator<Item = &'a RoomId> + Send + 'a,
+	Delivered: Iterator<Item = &'a RoomId> + Send + 'a,
 {
-	window.for_each(|room_id| {
+	delivered.for_each(|room_id| {
 		let room = self.rooms.entry(room_id.into()).or_default();
 
 		room.roomsince = self.next_batch;

--- a/src/service/sync/tests.rs
+++ b/src/service/sync/tests.rs
@@ -130,6 +130,19 @@ fn epilogue_tracks_a_first_complete_range() {
 	assert_eq!(conn.rooms[complete].roomsince, 7);
 }
 
+#[test]
+fn prologue_rewinds_a_complete_range_for_replay() {
+	let room_id = room_id!("!replay:example.com");
+	let mut conn = Connection {
+		rooms: [(room_id.to_owned(), Room { roomsince: 9 })].into(),
+		..Default::default()
+	};
+
+	conn.update_rooms_prologue(Some(5));
+
+	assert_eq!(conn.rooms[room_id].roomsince, 5);
+}
+
 fn request_with_list(list: List) -> Request {
 	let mut request = Request::new();
 

--- a/src/service/sync/tests.rs
+++ b/src/service/sync/tests.rs
@@ -1,3 +1,5 @@
+use std::iter::once;
+
 use ruma::{
 	UInt,
 	api::client::sync::sync_events::v5::{
@@ -6,9 +8,10 @@ use ruma::{
 	},
 	directory::RoomTypeFilter,
 	events::StateEventType,
+	room_id,
 };
 
-use super::Connection;
+use super::{Connection, Room};
 
 const LIST_ID: &str = "main";
 
@@ -95,6 +98,36 @@ fn update_cache_keeps_filters_when_omitted() {
 	let filters = cached_filters(&conn);
 
 	assert_eq!(filters.not_room_types, vec![RoomTypeFilter::Space]);
+}
+
+#[test]
+fn epilogue_advances_only_delivered_rooms() {
+	let delivered = room_id!("!a:example.com");
+	let undelivered = room_id!("!b:example.com");
+	let mut conn = Connection {
+		next_batch: 5,
+		rooms: [
+			(delivered.to_owned(), Room { roomsince: 3 }),
+			(undelivered.to_owned(), Room { roomsince: 3 }),
+		]
+		.into(),
+		..Default::default()
+	};
+
+	conn.update_rooms_epilogue(once(delivered));
+
+	assert_eq!(conn.rooms[delivered].roomsince, 5);
+	assert_eq!(conn.rooms[undelivered].roomsince, 3);
+}
+
+#[test]
+fn epilogue_tracks_a_first_delivered_room() {
+	let delivered = room_id!("!new:example.com");
+	let mut conn = Connection { next_batch: 7, ..Default::default() };
+
+	conn.update_rooms_epilogue(once(delivered));
+
+	assert_eq!(conn.rooms[delivered].roomsince, 7);
 }
 
 fn request_with_list(list: List) -> Request {

--- a/src/service/sync/tests.rs
+++ b/src/service/sync/tests.rs
@@ -101,33 +101,33 @@ fn update_cache_keeps_filters_when_omitted() {
 }
 
 #[test]
-fn epilogue_advances_only_delivered_rooms() {
-	let delivered = room_id!("!a:example.com");
-	let undelivered = room_id!("!b:example.com");
+fn epilogue_advances_only_complete_ranges() {
+	let complete = room_id!("!a:example.com");
+	let incomplete = room_id!("!b:example.com");
 	let mut conn = Connection {
 		next_batch: 5,
 		rooms: [
-			(delivered.to_owned(), Room { roomsince: 3 }),
-			(undelivered.to_owned(), Room { roomsince: 3 }),
+			(complete.to_owned(), Room { roomsince: 3 }),
+			(incomplete.to_owned(), Room { roomsince: 3 }),
 		]
 		.into(),
 		..Default::default()
 	};
 
-	conn.update_rooms_epilogue(once(delivered));
+	conn.update_rooms_epilogue(once(complete));
 
-	assert_eq!(conn.rooms[delivered].roomsince, 5);
-	assert_eq!(conn.rooms[undelivered].roomsince, 3);
+	assert_eq!(conn.rooms[complete].roomsince, 5);
+	assert_eq!(conn.rooms[incomplete].roomsince, 3);
 }
 
 #[test]
-fn epilogue_tracks_a_first_delivered_room() {
-	let delivered = room_id!("!new:example.com");
+fn epilogue_tracks_a_first_complete_range() {
+	let complete = room_id!("!new:example.com");
 	let mut conn = Connection { next_batch: 7, ..Default::default() };
 
-	conn.update_rooms_epilogue(once(delivered));
+	conn.update_rooms_epilogue(once(complete));
 
-	assert_eq!(conn.rooms[delivered].roomsince, 7);
+	assert_eq!(conn.rooms[complete].roomsince, 7);
 }
 
 fn request_with_list(list: List) -> Request {

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1058,7 +1058,11 @@
 #
 #default_power_level_content_override = { users_default = 50 }
 
-# This item is undocumented. Please contribute documentation for it.
+# Enables OTLP span export for Jaeger-compatible tracing.
+#
+# A build with performance measurements installs an OpenTelemetry layer
+# when this is enabled. It defaults to false, and `jaeger_filter` selects
+# the exported spans.
 #
 #allow_jaeger = false
 
@@ -1656,7 +1660,10 @@
 #
 #rocksdb_log_level = "error"
 
-# This item is undocumented. Please contribute documentation for it.
+# Routes RocksDB log messages to standard error.
+#
+# `rocksdb_log_level` still filters the emitted records. When disabled,
+# RocksDB uses the application's callback logger instead.
 #
 #rocksdb_log_stderr = false
 
@@ -1831,11 +1838,17 @@
 #
 #rocksdb_repair = false
 
-# This item is undocumented. Please contribute documentation for it.
+# Opens RocksDB in read-only mode.
+#
+# Writes are rejected and missing column families cannot be created. This
+# mode is disabled by default.
 #
 #rocksdb_read_only = false
 
-# This item is undocumented. Please contribute documentation for it.
+# Opens RocksDB as a secondary follower of a primary instance.
+#
+# Writes are rejected while the primary's latest WAL can be replayed into
+# this instance's view. Missing column families cannot be created.
 #
 #rocksdb_secondary = false
 
@@ -3109,7 +3122,10 @@
 #
 #key =
 
-# Whether to listen and allow for HTTP and HTTPS connections (insecure!)
+# Controls whether listeners accept both HTTP and HTTPS.
+#
+# Plain requests are served without redirecting them to HTTPS. This
+# weakens transport security and is disabled by default.
 #
 #dual_protocol = false
 

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -162,39 +162,92 @@
 #
 #db_write_buffer_capacity_mb = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache shared by the
+# `pduid_pdu` and `eventid_outlierpdu` column families: a PDU's full
+# body, keyed by its PDU ID, and the same body keyed by event ID when
+# the PDU is an outlier.
+#
+# This is an entry count, not a byte size. The cache's actual capacity
+# in bytes is this value multiplied by an internal per-column-family
+# key+value size estimate, then multiplied by `cache_capacity_modifier`.
+#
+# Scaled by your CPU core count by default; see
+# `cache_capacity_modifier` to scale this along with the other
+# individual LRU caches at once.
 #
 #pdu_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache shared by the
+# `shorteventid_authchain` and `authchainkey_authchain` column
+# families: a room event's full auth chain, keyed by its short event ID
+# or by the auth chain's own key.
+#
+# Same entry-count semantics as `pdu_cache_capacity` above; see there
+# for how this becomes a byte capacity and how
+# `cache_capacity_modifier` applies.
 #
 #auth_chain_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `shorteventid_eventid` column family: an event's full event ID,
+# looked up from its short event ID.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #shorteventid_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `eventid_shorteventid` column family: an event's short event ID,
+# looked up from its full event ID. The reverse lookup of
+# `shorteventid_cache_capacity`.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #eventidshort_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `eventid_pduid` column family: an event's PDU ID, looked up from its
+# full event ID.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #eventid_pdu_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `shortstatekey_statekey` column family: a state event's full state
+# key, looked up from its short state key.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #shortstatekey_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `statekey_shortstatekey` column family: a state event's short state
+# key, looked up from its full state key. The reverse lookup of
+# `shortstatekey_cache_capacity`.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #statekeyshort_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the RocksDB block cache for the
+# `servernameevent_data` column family: outbound federation events
+# (PDUs and EDUs) queued for delivery, keyed by destination server
+# name.
+#
+# Same entry-count semantics as `pdu_cache_capacity`.
 #
 #servernameevent_data_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of entries in the in-memory LRU cache of decompressed
+# room state (a list of short state-info entries per state hash), used
+# by the state compressor to avoid re-walking
+# `shortstatehash_statediff` on every lookup.
+#
+# Unlike the other caches on this page, this one is not backed by
+# RocksDB: it is a plain in-process cache sized directly in entries,
+# with no per-entry byte-size conversion. `cache_capacity_modifier`
+# still applies to it.
 #
 #stateinfo_cache_capacity = varies by system
 


### PR DESCRIPTION
Nine cache capacity fields in `Config` (`pdu_cache_capacity`,
`auth_chain_cache_capacity`, `shorteventid_cache_capacity`,
`eventidshort_cache_capacity`, `eventid_pdu_cache_capacity`,
`shortstatekey_cache_capacity`, `statekeyshort_cache_capacity`,
`servernameevent_data_cache_capacity`, `stateinfo_cache_capacity`) only
carried `/// default: varies by system`, so `tuwunel-example.toml` renders
them as "This item is undocumented. Please contribute documentation for
it." Their neighbors `db_cache_capacity_mb` / `db_write_buffer_capacity_mb`
already explain what they're for; these nine didn't say anything.

I ran into this chasing an unrelated RAM report on my own homeserver and
ended up reading `cf_opts.rs` and `state_compressor/mod.rs` to find out
what each one actually sizes, since the fields alone don't say. This PR
writes that up: which RocksDB column family (or pair of column families)
each of the eight RocksDB-backed fields is bound to, what that column
family holds, and that the values are entry counts rather than byte
sizes -- the real cache size is entries times an internal per-column-family
key+value size hint, then `cache_capacity_modifier`, and neither of those
multipliers is something the operator sets directly. `stateinfo_cache_capacity`
turned out to be the odd one out: a plain in-process `LruCache`, no RocksDB
underneath it at all, sized straight in entries.

Docs only -- no `default: N` line changed, so `documented_defaults_match_the_code`
doesn't need updating.