### PR TITLE
log/journald: gate the unix datagram socket to unix

### DIFF
--- a/src/core/log/journald.rs
+++ b/src/core/log/journald.rs
@@ -3,13 +3,14 @@
 //! The module routes formatted messages to the journal socket and records
 //! structured tracing fields for journal queries.
 
+#[cfg(unix)]
+use std::os::unix::net::UnixDatagram;
 use std::{
 	cell::RefCell,
 	env::args_os,
 	ffi::OsStr,
 	fmt::Debug,
 	io::{self, Write, stderr},
-	os::unix::net::UnixDatagram,
 	path::Path,
 };
 
@@ -25,6 +26,8 @@ use tracing_subscriber::{
 	registry::LookupSpan,
 };
 
+#[cfg(not(unix))]
+use self::unsupported::UnixDatagram;
 use super::is_systemd_mode;
 use crate::{
 	Config, Result,
@@ -40,6 +43,34 @@ use crate::{
 
 #[cfg(test)]
 mod tests;
+
+/// The journald submission socket is a unix datagram socket, which targets
+/// outside the unix family do not have. This module is compiled everywhere, so
+/// rather than a `#[cfg]` on each of the six items that mention a socket, those
+/// targets get one that cannot be opened.
+///
+/// Nothing constructs it: `enabled()` requires `is_systemd_mode()`, which tests
+/// `SYSTEMD_EXEC_PID` and `JOURNAL_STREAM`, so it is false wherever systemd is
+/// absent. These exist to keep the type checker honest, and they report failure
+/// rather than pretend to succeed.
+#[cfg(not(unix))]
+mod unsupported {
+	use std::io::{Error, ErrorKind::Unsupported, Result};
+
+	pub(super) struct UnixDatagram;
+
+	impl UnixDatagram {
+		pub(super) fn unbound() -> Result<Self> { Err(unavailable()) }
+
+		pub(super) fn send_to(&self, _payload: &[u8], _path: &str) -> Result<usize> {
+			Err(unavailable())
+		}
+	}
+
+	fn unavailable() -> Error {
+		Error::new(Unsupported, "journald requires unix datagram sockets")
+	}
+}
 
 /// Encoded journal fields; a longer run spills to the heap.
 type Buffer = SmallVec<[u8; 128]>;

--- a/src/core/log/journald.rs
+++ b/src/core/log/journald.rs
@@ -44,31 +44,27 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-/// The journald submission socket is a unix datagram socket, which targets
-/// outside the unix family do not have. This module is compiled everywhere, so
-/// rather than a `#[cfg]` on each of the six items that mention a socket, those
-/// targets get one that cannot be opened.
+/// Stand-in for the journald socket on targets outside the unix family.
 ///
-/// Nothing constructs it: `enabled()` requires `is_systemd_mode()`, which tests
-/// `SYSTEMD_EXEC_PID` and `JOURNAL_STREAM`, so it is false wherever systemd is
-/// absent. These exist to keep the type checker honest, and they report failure
-/// rather than pretend to succeed.
+/// Nothing constructs it, since `enabled()` is always false without systemd.
 #[cfg(not(unix))]
 mod unsupported {
-	use std::io::{Error, ErrorKind::Unsupported, Result};
+	use std::io;
+
+	use super::implement;
 
 	pub(super) struct UnixDatagram;
 
-	impl UnixDatagram {
-		pub(super) fn unbound() -> Result<Self> { Err(unavailable()) }
+	#[implement(UnixDatagram)]
+	pub(super) fn unbound() -> io::Result<Self> { Err(unavailable()) }
 
-		pub(super) fn send_to(&self, _payload: &[u8], _path: &str) -> Result<usize> {
-			Err(unavailable())
-		}
+	#[implement(UnixDatagram)]
+	pub(super) fn send_to(&self, _payload: &[u8], _path: &str) -> io::Result<usize> {
+		Err(unavailable())
 	}
 
-	fn unavailable() -> Error {
-		Error::new(Unsupported, "journald requires unix datagram sockets")
+	fn unavailable() -> io::Error {
+		io::Error::new(io::ErrorKind::Unsupported, "journald requires unix datagram sockets")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

`src/core/log/mod.rs` declares `pub mod journald;` with no condition, and the module
opens the journal through `std::os::unix::net::UnixDatagram`, so since #534 landed the
native journald submission `tuwunel_core` does not resolve on a non-unix target:

```
error[E0433]: cannot find `unix` in `os`
 --> src/core/log/journald.rs:7:6
  |
7 |     os::unix::net::UnixDatagram,
  |         ^^^^ could not find `unix` in `os`
```

Gating the module declaration is not available here. `console.rs` calls
`journald::enabled` from `ansi_enabled`, and `main/logging.rs` names
`journald::Fields`, both unconditionally, so the module has to exist on every target.

Six items mention the socket — the import, the `Journal::socket` field, `open`, `new`,
`send` and the `SOCKET` constant — and conditioning each one orphans the others
(`identifier()` loses its only caller, `SOCKET` its only readers). Instead a non-unix
stand-in supplies the two methods those items use:

```rust
#[cfg(not(unix))]
mod unsupported {
	use std::io::{Error, ErrorKind::Unsupported, Result};

	pub(super) struct UnixDatagram;

	impl UnixDatagram {
		pub(super) fn unbound() -> Result<Self> { Err(unavailable()) }

		pub(super) fn send_to(&self, _payload: &[u8], _path: &str) -> Result<usize> {
			Err(unavailable())
		}
	}

	fn unavailable() -> Error {
		Error::new(Unsupported, "journald requires unix datagram sockets")
	}
}
```

One added block; every other item in the file is untouched.

**Nothing constructs it, which is checkable rather than hopeful.** `enabled()` is
`config.log_journald && is_systemd_mode()`, and `is_systemd_mode()` tests
`SYSTEMD_EXEC_PID` and `JOURNAL_STREAM`. Both are absent without systemd, so
`Journal::open` returns `None` and `Journal::new` is never called. The stand-in reports
failure rather than pretending to succeed, so if that reasoning is ever wrong it says so
through the existing `writeln!(stderr(), …)` in `open`.

No behaviour change on unix. Same class of fix as #526, #527, #528 and #536.

**On verification.** CI builds Linux only, where none of this appears, so CI cannot
demonstrate the change: the symptom is absent there both before and after. It was
observed building v1.8.3 for `x86_64-pc-windows-msvc`, and `os::unix` being absent off
unix needs no reproduction beyond the target. `cargo +nightly fmt --check`, `cargo check`
and `cargo clippy` on the unix path are clean before and after.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; no runtime path is touched
      on unix.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
