### PR TITLE
impl: recursive rocksdb multi get

### DIFF
--- a/src/database/map.rs
+++ b/src/database/map.rs
@@ -47,7 +47,10 @@ use self::watch::Watch;
 ///
 /// `Get` accepts raw keys, while `Qry` serializes structured keys before
 /// lookup. Both yield pinned value handles through an asynchronous stream.
-pub use self::{get_batch::Get, qry_batch::Qry};
+pub use self::{
+	get_batch::{Get, RecursiveGetOutput},
+	qry_batch::Qry,
+};
 use crate::{Engine, util::map_err};
 
 /// Provides typed and raw access to one RocksDB column family.

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -189,6 +189,8 @@ where
 	let map = self.clone();
 
 	tokio::task::spawn_blocking(move || {
+		const SORTED: bool = true;
+
 		map.engine.ctx.server.check_running()?;
 
 		let snapshot = map.engine.db.snapshot();
@@ -208,14 +210,12 @@ where
 		let mut depth: usize = 0;
 		let mut truncated = false;
 
-		const SORTED: bool = true;
-
 		while !current_batch.is_empty() {
-			if let Some(max_d) = max_depth {
-				if depth >= max_d {
-					truncated = true;
-					break;
-				}
+			if let Some(max_d) = max_depth
+				&& depth >= max_d
+			{
+				truncated = true;
+				break;
 			}
 
 			// Sort keys for optimal sequential RocksDB multi-get access
@@ -237,11 +237,11 @@ where
 						extract_children(&parsed_value, &mut next_batch);
 						values.push(parsed_value);
 
-						if let Some(max_n) = max_nodes {
-							if values.len() >= max_n {
-								truncated = true;
-								break;
-							}
+						if let Some(max_n) = max_nodes
+							&& values.len() >= max_n
+						{
+							truncated = true;
+							break;
 						}
 					},
 					| Ok(None) => {

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -189,7 +189,7 @@ where
 	let map = self.clone();
 
 	tokio::task::spawn_blocking(move || {
-		const SORTED: bool = false;
+		const SORTED: bool = true;
 
 		map.engine.ctx.server.check_running()?;
 
@@ -219,7 +219,12 @@ where
 			}
 
 			// Sort keys for optimal sequential RocksDB multi-get access
-			current_batch.sort_unstable();
+			current_batch.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+
+			if max_nodes.is_some_and(|max_n| values.len() >= max_n) {
+				truncated = true;
+				break;
+			}
 
 			let db_results = map.engine.db.batched_multi_get_cf_opt(
 				&map.cf(),
@@ -237,9 +242,7 @@ where
 						extract_children(&parsed_value, &mut next_batch);
 						values.push(parsed_value);
 
-						if let Some(max_n) = max_nodes
-							&& values.len() >= max_n
-						{
+						if max_nodes.is_some_and(|max_n| values.len() >= max_n) {
 							truncated = true;
 							break;
 						}

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, hash::Hash, sync::Arc};
 
 use futures::{Stream, StreamExt, TryStreamExt};
 use rocksdb::{DBPinnableSlice, ReadOptions};
@@ -11,7 +11,7 @@ use tuwunel_core::{
 };
 
 use super::get::{cached_handle_from, handle_from};
-use crate::Handle;
+use crate::{Handle, util::map_err};
 
 /// Extends a stream of raw keys with batched map lookup.
 ///
@@ -134,4 +134,82 @@ where
 		.db
 		.batched_multi_get_cf_opt(&self.cf(), keys, SORTED, read_options)
 		.into_iter()
+}
+
+/// Performs a recursive breadth-first traversal over database keys.
+///
+/// Starting from `roots`, each batch of keys is fetched in RocksDB using
+/// `batched_multi_get_cf_opt`. Returned values are parsed by `parse_value`,
+/// and any child keys returned by `extract_children` are queued for the next
+/// level of traversal.
+///
+/// # Errors
+///
+/// Fails fast on any underlying RocksDB I/O or block corruption error.
+#[implement(super::Map)]
+#[tracing::instrument(skip_all, level = "trace")]
+pub async fn recursive_multi_get<K, V, P, F, I>(
+	self: &Arc<Self>,
+	roots: I,
+	parse_value: P,
+	extract_children: F,
+) -> Result<Vec<V>>
+where
+	K: AsRef<[u8]> + Eq + Hash + Clone + Send + Sync + 'static,
+	V: Send + 'static,
+	P: Fn(&[u8]) -> V + Send + Sync + 'static,
+	F: Fn(&V) -> Vec<K> + Send + Sync + 'static,
+	I: IntoIterator<Item = K>,
+{
+	let map = self.clone();
+	let mut current_batch: Vec<K> = roots.into_iter().collect();
+
+	tokio::task::spawn_blocking(move || {
+		let mut results = Vec::new();
+		let mut visited = HashSet::new();
+
+		for root in &current_batch {
+			visited.insert(root.clone());
+		}
+
+		while !current_batch.is_empty() {
+			const SORTED: bool = false;
+			let db_results = map.engine.db.batched_multi_get_cf_opt(
+				&map.cf(),
+				current_batch.iter(),
+				SORTED,
+				&map.read_options,
+			);
+
+			let mut next_batch = Vec::with_capacity(current_batch.len() * 2);
+
+			for result in db_results {
+				match result {
+					| Ok(Some(slice)) => {
+						let parsed_value = parse_value(slice.as_ref());
+						let children = extract_children(&parsed_value);
+
+						results.push(parsed_value);
+
+						for child in children {
+							if visited.insert(child.clone()) {
+								next_batch.push(child);
+							}
+						}
+					},
+					| Ok(None) => {},
+					| Err(e) => {
+						tracing::error!(%e, "RocksDB multi-get failure during recursive DAG traversal");
+						return Err(map_err(e));
+					},
+				}
+			}
+
+			current_batch = next_batch;
+		}
+
+		Ok(results)
+	})
+	.await
+	.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
 }

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -181,7 +181,7 @@ where
 				&map.read_options,
 			);
 
-			let mut next_batch = Vec::with_capacity(current_batch.len() * 2);
+			let mut next_batch = Vec::with_capacity(current_batch.len().saturating_mul(2));
 
 			for result in db_results {
 				match result {
@@ -211,5 +211,5 @@ where
 		Ok(results)
 	})
 	.await
-	.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+	.map_err(std::io::Error::other)?
 }

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -189,7 +189,7 @@ where
 	let map = self.clone();
 
 	tokio::task::spawn_blocking(move || {
-		const SORTED: bool = true;
+		const SORTED: bool = false;
 
 		map.engine.ctx.server.check_running()?;
 

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -136,80 +136,151 @@ where
 		.into_iter()
 }
 
+/// Result container for recursive multi-get DAG traversals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecursiveGetOutput<V, K> {
+	/// Values successfully fetched and parsed during traversal.
+	pub values: Vec<V>,
+
+	/// Keys requested during traversal that were missing from the database.
+	pub missing: Vec<K>,
+
+	/// Indicates whether the traversal stopped early due to node or depth caps.
+	pub truncated: bool,
+}
+
 /// Performs a recursive breadth-first traversal over database keys.
 ///
 /// Starting from `roots`, each batch of keys is fetched in RocksDB using
-/// `batched_multi_get_cf_opt`. Returned values are parsed by `parse_value`,
-/// and any child keys returned by `extract_children` are queued for the next
-/// level of traversal.
+/// `batched_multi_get_cf_opt` against a point-in-time snapshot. Returned values
+/// are parsed by `parse_value`, and any child keys appended to the sink buffer
+/// by `extract_children` are queued for the next level of traversal.
+///
+/// # Traversal Ordering
+/// Results are ordered level-by-level (BFS order). Within a single level,
+/// results reflect key sorting order. Note that this is **not** a topological
+/// sort.
+///
+/// # Bounds & Limits
+/// Traversal halts early if `max_nodes` (total parsed values) or `max_depth`
+/// (BFS depth iterations) is reached, marking `truncated = true` on the
+/// returned output.
 ///
 /// # Errors
-///
-/// Fails fast on any underlying RocksDB I/O or block corruption error.
+/// Fails fast on server shutdown, key parsing failure, RocksDB I/O errors, or
+/// block corruption.
 #[implement(super::Map)]
 #[tracing::instrument(skip_all, level = "trace")]
 pub async fn recursive_multi_get<K, V, P, F, I>(
 	self: &Arc<Self>,
 	roots: I,
+	max_nodes: Option<usize>,
+	max_depth: Option<usize>,
 	parse_value: P,
 	extract_children: F,
-) -> Result<Vec<V>>
+) -> Result<RecursiveGetOutput<V, K>>
 where
-	K: AsRef<[u8]> + Eq + Hash + Clone + Send + Sync + 'static,
+	K: AsRef<[u8]> + Ord + Hash + Clone + Send + Sync + 'static,
 	V: Send + 'static,
-	P: Fn(&[u8]) -> V + Send + Sync + 'static,
-	F: Fn(&V) -> Vec<K> + Send + Sync + 'static,
-	I: IntoIterator<Item = K>,
+	P: Fn(&[u8]) -> Result<V> + Send + Sync + 'static,
+	F: Fn(&V, &mut Vec<K>) + Send + Sync + 'static,
+	I: IntoIterator<Item = K> + Send + 'static,
 {
 	let map = self.clone();
-	let mut current_batch: Vec<K> = roots.into_iter().collect();
 
 	tokio::task::spawn_blocking(move || {
-		let mut results = Vec::new();
-		let mut visited = HashSet::new();
+		map.engine.ctx.server.check_running()?;
 
-		for root in &current_batch {
-			visited.insert(root.clone());
+		let snapshot = map.engine.db.snapshot();
+		let mut read_options = super::options::read_options_default(&map.engine);
+		read_options.set_snapshot(&snapshot);
+
+		let mut visited = HashSet::new();
+		let mut current_batch = Vec::new();
+		for root in roots {
+			if visited.insert(root.clone()) {
+				current_batch.push(root);
+			}
 		}
 
+		let mut values = Vec::new();
+		let mut missing = Vec::new();
+		let mut depth: usize = 0;
+		let mut truncated = false;
+
+		const SORTED: bool = true;
+
 		while !current_batch.is_empty() {
-			const SORTED: bool = false;
+			if let Some(max_d) = max_depth {
+				if depth >= max_d {
+					truncated = true;
+					break;
+				}
+			}
+
+			// Sort keys for optimal sequential RocksDB multi-get access
+			current_batch.sort_unstable();
+
 			let db_results = map.engine.db.batched_multi_get_cf_opt(
 				&map.cf(),
 				current_batch.iter(),
 				SORTED,
-				&map.read_options,
+				&read_options,
 			);
 
 			let mut next_batch = Vec::with_capacity(current_batch.len().saturating_mul(2));
 
-			for result in db_results {
+			for (key, result) in current_batch.into_iter().zip(db_results) {
 				match result {
 					| Ok(Some(slice)) => {
-						let parsed_value = parse_value(slice.as_ref());
-						let children = extract_children(&parsed_value);
+						let parsed_value = parse_value(slice.as_ref())?;
+						extract_children(&parsed_value, &mut next_batch);
+						values.push(parsed_value);
 
-						results.push(parsed_value);
-
-						for child in children {
-							if visited.insert(child.clone()) {
-								next_batch.push(child);
+						if let Some(max_n) = max_nodes {
+							if values.len() >= max_n {
+								truncated = true;
+								break;
 							}
 						}
 					},
-					| Ok(None) => {},
+					| Ok(None) => {
+						missing.push(key);
+					},
 					| Err(e) => {
-						tracing::error!(%e, "RocksDB multi-get failure during recursive DAG traversal");
+						tracing::error!(
+							key = ?key.as_ref(),
+							%e,
+							"RocksDB multi-get failure during recursive DAG traversal"
+						);
 						return Err(map_err(e));
 					},
 				}
 			}
 
+			// Filter out already visited keys from next_batch while preserving order
+			next_batch.retain(|child| visited.insert(child.clone()));
+
+			depth = depth.saturating_add(1);
+
+			if truncated {
+				break;
+			}
+
 			current_batch = next_batch;
+
+			map.engine.ctx.server.check_running()?;
 		}
 
-		Ok(results)
+		Ok(RecursiveGetOutput { values, missing, truncated })
 	})
 	.await
-	.map_err(std::io::Error::other)?
+	.map_err(|e| {
+		if e.is_panic() {
+			tracing::error!("blocking task panicked during recursive_multi_get");
+			std::io::Error::other("recursive_multi_get task panicked")
+		} else {
+			std::io::Error::other("recursive_multi_get task cancelled")
+		}
+	})?
 }

--- a/src/database/map/get_batch.rs
+++ b/src/database/map/get_batch.rs
@@ -237,16 +237,18 @@ where
 
 			for (key, result) in current_batch.into_iter().zip(db_results) {
 				match result {
-					| Ok(Some(slice)) => {
-						let parsed_value = parse_value(slice.as_ref())?;
-						extract_children(&parsed_value, &mut next_batch);
-						values.push(parsed_value);
+					| Ok(Some(slice)) =>
+						if max_nodes.is_none_or(|max_n| values.len() < max_n) {
+							let parsed_value = parse_value(slice.as_ref())?;
+							extract_children(&parsed_value, &mut next_batch);
+							values.push(parsed_value);
 
-						if max_nodes.is_some_and(|max_n| values.len() >= max_n) {
+							if max_nodes.is_some_and(|max_n| values.len() >= max_n) {
+								truncated = true;
+							}
+						} else {
 							truncated = true;
-							break;
-						}
-					},
+						},
 					| Ok(None) => {
 						missing.push(key);
 					},

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -40,7 +40,7 @@ pub use self::{
 	engine::Engine,
 	handle::Handle,
 	keyval::{KeyBuf, KeyVal, Slice, serialize_key, serialize_val},
-	map::{Get, Map, Qry, compact},
+	map::{Get, Map, Qry, RecursiveGetOutput, compact},
 	ser::{Cbor, Interfix, Json, SEP, Separator, serialize, serialize_to, serialize_to_vec},
 	txn::Txn,
 };

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1304,3 +1304,100 @@ async fn a_restore_is_not_repeated_on_reopen() -> Result {
 
 	Ok(())
 }
+
+#[tokio::test]
+async fn recursive_multi_get_traversal() -> Result<()> {
+	let root = var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+	let path = format!("{root}/tuwunel-database-recursive-{}", process_id());
+	let raw_config = Figment::new()
+		.merge(("server_name", "localhost"))
+		.merge(("database_path", &path))
+		.merge(("test", ["fresh", "cleanup"]));
+
+	let config = Config::new(&raw_config)?;
+	let runtime = Handle::current();
+	let logging = Logging {
+		subscriber: Arc::new(NoSubscriber::new()),
+		reload: LogLevelReloadHandles::default(),
+		capture: Arc::new(State::new()),
+	};
+
+	let metrics = Metrics::new(Some(&runtime));
+	let server =
+		Arc::new(Server::new(config, Sources::default(), Some(&runtime), logging, metrics));
+
+	let db = Database::open(&server).await?;
+	let map = &db["global"];
+
+	// Insert DAG nodes:
+	// A -> B, C
+	// B -> A (cycle) & D (diamond convergence)
+	// C -> D (diamond convergence) & M (missing)
+	// D -> E
+	map.put(b"node_A", b"node_B,node_C");
+	map.put(b"node_B", b"node_A,node_D");
+	map.put(b"node_C", b"node_D,node_M"); // node_M will be missing
+	map.put(b"node_D", b"node_E");
+	map.put(b"node_E", b"");
+
+	let parse_val = |slice: &[u8]| -> Result<String> {
+		String::from_utf8(slice.to_vec()).map_err(|e| std::io::Error::other(e).into())
+	};
+
+	let extract_children = |val: &String, sink: &mut Vec<Vec<u8>>| {
+		if !val.is_empty() {
+			for part in val.split(',') {
+				sink.push(part.as_bytes().to_vec());
+			}
+		}
+	};
+
+	// Test 1: Full traversal with cycle, diamond, and missing key detection
+	let output = map
+		.recursive_multi_get(
+			vec![b"node_A".to_vec(), b"node_A".to_vec()],
+			None,
+			None,
+			parse_val,
+			extract_children,
+		)
+		.await?;
+
+	assert!(!output.truncated);
+	assert_eq!(output.missing, vec![b"node_M".to_vec()]);
+	assert!(
+		output
+			.values
+			.contains(&"node_B,node_C".to_string())
+	);
+	assert!(
+		output
+			.values
+			.contains(&"node_A,node_D".to_string())
+	);
+	assert!(
+		output
+			.values
+			.contains(&"node_D,node_M".to_string())
+	);
+	assert!(output.values.contains(&"node_E".to_string()));
+	assert!(output.values.contains(&"".to_string()));
+
+	// Test 2: Truncation via max_depth
+	let depth_output = map
+		.recursive_multi_get(vec![b"node_A".to_vec()], None, Some(1), parse_val, extract_children)
+		.await?;
+
+	assert!(depth_output.truncated);
+	assert_eq!(depth_output.values.len(), 1);
+
+	// Test 3: Truncation via max_nodes
+	let node_output = map
+		.recursive_multi_get(vec![b"node_A".to_vec()], Some(2), None, parse_val, extract_children)
+		.await?;
+
+	assert!(node_output.truncated);
+	assert!(node_output.values.len() <= 2);
+
+	Ok(())
+}

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1334,11 +1334,11 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 	// B -> A (cycle) & D (diamond convergence)
 	// C -> D (diamond convergence) & M (missing)
 	// D -> E
-	map.put(b"node_A", b"node_B,node_C");
-	map.put(b"node_B", b"node_A,node_D");
-	map.put(b"node_C", b"node_D,node_M"); // node_M will be missing
-	map.put(b"node_D", b"node_E");
-	map.put(b"node_E", b"");
+	map.insert(b"node_A", b"node_B,node_C");
+	map.insert(b"node_B", b"node_A,node_D");
+	map.insert(b"node_C", b"node_D,node_M"); // node_M will be missing
+	map.insert(b"node_D", b"node_E");
+	map.insert(b"node_E", b"");
 
 	let parse_val = |slice: &[u8]| -> Result<String> {
 		String::from_utf8(slice.to_vec()).map_err(|e| std::io::Error::other(e).into())

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1365,23 +1365,13 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 
 	assert!(!output.truncated);
 	assert_eq!(output.missing, vec![b"node_M".to_vec()]);
-	assert!(
-		output
-			.values
-			.contains(&"node_B,node_C".to_owned())
-	);
-	assert!(
-		output
-			.values
-			.contains(&"node_A,node_D".to_owned())
-	);
-	assert!(
-		output
-			.values
-			.contains(&"node_D,node_M".to_owned())
-	);
-	assert!(output.values.contains(&"node_E".to_owned()));
-	assert!(output.values.contains(&String::new()));
+	assert_eq!(output.values, vec![
+		"node_B,node_C",
+		"node_A,node_D",
+		"node_D,node_M",
+		"node_E",
+		"",
+	]);
 
 	// Test 2: Truncation via max_depth
 	let depth_output = map
@@ -1397,7 +1387,16 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 		.await?;
 
 	assert!(node_output.truncated);
-	assert!(node_output.values.len() <= 2);
+	assert_eq!(node_output.values.len(), 2);
+	assert_eq!(node_output.values, vec!["node_B,node_C", "node_A,node_D"]);
+
+	// Test 4: Truncation via max_nodes = Some(0)
+	let zero_node_output = map
+		.recursive_multi_get(vec![b"node_A".to_vec()], Some(0), None, parse_val, extract_children)
+		.await?;
+
+	assert!(zero_node_output.truncated);
+	assert!(zero_node_output.values.is_empty());
 
 	Ok(())
 }

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1380,6 +1380,7 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 
 	assert!(depth_output.truncated);
 	assert_eq!(depth_output.values.len(), 1);
+	assert_eq!(depth_output.values, vec!["node_B,node_C"]);
 
 	// Test 3: Truncation via max_nodes
 	let node_output = map
@@ -1397,6 +1398,21 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 
 	assert!(zero_node_output.truncated);
 	assert!(zero_node_output.values.is_empty());
+
+	// Test 5: Mid-batch truncation preserves missing key recording and error checks
+	let mid_batch_output = map
+		.recursive_multi_get(
+			vec![b"node_C".to_vec(), b"node_M".to_vec()],
+			Some(1),
+			None,
+			parse_val,
+			extract_children,
+		)
+		.await?;
+
+	assert!(mid_batch_output.truncated);
+	assert_eq!(mid_batch_output.values, vec!["node_D,node_M"]);
+	assert_eq!(mid_batch_output.missing, vec![b"node_M".to_vec()]);
 
 	Ok(())
 }

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1368,20 +1368,20 @@ async fn recursive_multi_get_traversal() -> Result<()> {
 	assert!(
 		output
 			.values
-			.contains(&"node_B,node_C".to_string())
+			.contains(&"node_B,node_C".to_owned())
 	);
 	assert!(
 		output
 			.values
-			.contains(&"node_A,node_D".to_string())
+			.contains(&"node_A,node_D".to_owned())
 	);
 	assert!(
 		output
 			.values
-			.contains(&"node_D,node_M".to_string())
+			.contains(&"node_D,node_M".to_owned())
 	);
-	assert!(output.values.contains(&"node_E".to_string()));
-	assert!(output.values.contains(&"".to_string()));
+	assert!(output.values.contains(&"node_E".to_owned()));
+	assert!(output.values.contains(&String::new()));
 
 	// Test 2: Truncation via max_depth
 	let depth_output = map

--- a/src/service/migrations/injectivity/repair.rs
+++ b/src/service/migrations/injectivity/repair.rs
@@ -218,7 +218,7 @@ async fn patch_statediffs(services: &Services, scan: &Scan) -> Result {
 		.ready_fold(Digests::new(), |mut digests, (key, value)| {
 			let infected = short_of(value)
 				.filter(|state| scan.infected.contains(state))
-				.and_then(|state| key.try_into().ok().map(|digest| (state, digest)));
+				.zip(key.try_into().ok());
 
 			if let Some((state, digest)) = infected {
 				digests.entry(state).or_default().push(digest);


### PR DESCRIPTION
### What does this PR do?

Adds an optimized method which improves the speed of recursive queries (traversing deep forks can sometimes contribute to lag during peak federation hours). Puts an entire recursive query behind a single `tokio::spawnBlocking()` call and batches key lookups in RocksDB's monotonic order (for sequential reads and hot cache locality).

This PR does NOT hook the method up to anything (it's just there for future use). I don't have any explicit benchmark data yet, but it should be quite significant in many workloads.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [ ] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [ ] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Map::recursive_multi_get` for breadth-first DAG traversal over `RocksDB`, returning parsed values, missing keys, and a truncation flag. Improves deep ancestor/fork queries via snapshot reads; not wired to production yet.

- Ordering and bounds: BFS with per-level key sort, root deduplication, and visited tracking; limits via `max_nodes`/`max_depth`. When `max_nodes` is hit mid-batch, the method now consumes the full multi-get batch to record missing keys and surface RocksDB errors without parsing additional values, and sets `truncated = true`.
- Consistency and performance: snapshot-based reads; batched multi-get with `SORTED=true`; pre-allocated child sink; per-level server shutdown checks; fail-fast error mapping via `util::map_err`.
- API and tests: exports `RecursiveGetOutput` from `map.rs` and `database/mod.rs`. Unit tests cover cycles, diamond convergence, missing keys, depth/node truncation, and mid-batch truncation behavior. Migration behavior unchanged (minor `Option::zip` refactor in `service/migrations/injectivity/repair.rs`).

<sup>Written for commit f249ba9009a4b7e1a678896d150cbceba660e996. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gamesguru/tuwunel/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->