### PR TITLE
feat(policy): mandatory policy server + fail-closed mode

### DIFF
--- a/docs/development/compliance/msc.md
+++ b/docs/development/compliance/msc.md
@@ -63,7 +63,7 @@ in the [Out of scope](#out-of-scope) section.
 | MSC4297 | ✅ ● | 100/100 | State Resolution v2.1 | src/service/rooms/state_res/resolve.rs:257 conflicted state subgraph; tests pass |
 | MSC4291 | ✅ ● | 100/100 | Room IDs as hashes of the create event | v12 upgrade create event omits deprecated predecessor.event_id |
 | MSC4289 | ✅ ● | 100/100 | Explicitly privilege room creators | Room v12 creator privilege; complement 22 pass, 0 fail across six named tests |
-| MSC4284 | 🟨 ● | 70/90 | Policy Servers | outbound /sign, inbound verify, fetch-on-missing, reversible soft-fail |
+| MSC4284 | 🟨 ● | 70/90 | Policy Servers | outbound /sign, inbound verify, fetch-on-missing, reversible soft-fail; operator-mandatory server at a direct URL and optional fail-closed (beyond the MSC) |
 | MSC4277 | ✅ ● | 100/100 | Harmonizing the reporting endpoints | all 3 wired; score removed; user report 200 regardless to deter enumeration |
 | MSC4267 | ✅ ● | 90/100 | Automatically forgetting rooms on leave | auto-forget on Leave/Ban; stable + unstable capability advertised |
 | MSC4260 | ✅ ● | 85/90 | Reporting users (Client-Server API) | src/api/client/report.rs:63; admin notification, 404 M_NOT_FOUND on unknown u... |
@@ -268,7 +268,7 @@ for spec compliance.
 | MSC4178 | 🟨 ● | 75/90 | 1.13 | Error codes for requestToken | msisdn returns M_THREEPID_MEDIUM_NOT_SUPPORTED; bad email returns M_INVALID_P... |
 | MSC2409 | 🟨 ● | 70/70 | 1.13 | Proposal to send typing, presence and receipts to appservices | typing+receipt EDUs sent to AS; presence not forwarded |
 | MSC3970 | 🟨 ◐ | 70/80 | 1.7 | Scope transaction IDs to devices | txn key is user, device, txn with no path; redact untracked; echo user scoped |
-| MSC4284 | 🟨 ● | 70/90 | 1.18 | Policy Servers | outbound /sign, inbound verify, fetch-on-missing, reversible soft-fail |
+| MSC4284 | 🟨 ● | 70/90 | 1.18 | Policy Servers | outbound /sign, inbound verify, fetch-on-missing, reversible soft-fail; operator-mandatory server at a direct URL and optional fail-closed (beyond the MSC) |
 | MSC2290 | 🟨 ● | 65/55 |  | Separate Endpoints for Binding Threepids | add endpoint (UIA+dupe) + HS email validation; IS-bind half out of scope |
 | MSC1915 | 🟨 ● | 60/55 |  | MSC 1915 - Add unbind 3PID APIs | delete + deactivate return id_server_unbind_result; IS unbind out of HS scope |
 | MSC2675 | 🟨 ◐ | 60/75 | 1.3 | Serverside aggregations of message relationships | thread+edit+reference bundled (edit/ref gated); reactions unbundled |

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -150,25 +150,47 @@ verification on federated receives, fetch-on-missing for inbound events
 without a signature, and refusal/backoff caching to avoid hammering a server
 that is rate-limiting or has refused.
 
-Two configuration knobs:
+Configuration knobs:
 
 - `enable_policy_servers`: master switch (default `false`). When `false`,
-  Tuwunel ignores policy state entirely. When `true`, the gate engages only
-  in rooms that carry a valid `m.room.policy` state event.
+  Tuwunel ignores policy state entirely. When `true`, the gate engages in
+  rooms that carry a valid `m.room.policy` state event — and, if a mandatory
+  server is configured, in every room.
 - `policy_server_request_timeout`: seconds (default `5`) for both outbound
   `/sign` and inbound signature-fetch requests.
+- `policy_server_mandatory_url`, `policy_server_mandatory_name`,
+  `policy_server_mandatory_public_key`: together, an operator-configured
+  policy server consulted for every event in every room, reached directly at
+  the URL rather than by federation resolution. All three or none.
+- `policy_server_fail_closed`: refuse local sends when the policy server is
+  unreachable instead of sending them unsigned (default `false`).
 
 Operator-relevant implications when enabling:
 
-- **Per-room opt-in.** The global flag only allows the gate to engage; the
-  room's own `m.room.policy` state event is what activates it. Rooms without
-  the state event are unaffected.
+- **Per-room opt-in — unless a mandatory server is set.** By default the
+  global flag only allows the gate to engage; the room's own `m.room.policy`
+  state event is what activates it, and rooms without the state event are
+  unaffected. With `policy_server_mandatory_*` configured, the deployment's
+  policy server is consulted for every event in every room, `m.room.policy`
+  is ignored for that purpose (a room cannot opt out by unsetting it, and the
+  room-creator power of room version 12 does not help either), the policy
+  server does not need a user joined to the room, and federation need not be
+  enabled. This is the shape for a policy server that is a moderation control
+  of the deployment rather than a community's choice.
+- **The mandatory URL is trusted, on purpose.** `/sign` goes straight to the
+  configured base URL: no `.well-known`/SRV resolution, no
+  `forbidden_remote_server_names`, no `ip_range_denylist` — a policy server
+  on a loopback or private address is the common deployment and would
+  otherwise be denied. Point it only at a service you operate.
 - **Latency cost.** Every outbound send in a policy-room round-trips to the
   policy server before federating. The default 5-second cap prevents a
   single misbehaving policy server from stalling sends indefinitely.
-- **Fail-open on transport failure.** Network errors and timeouts are logged
-  and the event is sent or accepted unsigned, on the assumption that the
-  next homeserver in the room will pick up the gap.
+- **Fail-open on transport failure — by default.** Network errors, timeouts
+  and rate-limit backoffs are logged and the event is sent or accepted
+  unsigned, on the assumption that the next homeserver in the room will pick
+  up the gap. With `policy_server_fail_closed = true` the local send is
+  refused instead and inbound events soft-fail; the policy server then sits
+  on the availability path of every send, and must be run accordingly.
 - **Fail-closed on explicit refusal.** A policy server returning
   `400 M_FORBIDDEN` (or, on the unstable variant, `200 OK` with no signature
   for the configured `via`) causes outbound sends to fail with `M_FORBIDDEN`,
@@ -193,7 +215,9 @@ Operator-relevant implications when enabling:
 - **Privacy in encrypted rooms.** The PDU is forwarded to the policy server
   for signing. Ciphertext is opaque, but metadata (sender, timestamp, room,
   event type) is not. Encrypted-room policy delegation is the room's call;
-  Tuwunel does not block it.
+  Tuwunel does not block it. A mandatory server sees that metadata for
+  every event on the server, including rooms that never opted in — say so
+  in the deployment's privacy notice.
 - **Refusal and rate-limit caching.** Per-event refusals and
   `M_LIMIT_EXCEEDED` backoffs are persisted, so repeated arrivals of the same
   event do not re-hit a refusing or throttled server.

--- a/src/core/config/check.rs
+++ b/src/core/config/check.rs
@@ -76,6 +76,7 @@ pub fn check(config: &Config) -> Result {
 
 	check_observability(config)?;
 	check_network(config)?;
+	check_policy_servers(config)?;
 	check_storage(config)?;
 	check_registration(config)?;
 	check_registration_terms(config)?;
@@ -216,6 +217,53 @@ fn warn_loopback_in_container(addr: &SocketAddr) {
 			 Please change this to \"0.0.0.0\". If this is expected, you can ignore.",
 		);
 	}
+}
+
+/// The mandatory policy server is three fields that only mean something
+/// together, and a fail-closed switch that only means something with the
+/// master switch. A half-set triple would be read as "no mandatory server"
+/// and silently enforce nothing.
+fn check_policy_servers(config: &Config) -> Result {
+	let set = [
+		config.policy_server_mandatory_url.is_some(),
+		config.policy_server_mandatory_name.is_some(),
+		config
+			.policy_server_mandatory_public_key
+			.is_some(),
+	];
+	let any = set.iter().any(|s| *s);
+	if any && !set.iter().all(|s| *s) {
+		return Err!(Config(
+			"policy_server_mandatory_url",
+			"policy_server_mandatory_url, policy_server_mandatory_name and \
+			 policy_server_mandatory_public_key must be set together or not at all"
+		));
+	}
+
+	if any && !config.enable_policy_servers {
+		return Err!(Config(
+			"policy_server_mandatory_url",
+			"a mandatory policy server requires enable_policy_servers = true"
+		));
+	}
+
+	if config.policy_server_fail_closed && !config.enable_policy_servers {
+		return Err!(Config(
+			"policy_server_fail_closed",
+			"policy_server_fail_closed requires enable_policy_servers = true"
+		));
+	}
+
+	if let Some(url) = &config.policy_server_mandatory_url
+		&& !matches!(url.scheme(), "http" | "https")
+	{
+		return Err!(Config(
+			"policy_server_mandatory_url",
+			"policy_server_mandatory_url must be an http:// or https:// URL"
+		));
+	}
+
+	Ok(())
 }
 
 fn check_storage(config: &Config) -> Result {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -37,7 +37,7 @@ use itertools::Itertools;
 use regex::RegexSet;
 use ruma::{
 	OwnedMxcUri, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomVersionId,
-	api::client::discovery::discover_support::ContactRole,
+	api::client::discovery::discover_support::ContactRole, serde::Base64,
 };
 use serde::{Deserialize, de::IgnoredAny};
 use tuwunel_macros::config_example_generator;
@@ -1432,6 +1432,57 @@ pub struct Config {
 	/// default: 5
 	#[serde(default = "default_policy_server_request_timeout")]
 	pub policy_server_request_timeout: u64,
+
+	/// MSC4284: an operator-configured policy server consulted for EVERY
+	/// local event, regardless of whether the room carries an `m.room.policy`
+	/// state event. `/sign` is sent directly to this base URL, bypassing
+	/// federation server-name resolution, the `allow_federation` switch, the
+	/// `forbidden_remote_server_names` list, the `ip_range_denylist` and the
+	/// "policy server must be joined to the room" rule — the URL is trusted
+	/// because the operator wrote it. Use this when the policy server is a
+	/// moderation control of this deployment rather than a room's choice.
+	///
+	/// Requires `enable_policy_servers` and both companion fields below.
+	///
+	/// reloadable: yes
+	/// default: unset
+	/// config-example: "https://policy.internal:8448"
+	#[serde(default)]
+	pub policy_server_mandatory_url: Option<Url>,
+
+	/// MSC4284: the server name the mandatory policy server signs as. It is
+	/// the key under `event.signatures` and the X-Matrix `destination` of the
+	/// `/sign` request, and must equal the name the policy server uses for
+	/// itself.
+	///
+	/// reloadable: yes
+	/// default: unset
+	/// config-example: "policy.internal"
+	#[serde(default)]
+	pub policy_server_mandatory_name: Option<OwnedServerName>,
+
+	/// MSC4284: the mandatory policy server's ed25519 public key, unpadded
+	/// base64, as it would appear in `m.room.policy` `public_keys.ed25519`.
+	/// Inbound signatures are verified against it exactly as room-configured
+	/// keys are.
+	///
+	/// reloadable: yes
+	/// default: unset
+	/// config-example: "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+	#[serde(default)]
+	pub policy_server_mandatory_public_key: Option<Base64>,
+
+	/// MSC4284: when the policy server cannot be reached (network error,
+	/// timeout, or rate-limit backoff), refuse the local send instead of
+	/// letting it through. Off by default: a transient policy-server outage
+	/// then degrades to unsigned events. Turn it on when the policy server is
+	/// a hard requirement of the deployment and its availability is managed
+	/// accordingly.
+	///
+	/// reloadable: yes
+	/// default: false
+	#[serde(default)]
+	pub policy_server_fail_closed: bool,
 
 	/// MSC3925: fold the most recent message edit (an `m.replace` relation)
 	/// into `unsigned.m.relations` on a served event as the full replacement

--- a/src/core/config/tests.rs
+++ b/src/core/config/tests.rs
@@ -862,6 +862,42 @@ fn a_weak_cost_passes_the_config_check_with_a_warning() {
 	}
 }
 
+/// The mandatory policy server is only meaningful as a whole: a partial triple,
+/// or one without the master switch, must be refused at startup rather than
+/// read as "no mandatory server" and enforce nothing.
+#[test]
+fn mandatory_policy_server_is_all_or_nothing_and_needs_the_master_switch() {
+	const KEY: &str = "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg";
+	let full = format!(
+		"[global]\nenable_policy_servers = true\npolicy_server_mandatory_url = \
+		 \"https://policy.internal:8448\"\npolicy_server_mandatory_name = \
+		 \"policy.internal\"\npolicy_server_mandatory_public_key = \"{KEY}\"\n"
+	);
+	for (name, toml, ok) in [
+		("full triple with switch", full.as_str(), true),
+		(
+			"url only",
+			"[global]\nenable_policy_servers = true\npolicy_server_mandatory_url = \
+			 \"https://policy.internal:8448\"\n",
+			false,
+		),
+		(
+			"triple without switch",
+			"[global]\npolicy_server_mandatory_url = \"https://policy.internal:8448\"\n\
+			 policy_server_mandatory_name = \"policy.internal\"\n\
+			 policy_server_mandatory_public_key = \"A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\"\n",
+			false,
+		),
+		("fail-closed without switch", "[global]\npolicy_server_fail_closed = true\n", false),
+		("fail-closed with switch", "[global]\nenable_policy_servers = true\npolicy_server_fail_closed = true\n", true),
+		("nothing set", "[global]\n", true),
+	] {
+		let config = config_from_toml(toml).expect("the config should parse");
+		let (result, _logs) = check_with_captured_logs(&config);
+		assert_eq!(result.is_ok(), ok, "{name}: {result:?}");
+	}
+}
+
 /// A documented default is published to operators through the generated
 /// tuwunel-example.toml, so one that disagrees with the code hands out a value
 /// the server never uses. Only integer defaults are compared; prose such as

--- a/src/service/federation/execute.rs
+++ b/src/service/federation/execute.rs
@@ -37,6 +37,43 @@ where
 	self.execute_on(client, dest, request).await
 }
 
