### PR TITLE
chore: fix current nightly lints

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -33,4 +33,4 @@ unstable_features = true
 use_field_init_shorthand = true
 use_small_heuristics = "Off"
 use_try_shorthand = true
-wrap_comments = true
+wrap_comments = false

--- a/src/api/client/membership/members.rs
+++ b/src/api/client/membership/members.rs
@@ -2,7 +2,7 @@ use axum::extract::State;
 use futures::{FutureExt, StreamExt, pin_mut};
 use ruma::{
 	api::client::membership::{
-		get_member_events::{self},
+		get_member_events,
 		joined_members::{self, v3::RoomMember},
 	},
 	events::{

--- a/src/api/client/send.rs
+++ b/src/api/client/send.rs
@@ -17,8 +17,7 @@ use serde_json::from_str;
 use tuwunel_core::{
 	Err, Result, debug_warn, err,
 	matrix::{Event, pdu::PduBuilder},
-	utils::{self},
-	warn,
+	utils, warn,
 };
 use tuwunel_service::Services;
 

--- a/src/api/client/user_directory.rs
+++ b/src/api/client/user_directory.rs
@@ -1,9 +1,7 @@
 use axum::extract::State;
 use futures::{FutureExt, StreamExt, pin_mut};
 use ruma::{
-	UserId,
-	api::client::user_directory::search_users::{self},
-	events::room::join_rules::JoinRule,
+	UserId, api::client::user_directory::search_users, events::room::join_rules::JoinRule,
 };
 use tuwunel_core::{
 	Result,

--- a/src/api/client/well_known.rs
+++ b/src/api/client/well_known.rs
@@ -1,7 +1,7 @@
 use axum::extract::State;
 use ruma::api::client::discovery::{
 	discover_homeserver::{self, HomeserverInfo},
-	discover_support::{self},
+	discover_support,
 };
 use tuwunel_core::{Err, Result};
 

--- a/src/service/media/migrations.rs
+++ b/src/service/media/migrations.rs
@@ -1,8 +1,7 @@
 use std::{
 	collections::HashSet,
 	ffi::{OsStr, OsString},
-	fs::{self},
-	io,
+	fs, io,
 	path::{Path, PathBuf},
 	sync::Arc,
 	time::Instant,

--- a/src/service/rooms/state_res/resolve/split_conflicted.rs
+++ b/src/service/rooms/state_res/resolve/split_conflicted.rs
@@ -48,9 +48,9 @@ where
 		.flat_map(IntoIterator::into_iter)
 	{
 		let acc = occurrences
-			.entry(k.clone())
+			.entry(k)
 			.or_default()
-			.entry(v.clone())
+			.entry(v)
 			.or_default();
 
 		*acc = acc.saturating_add(1);
@@ -62,7 +62,7 @@ where
 	for (k, v) in occurrences {
 		for (id, occurrence_count) in v {
 			if occurrence_count == state_set_count {
-				unconflicted_state_map.insert((k.0.clone(), k.1.clone()), id.clone());
+				unconflicted_state_map.insert((k.0.clone(), k.1.clone()), id);
 			} else {
 				let conflicts = conflicted_state_set
 					.entry((k.0.clone(), k.1.clone()))
@@ -73,7 +73,7 @@ where
 					"Unexpected duplicate conflicted state event"
 				);
 
-				conflicts.push(id.clone());
+				conflicts.push(id);
 			}
 		}
 	}

--- a/src/service/rooms/state_res/test_utils.rs
+++ b/src/service/rooms/state_res/test_utils.rs
@@ -79,7 +79,7 @@ pub(super) async fn do_check(
 		let state_after = state_after_with(&state_before, fake_event, &event_id);
 		let event = rebuild_with_auth(fake_event, &auth_events, prev_events);
 
-		store.0.insert(event_id.clone(), event.clone());
+		store.0.insert(event_id.clone(), event);
 		event_map.insert(event_id.clone(), store.0[&event_id].clone());
 		state_at_event.insert(node, state_after);
 	}

--- a/src/service/sending/sender.rs
+++ b/src/service/sending/sender.rs
@@ -652,7 +652,7 @@ impl Service {
 		for (dest, events) in txns {
 			if self.server.config.startup_netburst && !events.is_empty() {
 				statuses.insert(dest.clone(), TransactionStatus::Running);
-				futures.push(self.send_events(dest.clone(), events));
+				futures.push(self.send_events(dest, events));
 			}
 		}
 


### PR DESCRIPTION
While checking CI on #576 and #577, I reproduced the nightly formatting and Clippy failures on unmodified current `main`. They are shared baseline failures, so I'm keeping the cleanup in its own PR instead of adding it to either feature patch.

This sets `wrap_comments = false` in `rustfmt.toml`, so the new nightly formatter leaves the existing comment layout alone. The original comment reflow has been removed from the diff; there are now nine changed files.

The remaining source changes simplify five imports ending in `::{self}` and remove six clones flagged by nightly Clippy. Each removed clone was at the value's final use. The clones still needed across state-resolution iterations and for the sending transaction status map remain in place. No toolchain pin or new lint allowances are added.

Verified locally on aarch64 Linux after this revision:

- `cargo fmt --all -- --check` with the formatter from the pinned development shell, nightly-2026-09-05, and nightly-2026-09-06.
- Clippy with `-D warnings` across all workspace targets and all features: Rust 1.95.0, nightly-2026-09-05, and nightly-2026-09-06. Both nightly runs use CI's test profile and existing solver/unstable-feature flags.
- Rust 1.95.0 `cargo test --offline --locked --workspace --all-targets --all-features`: 1,078 passed, zero failed, four existing ignored tests; benchmark smoke checks passed too. Server tests used isolated local databases and loopback networking.
- All original comment lines and the generated `tuwunel-example.toml` are unchanged from `main`.

I haven't run Complement locally; no protocol or compliance change is intended.
