### PR TITLE
tests: isolate default test databases

### DIFF
--- a/src/main/args.rs
+++ b/src/main/args.rs
@@ -1,13 +1,17 @@
 //! Integration with `clap`
 
-use std::{env::var, path::PathBuf, process::id as process_id};
+use std::{
+	env::{temp_dir, var},
+	path::PathBuf,
+	process::id as process_id,
+};
 
 use clap::{ArgAction, Parser, builder::RangedU64ValueParser};
 use tuwunel_core::{
 	Err, Result,
 	config::{Figment, FigmentValue},
 	err, implement, is_true, toml,
-	utils::available_parallelism,
+	utils::{available_parallelism, random_string},
 };
 
 /// Only its own argument may set this, since restoring is destructive and
@@ -307,14 +311,22 @@ fn histogram_buckets_parser() -> RangedU64ValueParser<usize> {
 
 /// Returns arguments for a test, naming the harnesses it opts into.
 ///
-/// The server name is preset to `localhost`. A test wanting another appends its
-/// own override, which wins, since the later value of a key takes precedence.
+/// The server name is preset to `localhost`, with a separate temporary database
+/// path for each call. Random names avoid reusing stale paths after process-id
+/// reuse. A test can append its own override, which takes precedence.
 #[implement(Args)]
 #[must_use]
+#[expect(
+	clippy::unnecessary_debug_formatting,
+	reason = "configuration overrides require a quoted and escaped path"
+)]
 pub fn default_test(name: &[&str]) -> Self {
+	let database_path = temp_dir().join(format!("tuwunel-test-{}", random_string(32)));
+
 	Self::default()
 		.with_tests(name)
 		.with_option("server_name=\"localhost\"")
+		.with_option(format!("database_path={database_path:?}"))
 }
 
 /// Returns these arguments with a database path isolated to this test.

--- a/src/main/tests/default_test_database.rs
+++ b/src/main/tests/default_test_database.rs
@@ -1,0 +1,126 @@
+#![cfg(test)]
+
+use std::{
+	array,
+	collections::HashSet,
+	env::temp_dir,
+	fs::{create_dir, read_to_string, remove_dir_all, write},
+	path::PathBuf,
+	thread,
+};
+
+use clap::Parser;
+use tuwunel::{Args, Runtime, Server, args::update};
+use tuwunel_core::{Result, config::Figment};
+use tuwunel_database::Database;
+
+/// Default tests must not inherit the database selected by a developer's
+/// configuration, and reapplying the same arguments must retain their path.
+#[test]
+fn default_test_overrides_the_configured_database() -> Result {
+	let args = Args::default_test(&["fresh", "cleanup"]);
+	let configured = Figment::new().merge(("database_path", "configured-database"));
+	let path: PathBuf = update(configured, &args)?.extract_inner("database_path")?;
+
+	assert_ne!(path, PathBuf::from("configured-database"));
+	assert_eq!(path.parent(), Some(temp_dir().as_path()));
+	let cloned = args.clone();
+	assert_eq!(database_path(&cloned)?, path);
+	assert_eq!(database_path(&args)?, path);
+
+	Ok(())
+}
+
+/// A shared path or a process-id-only path makes independent callers collide.
+#[test]
+fn concurrent_default_tests_have_distinct_databases() -> Result {
+	let callers: [_; 8] = array::from_fn(|_| {
+		thread::spawn(|| database_path(&Args::default_test(&["fresh", "cleanup"])))
+	});
+	let paths: HashSet<_> = callers
+		.into_iter()
+		.map(|caller| {
+			caller
+				.join()
+				.expect("argument builder did not panic")
+		})
+		.collect::<Result<_>>()?;
+
+	assert_eq!(paths.len(), 8);
+	for path in paths {
+		assert_eq!(path.parent(), Some(temp_dir().as_path()));
+	}
+
+	Ok(())
+}
+
+/// A test's explicit override still wins; ordinary CLI arguments gain no
+/// test-specific database override.
+#[test]
+fn explicit_database_overrides_remain_available() -> Result {
+	let explicit = temp_dir().join("chosen database with \"quotes\"");
+	let args = Args::default_test(&["fresh", "cleanup"])
+		.with_option(format!("database_path={explicit:?}"));
+
+	assert_eq!(database_path(&args)?, explicit);
+	update(Figment::new(), &Args::parse_from(["tuwunel"]))?
+		.find_value("database_path")
+		.expect_err("ordinary CLI arguments must not choose a test database");
+
+	Ok(())
+}
+
+/// Drive the real database's `fresh` and `cleanup` hooks with the default
+/// path, while another default caller owns a neighboring directory.
+#[test]
+fn default_database_cleanup_leaves_other_tests_alone() -> Result {
+	let mut args = Args::default_test(&["fresh", "cleanup"]);
+	args.maintenance = true;
+	let database = TestDirectory::create(database_path(&args)?)?;
+	let neighbor =
+		TestDirectory::create(database_path(&Args::default_test(&["fresh", "cleanup"]))?)?;
+	let stale = database.0.join("before-fresh");
+	let marker = neighbor.0.join("keep");
+	write(&stale, "old test data")?;
+	write(&marker, "another test's data")?;
+
+	let runtime = Runtime::new(Some(&args))?;
+	let server = Server::new(Some(&args), Some(&runtime))?;
+	let db = runtime.block_on(Database::open(&server.server))?;
+
+	assert_eq!(server.server.config.database_path, database.0);
+	assert!(!stale.exists(), "fresh must remove this test's old database");
+	assert_eq!(read_to_string(&marker)?, "another test's data");
+
+	drop(db);
+	drop(runtime);
+	drop(server);
+
+	assert!(!database.0.exists(), "cleanup must remove this test's database");
+	assert_eq!(read_to_string(&marker)?, "another test's data");
+
+	Ok(())
+}
+
+fn database_path(args: &Args) -> Result<PathBuf> {
+	Ok(update(Figment::new(), args)?.extract_inner("database_path")?)
+}
+
+/// Own only directories this test created successfully, including on failure.
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+	#[expect(
+		clippy::create_dir,
+		reason = "only claim and clean up a directory when this test creates it"
+	)]
+	fn create(path: PathBuf) -> Result<Self> {
+		assert_eq!(path.parent(), Some(temp_dir().as_path()));
+		create_dir(&path)?;
+		Ok(Self(path))
+	}
+}
+
+impl Drop for TestDirectory {
+	fn drop(&mut self) { remove_dir_all(&self.0).ok(); }
+}