+/// Sends a request to an operator-configured base URL instead of a resolved
+/// federation destination. Used for the mandatory policy server (MSC4284):
+/// the request is still signed as a federation request to `dest`, but the
+/// transport DELIBERATELY bypasses server-name resolution, the
+/// `allow_federation` switch, the forbidden-server list, the IP denylist and
+/// peer-status bookkeeping. The URL is trusted because the operator wrote it
+/// in the configuration; it is not a peer discovered from room state.
+#[implement(super::Service)]
+#[tracing::instrument(skip_all, name = "request_at", level = "debug")]
+pub async fn execute_at<T>(
+	&self,
+	base_url: &str,
+	dest: &ServerName,
+	request: T,
+) -> Result<T::IncomingResponse>
+where
+	T: OutgoingRequest + Debug + Send,
+	T::Authentication: FedAuth,
+	T::PathBuilder: FedPath,
+{
+	let client = &self.services.client.federation;
+	let request = self.to_http_request_at::<T>(base_url, dest, request)?;
+	let request = Request::try_from(request)?;
+	self.services.server.check_running()?;
+
+	let url = request.url().clone();
+	let method = request.method().clone();
+	let limit = self.services.server.config.max_response_size;
+	debug!(?method, ?url, "Sending request to configured URL");
+
+	let response = client.execute(request).await?;
+	let response = into_http_response(dest, base_url, &method, &url, response, limit).await?;
+
+	T::IncomingResponse::try_from_http_response(response)
+		.map_err(|e| err!(BadServerResponse("Server returned bad 200 response: {e:?}")))
+}
+
 /// Client-initiated key lookup (`/keys/query`, `/keys/claim`) over federation:
 /// skips servers already in backoff and bounds the request by
 /// `federation_keys_timeout` so a waiting client is not held past its own send
