### PR TITLE
sys/storage: gate the sysfs device discovery to unix

### DIFF
--- a/src/core/utils/sys/storage.rs
+++ b/src/core/utils/sys/storage.rs
@@ -5,9 +5,9 @@
 //! properties.
 //!
 //! Discovery reads sysfs under `/sys/dev/block/` and stats the device through
-//! `MetadataExt`, neither of which exists outside the unix family. Non-unix
-//! targets get arms that report nothing found, so callers need no condition of
-//! their own.
+//! `MetadataExt`, neither of which exists outside the unix family. On
+//! non-unix targets these functions report no raid or return an unsupported
+//! error, so callers need no condition of their own.
 
 use std::path::Path;
 #[cfg(unix)]
@@ -114,8 +114,8 @@ pub fn md_discover(path: &Path) -> MultiDevice {
 
 /// Get properties of a MultiDevice (md) storage system.
 ///
-/// Reports no raid on a target without sysfs, which is what the unix arm also
-/// returns for a path that is not on one.
+/// Reports no raid, since discovery needs sysfs, which this platform does
+/// not have.
 #[cfg(not(unix))]
 #[must_use]
 pub fn md_discover(_path: &Path) -> MultiDevice { MultiDevice::default() }
@@ -205,8 +205,8 @@ pub fn name_from_path(path: &Path) -> Result<String> {
 
 /// Get the name of the block device on which Path is mounted.
 ///
-/// Naming the device requires sysfs, so this reports the target cannot do it.
-/// The unix arm already returns an error when the name is not there to be read.
+/// Naming the device requires sysfs, so this always returns an unsupported
+/// error.
 #[cfg(not(unix))]
 pub fn name_from_path(_path: &Path) -> Result<String> {
 	use std::io::{Error, ErrorKind::Unsupported};

--- a/src/core/utils/sys/storage.rs
+++ b/src/core/utils/sys/storage.rs
@@ -3,19 +3,29 @@
 //! The helpers inspect filesystem metadata and system block-device information.
 //! Discovery covers backing device names, software RAID, and multi-queue
 //! properties.
+//!
+//! Discovery reads sysfs under `/sys/dev/block/` and stats the device through
+//! `MetadataExt`, neither of which exists outside the unix family. Non-unix
+//! targets get arms that report nothing found, so callers need no condition of
+//! their own.
 
+use std::path::Path;
+#[cfg(unix)]
 use std::{
 	ffi::OsStr,
 	fs,
 	fs::{FileType, read_to_string},
-	path::{Path, PathBuf},
+	path::PathBuf,
 };
 
+#[cfg(unix)]
 use itertools::Itertools;
+#[cfg(unix)]
 use libc::dev_t;
 
+use crate::Result;
+#[cfg(unix)]
 use crate::{
-	Result,
 	result::FlatOk,
 	utils::{result::LogDebugErr, string::SplitInfallible},
 };
@@ -57,6 +67,7 @@ pub struct Queue {
 }
 
 /// Get properties of a MultiDevice (md) storage system
+#[cfg(unix)]
 #[must_use]
 pub fn md_discover(path: &Path) -> MultiDevice {
 	let dev_id = dev_from_path(path)
@@ -101,7 +112,16 @@ pub fn md_discover(path: &Path) -> MultiDevice {
 	}
 }
 
+/// Get properties of a MultiDevice (md) storage system.
+///
+/// Reports no raid on a target without sysfs, which is what the unix arm also
+/// returns for a path that is not on one.
+#[cfg(not(unix))]
+#[must_use]
+pub fn md_discover(_path: &Path) -> MultiDevice { MultiDevice::default() }
+
 /// Get properties of a MultiQueue within a MultiDevice.
+#[cfg(unix)]
 #[must_use]
 fn mq_discover(path: &Path) -> MultiQueue {
 	let mq_path = path.join("mq/");
@@ -133,6 +153,7 @@ fn mq_discover(path: &Path) -> MultiQueue {
 }
 
 /// Get properties of a Queue within a MultiQueue.
+#[cfg(unix)]
 fn queue_discover(dir: &Path) -> Queue {
 	let queue_id = dir.file_name();
 
@@ -165,6 +186,7 @@ fn queue_discover(dir: &Path) -> Queue {
 }
 
 /// Get the name of the block device on which Path is mounted.
+#[cfg(unix)]
 pub fn name_from_path(path: &Path) -> Result<String> {
 	use std::io::{Error, ErrorKind::NotFound};
 
@@ -181,9 +203,20 @@ pub fn name_from_path(path: &Path) -> Result<String> {
 		.map(Into::into)
 }
 
+/// Get the name of the block device on which Path is mounted.
+///
+/// Naming the device requires sysfs, so this reports the target cannot do it.
+/// The unix arm already returns an error when the name is not there to be read.
+#[cfg(not(unix))]
+pub fn name_from_path(_path: &Path) -> Result<String> {
+	use std::io::{Error, ErrorKind::Unsupported};
+
+	Err(Error::new(Unsupported, "Block device discovery requires sysfs.").into())
+}
+
 /// Get the (major, minor) of the block device on which Path is mounted.
+#[cfg(unix)]
 fn dev_from_path(path: &Path) -> Result<(dev_t, dev_t)> {
-	#[cfg(target_family = "unix")]
 	use std::os::unix::fs::MetadataExt;
 
 	let stat = fs::metadata(path)?;
@@ -214,6 +247,7 @@ fn dev_from_path(path: &Path) -> Result<(dev_t, dev_t)> {
 	Ok((major, minor))
 }
 
+#[cfg(unix)]
 fn block_path((major, minor): (dev_t, dev_t)) -> PathBuf {
 	format!("/sys/dev/block/{major}:{minor}/").into()
 }


### PR DESCRIPTION
### What does this PR do?

`sys/storage.rs` walks `/sys/dev/block/` and reaches the device through
`MetadataExt::dev` and `libc::major`/`libc::minor`, none of which exists off unix, so
`tuwunel_core` does not compile there:

```
error[E0599]: no method named `dev` found for struct `Metadata` in the current scope
error[E0425]: cannot find function `major` in crate `libc`
error[E0425]: cannot find function `minor` in crate `libc`
```

`dev_from_path` already carries `#[cfg(target_family = "unix")]` on its `MetadataExt`
import — which is what makes the method go missing rather than the import fail — but the
three call sites below it were never gated to match. This puts the whole discovery path
behind the same condition, so that attribute becomes redundant and goes with it.

`md_discover` and `name_from_path` are the two entry points, both called unconditionally
from `database/pool/configure.rs`, so each gains a `#[cfg(not(unix))]` arm rather than
pushing a condition onto the caller:

```rust
/// Get properties of a MultiDevice (md) storage system.
///
/// Reports no raid on a target without sysfs, which is what the unix arm also
/// returns for a path that is not on one.
#[cfg(not(unix))]
#[must_use]
pub fn md_discover(_path: &Path) -> MultiDevice { MultiDevice::default() }
```

```rust
/// Get the name of the block device on which Path is mounted.
///
/// Naming the device requires sysfs, so this reports the target cannot do it.
/// The unix arm already returns an error when the name is not there to be read.
#[cfg(not(unix))]
pub fn name_from_path(_path: &Path) -> Result<String> {
	use std::io::{Error, ErrorKind::Unsupported};

	Err(Error::new(Unsupported, "Block device discovery requires sysfs.").into())
}
```

Both mirror an outcome the unix arm already produces: `md_discover` returns the same
empty `MultiDevice` it returns for a path that is not on a raid, and `name_from_path`
already returns `NotFound` when `DEVNAME` is not there to be read, so
`configure.rs` handles an error from it today.

`mq_discover`, `queue_discover`, `dev_from_path` and `block_path` are private and
reachable only from the gated entry points, so they need no second arm. `itertools` and
`libc::dev_t` do resolve off unix but are used only by the gated items, so they follow
the same condition; `Path` and `Result` are used by both arms and stay ungated.

The module comment is rewritten to say which facility is missing rather than which
platform is running, since the condition is `unix`, not any one target.

No behaviour change on unix. Same class of fix as #526, #527, #528 and #536.

**On verification.** CI builds Linux only, where none of this appears, so CI cannot
demonstrate the change: the symptom is absent there both before and after. It was
observed building v1.8.3 for `x86_64-pc-windows-msvc`, and the three errors above are
reproducible on any host with a two-file crate that depends on `libc` and calls
`stat.dev()`, `libc::major` and `libc::minor` behind the same
`#[cfg(target_family = "unix")]` import this file has. `cargo +nightly fmt --check`,
`cargo check` and `cargo clippy` on the unix path are clean before and after.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above. — none; the unix path is unchanged.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed. — n/a
- [x] User-facing changes are reflected in `docs/`. — n/a
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.