### PR TITLE
api/client: clamp message pagination bounds

### DIFF
--- a/src/api/client/message.rs
+++ b/src/api/client/message.rs
@@ -1,5 +1,9 @@
 use axum::extract::State;
-use futures::{FutureExt, StreamExt, TryFutureExt, future::Either, pin_mut};
+use futures::{
+	FutureExt, StreamExt, TryFutureExt,
+	future::{Either, ready},
+	pin_mut,
+};
 use ruma::{
 	DeviceId, RoomId, UInt, UserId,
 	api::{
@@ -13,7 +17,7 @@ use ruma::{
 	serde::Raw,
 };
 use tuwunel_core::{
-	Err, PduId, Result, at,
+	Err, PduId, Result, at, err,
 	matrix::{
 		event::{Event, Matches},
 		pdu::{PduCount, PduEvent},
@@ -22,7 +26,7 @@ use tuwunel_core::{
 	smallvec::SmallVec,
 	utils::{
 		BoolExt, IterStream, ReadyExt,
-		result::{FlatOk, LogErr},
+		result::LogErr,
 		stream::{BroadbandExt, TryIgnore, WidebandExt},
 	},
 };
@@ -141,13 +145,17 @@ pub(crate) async fn get_messages(
 
 	let from: PduCount = from
 		.map(str::parse)
-		.transpose()?
+		.transpose()
+		.map_err(|_| err!(Request(InvalidParam("Invalid `from` token."))))?
 		.unwrap_or_else(|| match dir {
 			| Direction::Forward => PduCount::min(),
 			| Direction::Backward => PduCount::max(),
 		});
 
-	let to: Option<PduCount> = to.map(str::parse).flat_ok();
+	let to: Option<PduCount> = to
+		.map(str::parse)
+		.transpose()
+		.map_err(|_| err!(Request(InvalidParam("Invalid `to` token."))))?;
 
 	let limit: usize = limit
 		.and_then(|limit| limit.try_into().ok())
@@ -185,9 +193,17 @@ pub(crate) async fn get_messages(
 
 	let shortroomid = services.short.get_shortroomid(room_id).await?;
 	let mut scanned = None;
+	let mut reached_to = false;
 	let events: Vec<_> = it
 		.inspect(|(count, _)| scanned = Some(*count))
-		.ready_take_while(|(count, _)| Some(*count) != to)
+		.take_while(|(count, _)| {
+			reached_to = to.is_some_and(|to| match dir {
+				| Direction::Forward => *count >= to,
+				| Direction::Backward => *count <= to,
+			});
+
+			ready(!reached_to)
+		})
 		.ready_filter_map(|item| event_filter(item, filter))
 		.wide_filter_map(|item| related_by_filter(services, shortroomid, filter, item))
 		.wide_filter_map(|item| event_filters(services, sender_user, item, bypass_visibility))
@@ -228,7 +244,7 @@ pub(crate) async fn get_messages(
 		.collect()
 		.await;
 
-	let exhausted = matches!(dir, Direction::Backward) && events.len() < limit && scanned != to;
+	let exhausted = matches!(dir, Direction::Backward) && events.len() < limit && !reached_to;
 	let next_token = if exhausted { scanned } else { events.last().map(at!(0)) };
 
 	let chunk = events

--- a/src/main/tests/messages_pagination_bounds.rs
+++ b/src/main/tests/messages_pagination_bounds.rs
@@ -1,0 +1,416 @@
+#![cfg(test)]
+
+use std::{env::temp_dir, fs::remove_dir_all, net::TcpListener, process::id as process_id};
+
+use futures::future::join;
+use reqwest::{Response, StatusCode};
+use serde_json::{Value, json};
+use tuwunel::{Args, Runtime, Server, async_run, async_start, async_stop};
+use tuwunel_core::{
+	PduId, Result,
+	matrix::pdu::{PduCount, RawPduId},
+	ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId},
+};
+use tuwunel_service::Services;
+
+use self::client::{Client, field, register, wait_until_ready};
+
+mod client;
+
+const ACCESS_TOKEN: &str = "messages-pagination-bounds-test-access-token";
+const MESSAGE: &str = "m.room.message";
+const MESSAGE_FILTER: &str = r#"{"types":["m.room.message"]}"#;
+const EMPTY_FILTER: &str = r#"{"types":["com.example.never"]}"#;
+
+#[test]
+fn messages_respect_pagination_bounds() -> Result {
+	let listener = TcpListener::bind(("127.0.0.1", 0))?;
+	let port = listener.local_addr()?.port();
+	let db_path = temp_dir().join(format!("tuwunel-pagination-bounds-{}", process_id()));
+	let mut args = Args::default_test(&["fresh", "cleanup"]);
+
+	args.option.extend([
+		format!("database_path={db_path:?}"),
+		"address=[\"127.0.0.1\"]".to_owned(),
+		format!("port={port}"),
+		"listening=true".to_owned(),
+	]);
+
+	let runtime = Runtime::new(Some(&args))?;
+	let server = Server::new(Some(&args), Some(&runtime))?;
+	let result = runtime.block_on(async {
+		let services = async_start(&server).await?;
+		let base = format!("http://127.0.0.1:{port}");
+
+		drop(listener);
+
+		let exercise = async {
+			let outcome = exercise(&services, &base).await;
+			let shutdown = server.server.shutdown();
+
+			outcome.and(shutdown)
+		};
+
+		let (run_result, outcome) = join(async_run(&server), exercise).await;
+
+		drop(services);
+		async_stop(&server).await?;
+		run_result?;
+
+		outcome
+	});
+
+	drop(runtime);
+	remove_dir_all(&db_path).ok();
+
+	result
+}
+
+async fn exercise(services: &Services, base: &str) -> Result {
+	wait_until_ready(services, base).await?;
+	register(services, "pagination", ACCESS_TOKEN).await?;
+
+	invalid_tokens(services, base).await?;
+	global_bounds(services, base).await?;
+	filtered_bounds(services, base).await?;
+	backfilled_bounds(services, base).await
+}
+
+async fn fixture<'a>(services: &'a Services, base: &'a str) -> Result<(Client<'a>, OwnedRoomId)> {
+	let client = Client { services, base, token: ACCESS_TOKEN };
+	let room = client
+		.create_room(&json!({
+			"preset": "private_chat",
+			"initial_state": [{
+				"type": "m.room.history_visibility",
+				"state_key": "",
+				"content": {"history_visibility": "world_readable"},
+			}],
+		}))
+		.await?;
+
+	Ok((client, room))
+}
+
+async fn global_bounds(services: &Services, base: &str) -> Result {
+	let (client, room) = fixture(services, base).await?;
+	let other = client
+		.create_room(&json!({"preset": "private_chat"}))
+		.await?;
+	let first = send(&client, &room, MESSAGE, "first").await?;
+
+	send(&client, &other, MESSAGE, "gap-one").await?;
+	let low = sync_token(&client).await?;
+	let middle = send(&client, &room, MESSAGE, "middle").await?;
+
+	send(&client, &other, MESSAGE, "gap-two").await?;
+	let high = sync_token(&client).await?;
+	let last = send(&client, &room, MESSAGE, "last").await?;
+
+	assert!(first.1.parse::<i64>()? < low.parse::<i64>()?);
+	assert!(low.parse::<i64>()? < middle.1.parse::<i64>()?);
+	assert!(middle.1.parse::<i64>()? < high.parse::<i64>()?);
+	assert!(high.parse::<i64>()? < last.1.parse::<i64>()?);
+
+	// A sync position can fall between this room's events. Neither direction
+	// may continue until it happens to find an event with that exact count.
+	for (dir, from, to) in [
+		("b", &last.1, &low),
+		("f", &first.1, &high),
+		("b", &high, &low),
+		("f", &low, &high),
+	] {
+		let page = page(&client, &room, &[
+			("dir", dir),
+			("from", from),
+			("to", to),
+			("filter", MESSAGE_FILTER),
+			("limit", "100"),
+		])
+		.await?;
+
+		assert_page(&page, &[middle.0.as_str()], Some(&middle.1));
+	}
+
+	// Exact, equal, and reversed bounds all exclude the boundary itself.
+	for (dir, from, to) in [
+		("b", &last.1, &middle.1),
+		("f", &first.1, &middle.1),
+		("b", &middle.1, &middle.1),
+		("f", &middle.1, &middle.1),
+		("b", &first.1, &high),
+		("f", &last.1, &low),
+	] {
+		let page = page(&client, &room, &[
+			("dir", dir),
+			("from", from),
+			("to", to),
+			("filter", MESSAGE_FILTER),
+		])
+		.await?;
+
+		assert_page(&page, &[], None);
+	}
+
+	Ok(())
+}
+
+async fn filtered_bounds(services: &Services, base: &str) -> Result {
+	let (client, room) = fixture(services, base).await?;
+	let other = client
+		.create_room(&json!({"preset": "private_chat"}))
+		.await?;
+
+	send(&client, &room, MESSAGE, "before-bound").await?;
+	send(&client, &other, MESSAGE, "low-gap").await?;
+	let low = sync_token(&client).await?;
+
+	send(&client, &room, "com.example.pagination", "filtered-event").await?;
+	let visible = send(&client, &room, MESSAGE, "visible-event").await?;
+
+	send(&client, &other, MESSAGE, "high-gap").await?;
+	let high = sync_token(&client).await?;
+	send(&client, &room, MESSAGE, "after-bound").await?;
+
+	for (dir, from, to) in [("b", &high, &low), ("f", &low, &high)] {
+		let partial = page(&client, &room, &[
+			("dir", dir),
+			("from", from),
+			("to", to),
+			("filter", MESSAGE_FILTER),
+			("limit", "100"),
+		])
+		.await?;
+
+		assert_page(&partial, &[visible.0.as_str()], Some(&visible.1));
+
+		let empty = page(&client, &room, &[
+			("dir", dir),
+			("from", from),
+			("to", to),
+			("filter", EMPTY_FILTER),
+			("limit", "100"),
+		])
+		.await?;
+
+		assert_page(&empty, &[], None);
+	}
+
+	let limited = page(&client, &room, &[
+		("dir", "b"),
+		("from", &high),
+		("to", &low),
+		("filter", MESSAGE_FILTER),
+		("limit", "1"),
+	])
+	.await?;
+
+	assert_page(&limited, &[visible.0.as_str()], Some(&visible.1));
+
+	let remainder = page(&client, &room, &[
+		("dir", "b"),
+		("from", field(&limited, "end")?),
+		("to", &low),
+		("filter", MESSAGE_FILTER),
+		("limit", "1"),
+	])
+	.await?;
+
+	assert_page(&remainder, &[], None);
+
+	Ok(())
+}
+
+async fn invalid_tokens(services: &Services, base: &str) -> Result {
+	let (client, room) = fixture(services, base).await?;
+	let mut failures = Vec::new();
+
+	for dir in ["b", "f"] {
+		for name in ["from", "to"] {
+			// Ruma's compatibility parser treats empty optional tokens as omitted.
+			let response = messages(&client, &room, &[("dir", dir), (name, "")]).await?;
+
+			assert_eq!(response.status(), StatusCode::OK);
+
+			for token in
+				[" ", "not-a-token", "1.5", "9223372036854775808", "-9223372036854775809"]
+			{
+				let response = messages(&client, &room, &[("dir", dir), (name, token)]).await?;
+				let status = response.status();
+				let body: Value = response.json().await?;
+
+				if status != StatusCode::BAD_REQUEST || body["errcode"] != "M_INVALID_PARAM" {
+					failures.push((dir, name, token, status, body["errcode"].clone()));
+				}
+			}
+		}
+	}
+
+	assert!(
+		failures.is_empty(),
+		"malformed tokens must return 400 M_INVALID_PARAM: {failures:?}"
+	);
+
+	Ok(())
+}
+
+async fn backfilled_bounds(services: &Services, base: &str) -> Result {
+	let (client, room) = fixture(services, base).await?;
+	let first = send(&client, &room, MESSAGE, "oldest").await?;
+	let middle = send(&client, &room, MESSAGE, "older").await?;
+	let last = send(&client, &room, MESSAGE, "old").await?;
+
+	for (event, count) in [(&first.0, -50), (&middle.0, -30), (&last.0, -10)] {
+		move_to_backfilled_position(services, &room, event, count).await?;
+	}
+
+	services.clear_cache().await;
+
+	let backward = page(&client, &room, &[
+		("dir", "b"),
+		("from", "0"),
+		("to", "-40"),
+		("filter", MESSAGE_FILTER),
+	])
+	.await?;
+
+	assert_page(&backward, &[last.0.as_str(), middle.0.as_str()], Some("-30"));
+
+	let forward = page(&client, &room, &[
+		("dir", "f"),
+		("from", "-60"),
+		("to", "-20"),
+		("filter", MESSAGE_FILTER),
+	])
+	.await?;
+
+	assert_page(&forward, &[first.0.as_str(), middle.0.as_str()], Some("-30"));
+
+	for (dir, from, expected, end) in
+		[("b", "0", last.0.as_str(), "-10"), ("f", "-60", first.0.as_str(), "-50")]
+	{
+		let page = page(&client, &room, &[
+			("dir", dir),
+			("from", from),
+			("to", "-30"),
+			("filter", MESSAGE_FILTER),
+		])
+		.await?;
+
+		assert_page(&page, &[expected], Some(end));
+	}
+
+	Ok(())
+}
+
+/// Re-key validated events to exercise stored backfill ordering without a
+/// remote server. Pagination reads these timeline rows and event-id mappings.
+async fn move_to_backfilled_position(
+	services: &Services,
+	room: &RoomId,
+	event: &EventId,
+	count: i64,
+) -> Result {
+	let old = services.timeline.get_pdu_id(event).await?;
+	let new: RawPduId = PduId {
+		shortroomid: services.short.get_shortroomid(room).await?,
+		count: PduCount::Backfilled(count),
+	}
+	.into();
+	let timeline = services.db.get("pduid_pdu")?;
+	let stored = timeline.get(&old).await?;
+
+	timeline.insert(&new, stored.as_ref());
+	timeline.remove(&old);
+	services
+		.db
+		.get("eventid_pduid")?
+		.insert(event.as_bytes(), new);
+
+	Ok(())
+}
+
+async fn send(
+	client: &Client<'_>,
+	room: &RoomId,
+	kind: &str,
+	txn: &str,
+) -> Result<(OwnedEventId, String)> {
+	let response: Value = client
+		.services
+		.client
+		.clients
+		.default
+		.put(client.url(&format!("rooms/{room}/send/{kind}/{txn}")))
+		.bearer_auth(client.token)
+		.json(&json!({"msgtype": "m.text", "body": txn}))
+		.send()
+		.await?
+		.error_for_status()?
+		.json()
+		.await?;
+	let event: OwnedEventId = field(&response, "event_id")?.try_into()?;
+	let count = client
+		.services
+		.timeline
+		.get_pdu_id(&event)
+		.await?
+		.pdu_count();
+
+	Ok((event, count.to_string()))
+}
+
+async fn sync_token(client: &Client<'_>) -> Result<String> {
+	let response: Value = client
+		.services
+		.client
+		.clients
+		.default
+		.get(client.url("sync"))
+		.bearer_auth(client.token)
+		.query(&[("timeout", "0")])
+		.send()
+		.await?
+		.error_for_status()?
+		.json()
+		.await?;
+
+	Ok(field(&response, "next_batch")?.to_owned())
+}
+
+async fn messages(
+	client: &Client<'_>,
+	room: &RoomId,
+	query: &[(&str, &str)],
+) -> Result<Response> {
+	Ok(client
+		.services
+		.client
+		.clients
+		.default
+		.get(client.url(&format!("rooms/{room}/messages")))
+		.bearer_auth(client.token)
+		.query(query)
+		.send()
+		.await?)
+}
+
+async fn page(client: &Client<'_>, room: &RoomId, query: &[(&str, &str)]) -> Result<Value> {
+	Ok(messages(client, room, query)
+		.await?
+		.error_for_status()?
+		.json()
+		.await?)
+}
+
+fn assert_page(page: &Value, expected: &[&str], end: Option<&str>) {
+	let events: Vec<_> = page["chunk"]
+		.as_array()
+		.expect("messages response chunk")
+		.iter()
+		.map(|event| event["event_id"].as_str().expect("event id"))
+		.collect();
+
+	assert_eq!(events, expected, "{page}");
+	assert_eq!(page.get("end").and_then(Value::as_str), end, "{page}");
+}


### PR DESCRIPTION
While checking `/messages` during the rebase, I confirmed that upstream can still ignore a valid `to` token from `/sync`. Tuwunel's sync token is a global stream position, so activity in another room can advance it without creating an event at that position in the room being paginated. The current loop only stops when an event's count exactly matches `to`; if no event matches, it keeps walking past the requested boundary. The [Matrix spec explicitly allows sync tokens for both `from` and `to`](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmessages).

This keeps the existing exclusive boundary, but checks it in the direction of travel: forward pagination stops at or above `to`, backward pagination at or below it. Malformed non-empty `from` and `to` tokens return HTTP 400 with `M_INVALID_PARAM`, instead of becoming a server error or being silently ignored. Empty optional tokens still behave as omitted, preserving Ruma's existing compatibility handling.

One detail worth calling out: current `main` uses the last scanned event to keep exhausted backward pages moving, including pages where every event was filtered out. The fix distinguishes reaching `to` from exhausting the local timeline, so that fallback cannot return an `end` token past the requested bound. The existing exhausted-page behavior is otherwise unchanged.

The regression tests use the existing server-booting client harness. They capture real `/sync` tokens while a second room advances the stream, check both directions and exact bounds, and cover malformed tokens, filtered-page continuation, and negative backfill positions. I reproduced the out-of-bound event and malformed-token failures on unmodified upstream `main` before applying the fix.

For context, I've been running the pagination-bounds and token-validation fix in production in the MindRoom fork since [v1.8.2-mindroom.2](https://github.com/mindroom-ai/mindroom-tuwunel/releases/tag/v1.8.2-mindroom.2) in July 2026, and have carried it through subsequent upstream rebases. Upstreaming it means one less general-purpose patch to maintain in the fork. This PR adapts that fix to current upstream `main`'s exhausted-page handling and uses the upstream test harness; no fork-specific infrastructure or release changes are included.

Verified in the repository's pinned `nix develop .#dynamic` shell on aarch64 Linux, with isolated local test databases and loopback networking:

- `cargo fmt --all -- --check` — nightly rustfmt, clean
- `cargo clippy --offline --locked --workspace --all-targets --all-features -- -D warnings` — clean on the pinned Rust 1.95.0 toolchain
- `cargo test --offline --locked --workspace --all-targets --all-features` — 1,063 passed, zero failed, four existing ignored tests; benchmark smoke targets also passed

I also tried nightly-2026-09-05 with CI's trait-solver setting. That run stops on existing `unnecessary_self_imports` and `redundant_clone` lints outside this diff; I left those untouched.

The full suite includes the existing exhausted-backward-page regression as well as the new bounds/token cases. I haven't run Complement locally; its pagination result diff still needs checking in CI.