@@ -291,7 +328,8 @@ where
 	T::Authentication: FedAuth,
 	T::PathBuilder: FedPath,
 {
-	let response = into_http_response(dest, actual, method, url, response, limit).await?;
+	let response =
+		into_http_response(dest, &actual.to_string(), method, url, response, limit).await?;
 
 	T::IncomingResponse::try_from_http_response(response)
 		.map_err(|e| err!(BadServerResponse("Server returned bad 200 response: {e:?}")))
@@ -299,7 +337,7 @@ where
 
 async fn into_http_response(
 	dest: &ServerName,
-	actual: &ActualDest,
+	actual: &str,
 	method: &Method,
 	url: &Url,
 	mut response: Response,
@@ -310,8 +348,7 @@ async fn into_http_response(
 		?status, ?method,
 		request_url = ?url,
 		response_url = ?response.url(),
-		"Received response from {}",
-		actual.to_string(),
+		"Received response from {actual}",
 	);
 
 	let mut http_response_builder = http::Response::builder()
@@ -410,6 +447,22 @@ where
 	T::Authentication: FedAuth,
 	T::PathBuilder: FedPath,
 {
+	self.to_http_request_at::<T>(actual.to_string().as_str(), dest, request)
+}
+
+/// Builds and signs the federation request against an explicit base URL.
+#[implement(super::Service)]
+fn to_http_request_at<T>(
+	&self,
+	base_url: &str,
+	dest: &ServerName,
+	request: T,
+) -> Result<http::Request<Vec<u8>>>
+where
+	T: OutgoingRequest + Send,
+	T::Authentication: FedAuth,
+	T::PathBuilder: FedPath,
+{
 	const VERSIONS: [MatrixVersion; 1] = [MatrixVersion::V1_11];
 	let supported = SupportedVersions {
 		versions: VERSIONS.into(),
@@ -424,6 +477,6 @@ where
 	let path = T::PathBuilder::input(&supported);
 
 	request
-		.try_into_http_request::<Vec<u8>>(actual.to_string().as_str(), auth, path)
+		.try_into_http_request::<Vec<u8>>(base_url, auth, path)
 		.map_err(|e| err!(BadServerResponse("Invalid destination: {e:?}")))
 }

--- a/src/service/rooms/event_handler/policy_server.rs
+++ b/src/service/rooms/event_handler/policy_server.rs
@@ -12,7 +12,7 @@ use ruma::{
 		federation::policy::sign_event::v1 as sign_event,
 	},
 	events::{
-		StateEventType,
+		StateEventType, TimelineEventType,
 		room::policy::{POLICY_SERVER_ED25519_SIGNING_KEY_ID, RoomPolicyEventContent},
 	},
 	serde::Base64,
@@ -22,7 +22,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::to_raw_value;
 use tuwunel_core::{
 	Err, Result, at, debug, implement,
-	matrix::{Event, pdu::into_outgoing_federation, room_version::rules as room_version_rules},
+	matrix::{
+		Event,
+		pdu::into_outgoing_federation,
+		room_version::{from_create_event, rules as room_version_rules},
+	},
 	trace,
 	utils::time::now_secs,
 	warn,
@@ -104,6 +108,59 @@ enum PolicySigState {
 	},
 }
 
+/// Where `/sign` goes for a room: the room's own `m.room.policy` server
+/// (reached by federation resolution of `content.via`) or the operator's
+/// mandatory server (reached directly at `direct_url`). Signature slot, key
+/// and X-Matrix destination come from `content` in both cases, so the
+/// verification path is identical.
+#[derive(Clone, Debug)]
+pub(super) struct PolicyTarget {
+	pub content: RoomPolicyEventContent,
+	pub direct_url: Option<String>,
+}
+
+/// What a caller does with a `/sign` outcome that yielded no signature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Reaction {
+	/// Send or accept the event unsigned.
+	Proceed,
+	/// Refuse the local send; soft-fail the inbound event.
+	Reject,
+}
+
+/// The single place where fail-open versus fail-closed is decided. An explicit
+/// refusal always rejects; a signature always proceeds; everything in between
+/// (transport failure, timeout, rate-limit backoff) follows the switch.
+fn react_to_fetch(outcome: &FetchOutcome, fail_closed: bool) -> Reaction {
+	match outcome {
+		| FetchOutcome::Signed(_) => Reaction::Proceed,
+		| FetchOutcome::Refused { .. } => Reaction::Reject,
+		| FetchOutcome::FailOpen | FetchOutcome::RateLimited { .. } =>
+			if fail_closed {
+				Reaction::Reject
+			} else {
+				Reaction::Proceed
+			},
+	}
+}
+
+/// The mandatory server, when configured, is consulted for every room and the
+/// room's own `m.room.policy` is not consulted at all — otherwise a room could
+/// opt out of a deployment-wide control by unsetting one state event.
+fn resolve_policy_target(
+	mandatory: Option<(OwnedServerName, Base64, String)>,
+	room: Option<RoomPolicyEventContent>,
+) -> Option<PolicyTarget> {
+	if let Some((name, key, url)) = mandatory {
+		return Some(PolicyTarget {
+			content: RoomPolicyEventContent::new(name, key),
+			direct_url: Some(url),
+		});
+	}
+
+	room.map(|content| PolicyTarget { content, direct_url: None })
+}
+
 /// Lenient deserialiser that accepts either the stable
 /// `public_keys: { ed25519: ... }` shape or the MSC4284 unstable singular
 /// `public_key: <ed25519>` shape, and folds the latter into the former.
@@ -182,6 +239,28 @@ fn current_policy_state(
 		})
 }
 
