### PR TITLE
read_marker: Tolerate backfilled events in private read markers

### DIFF
--- a/src/api/client/read_marker/mod.rs
+++ b/src/api/client/read_marker/mod.rs
@@ -2,7 +2,7 @@ mod read_markers;
 mod receipt;
 
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId, events::receipt::ReceiptThread};
-use tuwunel_core::{Err, PduCount, Result, err, utils::result::LogErr};
+use tuwunel_core::{PduCount, Result, err, utils::result::LogErr};
 use tuwunel_service::{Services, rooms::read_receipt::PrivateRead};
 
 pub(crate) use self::{read_markers::set_read_marker_route, receipt::create_receipt_route};
@@ -11,7 +11,8 @@ pub(crate) use self::{read_markers::set_read_marker_route, receipt::create_recei
 /// marker for `thread` there.
 ///
 /// Returns whether the marker advanced. A backfilled event carries no forward
-/// position, so it is rejected rather than stored.
+/// position, so it is skipped like a non-advancing write rather than failing
+/// the request.
 async fn set_private_marker(
 	services: &Services,
 	room_id: &RoomId,
@@ -25,10 +26,10 @@ async fn set_private_marker(
 		.await
 		.map_err(|_| err!(Request(NotFound("Event not found."))))?;
 
+	// A backfilled event has no forward position; its position is below every
+	// live event, so storing it can never advance the marker.
 	let PduCount::Normal(count) = count else {
-		return Err!(Request(InvalidParam(
-			"Event is a backfilled PDU and cannot be marked as read."
-		)));
+		return Ok(false);
 	};
 
 	let advanced = services

--- a/src/api/client/read_marker/mod.rs
+++ b/src/api/client/read_marker/mod.rs
@@ -2,7 +2,7 @@ mod read_markers;
 mod receipt;
 
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId, events::receipt::ReceiptThread};
-use tuwunel_core::{PduCount, Result, err, utils::result::LogErr};
+use tuwunel_core::{PduCount, Result, debug, err, utils::result::LogErr};
 use tuwunel_service::{Services, rooms::read_receipt::PrivateRead};
 
 pub(crate) use self::{read_markers::set_read_marker_route, receipt::create_receipt_route};
@@ -29,6 +29,7 @@ async fn set_private_marker(
 	// A backfilled event has no forward position; its position is below every
 	// live event, so storing it can never advance the marker.
 	let PduCount::Normal(count) = count else {
+		debug!(%user_id, %room_id, %event, "Backfilled event was requested to be marked as read");
 		return Ok(false);
 	};
 


### PR DESCRIPTION
### What does this PR do?

Posting m.read.private at a backfilled event failed the entire /read_markers request with M_INVALID_PARAM. In a room joined over federation where the latest message predates the join, every message a client can target is backfilled, so no read marker, public receipt, or notification reset could ever be posted there; the room stayed unread for such clients forever.

A backfilled position orders below every live event, so storing it can never advance the marker. Skip the write like a non-advancing receipt instead of erroring: the request succeeds, the accompanying public receipt and fully-read marker are still stored, and the notification-count reset on advance still runs.

The client/server spec says nothing about backfilled events, so the error appears to be from a desire to indicate to clients that they requested something Tuwunel couldn't entirely fulfill rather than indicating a request that was truly invalid from a protocol standpoint. In the case I tested, it was a request to set the read marker to the same event it was already on, so a no-op in terms of moving the read marker, but an important one because otherwise the client will never show the room as read. Worst case, it should be harmless to accept and skip, because it's not like clients do anything useful with the 400 error.

Fairly niche case, but also an extremely simple fix.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [ ] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [n/a] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [n/a] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