### PR DESCRIPTION
### What does this PR do?

While checking upstream's test setup during the fork rebase, I noticed that `Args::default_test` selects `localhost` as the server name but leaves the database path to the normal configuration. Several smoke and listener tests use that helper without providing their own path. That matters because the `fresh` and `cleanup` hooks remove the selected database directory: those tests should not share a configured database or depend on each caller remembering an override.

This gives each call a randomly named database path under the system temporary directory. The path is stored in the arguments, so cloning or reapplying those arguments keeps the same database. An explicit `.with_option("database_path=...")` added afterward still wins, and ordinary server startup is unchanged. No new dependency or separate test crate is needed.

The regression tests check that a configured database path is overridden, concurrent callers get distinct paths, and explicit overrides still work. A database-lifecycle test also exercises the real `fresh` and `cleanup` hooks while a neighboring test directory holds a marker that must survive.

The fork already carries default test-database isolation; this extracts that behavior into upstream's existing argument builder and adds focused coverage there.

Verified in the pinned Nix dynamic shell (Rust 1.95.0 and nightly rustfmt):

- `cargo fmt --all -- --check`
- `cargo clippy --offline --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --offline --locked --workspace --all-targets --all-features` — 1,082 passed, 0 failed, 4 ignored, matching upstream's ignored count.

I first ran the regression against unchanged upstream and confirmed the missing/inherited-path failures. I also ran the final integration-test binary in three simultaneous processes sharing a temporary directory with spaces and quotes: all 12 checks passed, and no test databases remained. Test runs used isolated networking and storage, with debug symbols disabled.

### Checklist

- [x] Nightly formatting and pinned stable Clippy/rustc checks pass; intentional lint expectations explain why quoting and exclusive directory creation are needed.
- [x] Complement was not run locally; no compliance-result changes are claimed.
- [x] No public configuration options changed, so no example-config regeneration is needed.
- [x] The test-helper behavior is documented in source; no operator-facing feature was added.
- [x] I agree to the Apache-2.0 licensing terms and the project's Code of Conduct.