+/// The policy target for a room: the operator's mandatory server if
+/// configured (without touching room state), else the room's own.
+#[implement(super::Service)]
+pub(super) async fn lookup_policy_target(&self, room_id: &RoomId) -> Option<PolicyTarget> {
+	let config = &self.services.server.config;
+	let mandatory = match (
+		&config.policy_server_mandatory_url,
+		&config.policy_server_mandatory_name,
+		&config.policy_server_mandatory_public_key,
+	) {
+		| (Some(url), Some(name), Some(key)) =>
+			Some((name.clone(), key.clone(), url.to_string())),
+		| _ => None,
+	};
+
+	if mandatory.is_some() {
+		return resolve_policy_target(mandatory, None);
+	}
+
+	resolve_policy_target(None, self.lookup_policy_server(room_id).await)
+}
+
 /// Returns the room's policy event content when a policy server is in effect:
 /// state event present (stable `m.room.policy`, falling back to MSC4284's
 /// unstable `org.matrix.msc4284.policy`), parses cleanly under either the
@@ -231,19 +310,30 @@ where
 		return Ok(());
 	}
 
-	let Ok(room_version) = self
+	// The create event has no room state yet, so its version comes from its
+	// own content. Without this the mandatory policy server would never see
+	// room creation at all.
+	let room_version = match self
 		.services
 		.state
 		.get_room_version(pdu.room_id())
 		.await
