### PR TITLE
fix: summarize storage sync output

### DIFF
--- a/src/admin/query/storage/mod.rs
+++ b/src/admin/query/storage/mod.rs
@@ -114,8 +114,8 @@ pub(crate) enum StorageCommand {
 		verbose: bool,
 	},
 
-	/// Transfer objects from a source provider which do not exist on a
-	/// destination provider.
+	/// Copy objects from a source provider which do not exist on a
+	/// destination provider, then report the number copied.
 	Sync {
 		/// Use source configured provider by name.
 		src: String,

--- a/src/admin/query/storage/sync.rs
+++ b/src/admin/query/storage/sync.rs
@@ -14,28 +14,27 @@ pub(super) async fn query_storage_sync(&self, src: String, dst: String) -> Resul
 
 	let dst_p = self.services.storage.provider(&dst)?;
 
-	let src = src_p
+	let src_objects = src_p
 		.list(None)
 		.map_ok(|meta| meta.location)
 		.try_collect::<HashSet<_>>();
 
-	let dst = dst_p
+	let dst_objects = dst_p
 		.list(None)
 		.map_ok(|meta| meta.location)
 		.try_collect::<HashSet<_>>();
 
-	let (src, dst) = try_join(src, dst).await?;
+	let (src_objects, dst_objects) = try_join(src_objects, dst_objects).await?;
 
-	src.difference(&dst)
+	let copied = src_objects
+		.difference(&dst_objects)
 		.try_stream()
 		.broadn_and_then(2, async |item| {
 			let data = src_p.get(item.as_ref()).await?;
-			let put = dst_p.put_one(item.as_ref(), data).await?;
+			dst_p.put_one(item.as_ref(), data).await
+		})
+		.try_fold(0_usize, async |count, _| Ok(count.saturating_add(1)))
+		.await?;
 
-			Ok((item, put))
-		})
-		.try_for_each(|(item, put)| {
-			writeln!(&self, "Moved {item} from {src:?} to {dst:?}; {put:?}")
-		})
-		.await
+	writeln!(self, "Copied {copied} objects from {src:?} to {dst:?}.").await
 }


### PR DESCRIPTION
### What does this PR do?
`!admin query storage sync` previously emitted one line for every copied object. For large media sets, the accumulated admin output could exceed the 64 MiB limit and abort the command. The old output also formatted the shadowed source and destination object sets instead of the provider names.

This change:

- Counts successfully copied objects.
- Emits one final summary instead of per-object output.
- Describes the operation as copying, since source objects are retained.
- Preserves the existing source/destination comparison, concurrency, and error propagation.
- Reports zero copied objects when the providers are already synchronized.
- Updates the command help.

The existing storage-provider documentation already describes the command.

Fixes #571

### Testing
- `cargo +1.95.0 test -p tuwunel_admin --lib --locked`
=> 21 tests passed
- `cargo +1.95.0 clippy -p tuwunel_admin --lib --locked --no-deps`
=> passed without warnings
- `cargo +nightly fmt --all --check`
=> passed

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] **No** Complement compliance changes were made
- [x] **No** config option changes were made
- [x] Existing `docs/media/storage.md` documentation already covers the `storage sync` command, no doc changes required
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.