-	else {
-		return Ok(());
+	{
+		| Ok(room_version) => room_version,
+		| Err(_) if *pdu.kind() == TimelineEventType::RoomCreate => from_create_event(pdu)?,
+		| Err(_) => return Ok(()),
 	};
 
-	let Some(policy) = self.lookup_policy_server(pdu.room_id()).await else {
+	let Some(target) = self.lookup_policy_target(pdu.room_id()).await else {
 		trace!(room_id = %pdu.room_id(), "no policy server configured");
 		return Ok(());
 	};
+	let policy = &target.content;
+	let fail_closed = self
+		.services
+		.server
+		.config
+		.policy_server_fail_closed;
 
 	let event_id = pdu.event_id();
 	match self.cached_policy_state(event_id).await {
@@ -252,17 +342,23 @@ where
 
 		| Some(PolicySigState::BackoffUntil { until_secs }) if until_secs > now_secs() => {
 			debug!(via = %policy.via, until_secs, "skipping outbound /sign during policy backoff");
+			if fail_closed {
+				return Err!(Request(Unknown(
+					"Policy server is in backoff and policy_server_fail_closed is set."
+				)));
+			}
 			return Ok(());
 		},
 		| _ => {},
 	}
 
-	match self
-		.fetch_policy_signature(&policy, pdu_json, &room_version)
-		.await
-	{
+	let outcome = self
+		.fetch_policy_signature(&target, pdu_json, &room_version)
+		.await;
+
+	match &outcome {
 		| FetchOutcome::Signed(signature) => {
-			insert_policy_signature(pdu_json, &policy.via, &signature);
+			insert_policy_signature(pdu_json, &policy.via, signature);
 			debug!(via = %policy.via, event_id = %event_id, "folded policy server signature");
 		},
 		| FetchOutcome::Refused { status, errcode } => {
@@ -279,9 +375,20 @@ where
 			return Err!(Request(Forbidden("Event was rejected by the room's policy server.")));
 		},
 		| FetchOutcome::RateLimited { until_secs } => {
-			self.cache_policy_backoff(event_id, until_secs);
+			self.cache_policy_backoff(event_id, *until_secs);
 		},
 		| FetchOutcome::FailOpen => {},
+	}
+
+	if react_to_fetch(&outcome, fail_closed) == Reaction::Reject {
+		warn!(
+			via = %policy.via,
+			event_id = %event_id,
+			"policy server unreachable and policy_server_fail_closed is set; refusing"
+		);
+		return Err!(Request(Unknown(
+			"Policy server unreachable and policy_server_fail_closed is set."
+		)));
 	}
 
 	Ok(())
@@ -295,14 +402,15 @@ where
 	name = "policy_fetch",
 	level = "debug",
 	skip_all,
-	fields(via = %policy.via)
+	fields(via = %target.content.via)
 )]
 async fn fetch_policy_signature(
 	&self,
-	policy: &RoomPolicyEventContent,
+	target: &PolicyTarget,
 	pdu_json: &CanonicalJsonObject,
 	room_version: &RoomVersionId,
 ) -> FetchOutcome {
+	let policy = &target.content;
 	let outgoing = into_outgoing_federation(pdu_json.clone(), room_version);
 	let Ok(raw) = to_raw_value(&outgoing) else {
 		warn!(via = %policy.via, "failed to serialize PDU for policy /sign; failing open");
@@ -318,9 +426,7 @@ async fn fetch_policy_signature(
 
 	let response = match tokio::time::timeout(
 		timeout,
-		self.services
-			.federation
-			.execute(&policy.via, sign_event::Request::new(raw)),
+		self.call_sign(target, sign_event::Request::new(raw)),
 	)
 	.await
 	{
@@ -379,6 +485,27 @@ async fn fetch_policy_signature(
 			FetchOutcome::Refused { status: StatusCode::OK, errcode: None },
 			FetchOutcome::Signed,
 		)
+}
+
+/// One `/sign` round-trip over the transport the target asks for.
+#[implement(super::Service)]
+async fn call_sign(
+	&self,
+	target: &PolicyTarget,
+	request: sign_event::Request,
+) -> Result<sign_event::Response> {
+	match &target.direct_url {
+		| Some(base_url) =>
+			self.services
+				.federation
+				.execute_at(base_url, &target.content.via, request)
+				.await,
+		| None =>
+			self.services
+				.federation
+				.execute(&target.content.via, request)
+				.await,
+	}
 }
 
 fn classify_fetch_error(
@@ -449,8 +576,19 @@ async fn fetch_inbound_policy_signature<E>(
 where
 	E: Event,
 {
-	let Some(policy) = self.lookup_policy_server(pdu.room_id()).await else {
+	let Some(target) = self.lookup_policy_target(pdu.room_id()).await else {
 		return PolicyCheck::NotApplicable;
+	};
+	let policy = &target.content;
+	let fail_closed = self
+		.services
+		.server
+		.config
+		.policy_server_fail_closed;
+	let unreachable = if fail_closed {
+		PolicyCheck::Invalid
+	} else {
+		PolicyCheck::Pass
 	};
 
 	let Ok(room_version) = self
@@ -469,18 +607,20 @@ where
 			debug!(
 				until_secs,
 				via = %policy.via,
-				"policy server in backoff; failing open"
+				fail_closed,
+				"policy server in backoff"
 			);
 
-			return PolicyCheck::Pass;
+			return unreachable;
 		},
 		| _ => {},
 	}
 
-	match self
-		.fetch_policy_signature(&policy, pdu_json, &room_version)
-		.await
-	{
+	let outcome = self
+		.fetch_policy_signature(&target, pdu_json, &room_version)
+		.await;
+
+	match &outcome {
 		| FetchOutcome::Signed(signature) => {
 			debug!(
 				via = %policy.via,
@@ -488,8 +628,8 @@ where
 				"folded inbound policy server signature"
 			);
 
-			insert_policy_signature(pdu_json, &policy.via, &signature);
-			PolicyCheck::Pass
+			insert_policy_signature(pdu_json, &policy.via, signature);
+			return PolicyCheck::Pass;
 		},
 		| FetchOutcome::Refused { status, errcode } => {
 			warn!(
@@ -502,13 +642,17 @@ where
 			);
 
 			self.cache_policy_refused(event_id);
-			PolicyCheck::Invalid
+			return PolicyCheck::Invalid;
 		},
 		| FetchOutcome::RateLimited { until_secs } => {
-			self.cache_policy_backoff(event_id, until_secs);
-			PolicyCheck::Pass
+			self.cache_policy_backoff(event_id, *until_secs);
 		},
-		| FetchOutcome::FailOpen => PolicyCheck::Pass,
+		| FetchOutcome::FailOpen => {},
+	}
+
+	match react_to_fetch(&outcome, fail_closed) {
+		| Reaction::Proceed => PolicyCheck::Pass,
+		| Reaction::Reject => PolicyCheck::Invalid,
 	}
 }
 
@@ -535,9 +679,10 @@ where
 		return PolicyCheck::NotApplicable;
 	}
 
-	let Some(policy) = self.lookup_policy_server(pdu.room_id()).await else {
+	let Some(target) = self.lookup_policy_target(pdu.room_id()).await else {
 		return PolicyCheck::NotApplicable;
 	};
+	let policy = &target.content;
 
 	let Ok(room_version) = self
 		.services
@@ -548,7 +693,8 @@ where
 		return PolicyCheck::NotApplicable;
 	};
 
-	// `lookup_policy_server` already verified the ed25519 entry is present.
+	// Both target kinds carry an ed25519 entry: the room lookup verified it,
+	// and the mandatory target is built from one.
 	let Some(public_key) = policy
 		.public_keys
 		.get(&SigningKeyAlgorithm::Ed25519)

--- a/src/service/rooms/event_handler/policy_server/tests.rs
+++ b/src/service/rooms/event_handler/policy_server/tests.rs
@@ -2,14 +2,16 @@ use http::StatusCode;
 use ruma::{
 	CanonicalJsonObject, CanonicalJsonValue, OwnedEventId, OwnedServerName, RoomVersionId,
 	api::error::{ErrorKind, LimitExceededErrorData},
+	events::room::policy::RoomPolicyEventContent,
 	serde::Base64,
 };
 use serde::{Deserialize, Serialize};
 use tuwunel_database::{Cbor, deserialize_from_slice, serialize_to_vec};
 
 use super::{
-	FetchOutcome, POLICY_REFUSAL_TTL, PolicyCheck, PolicySigState, check_policy_signature,
-	classify_fetch_error, current_policy_state, insert_policy_signature,
+	FetchOutcome, POLICY_REFUSAL_TTL, PolicyCheck, PolicySigState, Reaction,
+	check_policy_signature, classify_fetch_error, current_policy_state, insert_policy_signature,
+	react_to_fetch, resolve_policy_target,
 };
 
 #[derive(Deserialize)]
@@ -206,4 +208,86 @@ fn treats_old_refusal_encoding_as_absent() {
 	let decoded = deserialize_from_slice::<Cbor<PolicySigState>>(&encoded);
 
 	assert!(current_policy_state(decoded, 0).is_none());
+}
+
+/// Fail-open versus fail-closed is one function, so it is one table: refusal
+/// always rejects, a signature always proceeds, and only the transport-shaped
+/// outcomes follow the switch.
+#[test]
+fn reacts_to_fetch_outcomes_per_fail_closed_switch() {
+	let cases = [
+		("signed, open", FetchOutcome::Signed("sig".to_owned()), false, Reaction::Proceed),
+		(
+			"signed, closed",
+			FetchOutcome::Signed("sig".to_owned()),
+			true,
+			Reaction::Proceed,
+		),
+		(
+			"refused, open",
+			FetchOutcome::Refused {
+				status: StatusCode::BAD_REQUEST,
+				errcode: Some(ErrorKind::Forbidden),
+			},
+			false,
+			Reaction::Reject,
+		),
+		(
+			"refused, closed",
+			FetchOutcome::Refused {
+				status: StatusCode::BAD_REQUEST,
+				errcode: Some(ErrorKind::Forbidden),
+			},
+			true,
+			Reaction::Reject,
+		),
+		("transport, open", FetchOutcome::FailOpen, false, Reaction::Proceed),
+		("transport, closed", FetchOutcome::FailOpen, true, Reaction::Reject),
+		(
+			"rate-limited, open",
+			FetchOutcome::RateLimited { until_secs: 1 },
+			false,
+			Reaction::Proceed,
+		),
+		(
+			"rate-limited, closed",
+			FetchOutcome::RateLimited { until_secs: 1 },
+			true,
+			Reaction::Reject,
+		),
+	];
+
+	for (name, outcome, fail_closed, expected) in cases {
+		assert_eq!(react_to_fetch(&outcome, fail_closed), expected, "{name}");
+	}
+}
+
+/// The mandatory server takes precedence over the room's own, and a room's
+/// own is used only when no mandatory server is configured.
+#[test]
+fn mandatory_policy_server_wins_over_the_room_state() {
+	let key = Base64::parse("A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg").expect("valid base64");
+	let room_key =
+		Base64::parse("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").expect("valid base64");
+	let mandatory_name: OwnedServerName = "policy.internal".try_into().expect("valid name");
+	let room_name: OwnedServerName = "policy.example.org"
+		.try_into()
+		.expect("valid name");
+	let mandatory =
+		Some((mandatory_name.clone(), key, "https://policy.internal:8448".to_owned()));
+	let room = Some(RoomPolicyEventContent::new(room_name.clone(), room_key));
+
+	let target =
+		resolve_policy_target(mandatory.clone(), room.clone()).expect("mandatory target");
+	assert_eq!(target.content.via, mandatory_name);
+	assert_eq!(target.direct_url.as_deref(), Some("https://policy.internal:8448"));
+
+	let target = resolve_policy_target(mandatory, None).expect("mandatory target without room");
+	assert_eq!(target.content.via, mandatory_name);
+
+	let target = resolve_policy_target(None, room).expect("room target");
+	assert_eq!(target.content.via, room_name);
+	assert!(target.direct_url.is_none(), "a room's own server is resolved by federation");
+
+	assert!(resolve_policy_target(None, None).is_none());
 }

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1172,6 +1172,50 @@
 #
 #policy_server_request_timeout = 5
 
+# MSC4284: an operator-configured policy server consulted for EVERY
+# local event, regardless of whether the room carries an `m.room.policy`
+# state event. `/sign` is sent directly to this base URL, bypassing
+# federation server-name resolution, the `allow_federation` switch, the
+# `forbidden_remote_server_names` list, the `ip_range_denylist` and the
+# "policy server must be joined to the room" rule — the URL is trusted
+# because the operator wrote it. Use this when the policy server is a
+# moderation control of this deployment rather than a room's choice.
+#
+# Requires `enable_policy_servers` and both companion fields below.
+#
+# reloadable: yes
+#
+#policy_server_mandatory_url = "https://policy.internal:8448"
+
+# MSC4284: the server name the mandatory policy server signs as. It is
+# the key under `event.signatures` and the X-Matrix `destination` of the
+# `/sign` request, and must equal the name the policy server uses for
+# itself.
+#
+# reloadable: yes
+#
+#policy_server_mandatory_name = "policy.internal"
+
+# MSC4284: the mandatory policy server's ed25519 public key, unpadded
+# base64, as it would appear in `m.room.policy` `public_keys.ed25519`.
+# Inbound signatures are verified against it exactly as room-configured
+# keys are.
+#
+# reloadable: yes
+#
+#policy_server_mandatory_public_key = "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+
+# MSC4284: when the policy server cannot be reached (network error,
+# timeout, or rate-limit backoff), refuse the local send instead of
+# letting it through. Off by default: a transient policy-server outage
+# then degrades to unsigned events. Turn it on when the policy server is
+# a hard requirement of the deployment and its availability is managed
+# accordingly.
+#
+# reloadable: yes
+#
+#policy_server_fail_closed = false
+
 # MSC3925: fold the most recent message edit (an `m.replace` relation)
 # into `unsigned.m.relations` on a served event as the full replacement
 # event, on the client read endpoints. Off by default: it adds a typed


### PR DESCRIPTION
Adds four opt-in `[global]` knobs. With them unset, behaviour is byte-for-byte upstream.

| knob | meaning |
|---|---|
| `policy_server_mandatory_url` | `/sign` target for **every** local event, bypassing the federation resolver, `allow_federation`, the denylist, and the "policy server must have a user in the room" requirement |
| `policy_server_mandatory_name` | name used in the `signatures[...]` slot and the X-Matrix `destination` |
| `policy_server_mandatory_public_key` | ed25519 key used to verify the signature that comes back |
| `policy_server_fail_closed` | policy server unreachable / timing out / in backoff → **reject** the send (default `false`, i.e. today's behaviour) |

The three `mandatory_*` knobs are all-or-nothing and require `enable_policy_servers`; `config/check.rs` enforces that.

## Why

Deployments that must guarantee a policy decision on every event cannot rely on `m.room.policy`: it is room state, so a room creator can remove it. In v12 rooms that removal is itself not policed, so the guard disappears **silently**.

Fail-open is also the wrong default for those deployments — an unreachable policy server currently means events flow unchecked, which is indistinguishable from a policy that allows everything.

## Implementation

- `PolicyTarget` + `lookup_policy_target` in `policy_server.rs` — the mandatory target short-circuits the resolver.
- `federation.execute_at` in `federation/execute.rs` — sends to an explicit URL/name pair instead of resolving a server name.
- `react_to_fetch` is now pure, with table tests.
- `m.room.create` is evaluated too. The room version is read from the create event's own content; without that the existing guard skips it silently — exactly the hole this mode exists to close.

`tuwunel-example.toml` is regenerated by the proc-macro at compile time, not hand-edited.

## Testing

`cargo +nightly fmt --check` and `cargo clippy --workspace --all-targets` are clean.

Behaviour is proven end-to-end against a real tuwunel binary and a stub policy server — not mocked:

- every local event calls `/sign`, including `m.room.create`
- rejections come back as 403 `M_FORBIDDEN`
- `/sign` carries X-Matrix with `destination` set to the configured name
- a v12 room whose creator **removes** `m.room.policy` is still policed
- with `fail_closed = true`, a policy server returning 500 — or entirely down — rejects the send, and the warning names `fail_closed`
- **control:** with `fail_closed = false` the same dead server lets the event through, matching current behaviour

Happy to adjust naming, split the commit, or move the fail-closed knob under a different section if you prefer.