### PR TITLE
sync: include quiet rooms in full-state responses

### DIFF
--- a/src/api/client/sync/v3.rs
+++ b/src/api/client/sync/v3.rs
@@ -1102,7 +1102,7 @@ async fn load_joined_room(
 		next_batch,
 		&timeline_pdus,
 		last_timeline_count,
-		timeline_changed,
+		timeline_changed || full_state || initial,
 		state_after,
 	)
 	.boxed()
@@ -1636,10 +1636,10 @@ async fn gather_room_metadata(
 	next_batch: u64,
 	timeline_pdus: &[(PduCount, PduEvent)],
 	last_timeline_count: PduCount,
-	timeline_changed: bool,
+	include_state: bool,
 	state_after: StateAfter,
 ) -> Result<RoomMetadata> {
-	let since_shortstatehash = timeline_changed.then_async(|| {
+	let since_shortstatehash = include_state.then_async(|| {
 		services
 			.timeline
 			.prev_shortstatehash(room_id, PduCount::Normal(since).saturating_add(1))
@@ -1668,17 +1668,29 @@ async fn gather_room_metadata(
 			.inspect_err(inspect_debug_log)
 	});
 
-	let current_shortstatehash = timeline_changed.then_async(|| {
-		services
-			.timeline
-			.get_shortstatehash(room_id, last_timeline_count)
-			.inspect_err(inspect_debug_log)
+	let current_shortstatehash = include_state.then_async(async || {
+		// An empty timeline needs state after the last event, not before it.
+		let state = async {
+			if timeline_pdus.is_empty() {
+				services
+					.timeline
+					.next_shortstatehash(room_id, last_timeline_count)
+					.await
+			} else {
+				services
+					.timeline
+					.get_shortstatehash(room_id, last_timeline_count)
+					.await
+			}
+		};
+		state
 			.or_else(|_| services.state.get_room_shortstatehash(room_id))
+			.await
 			.map_err(|_| err!(Database(error!("Room {room_id} has no state"))))
 	});
 
 	let encrypted_room =
-		timeline_changed.then_async(|| services.state_accessor.is_encrypted_room(room_id));
+		include_state.then_async(|| services.state_accessor.is_encrypted_room(room_id));
 
 	let receipt_events = services
 		.read_receipt

--- a/src/main/tests/sync_full_state.rs
+++ b/src/main/tests/sync_full_state.rs
@@ -1,0 +1,263 @@
+#![cfg(test)]
+
+use std::{env::temp_dir, fs::remove_dir_all, net::TcpListener};
+
+use futures::future::join;
+use serde_json::{Value, json};
+use tuwunel::{Args, Runtime, Server, async_run, async_start, async_stop};
+use tuwunel_core::{
+	Err, Result, err,
+	ruma::{RoomId, UserId},
+	utils::random_string,
+};
+use tuwunel_service::Services;
+
+use self::client::{Client, field, register, wait_until_ready};
+
+mod client;
+
+const ACCESS_TOKEN: &str = "sync-full-state-test-access-token";
+const EMPTY_TIMELINE: &str = r#"{"room":{"timeline":{"limit":0}}}"#;
+
+/// Full-state responses must carry quiet rooms and their latest state even
+/// when the timeline is empty, without making ordinary incremental sync noisy.
+#[test]
+fn full_state_includes_quiet_joined_rooms() -> Result {
+	let listener = TcpListener::bind(("127.0.0.1", 0))?;
+	let port = listener.local_addr()?.port();
+	let db_path = temp_dir().join(format!("tuwunel-sync-full-state-{}", random_string(32)));
+	let args = Args::default_test(&["fresh", "cleanup"])
+		.with_option(format!("database_path={db_path:?}"))
+		.with_option("address=[\"127.0.0.1\"]")
+		.with_option(format!("port={port}"))
+		.with_option("listening=true");
+
+	let runtime = Runtime::new(Some(&args))?;
+	let server = Server::new(Some(&args), Some(&runtime))?;
+	let result = runtime.block_on(async {
+		let services = async_start(&server).await?;
+		let base = format!("http://127.0.0.1:{port}");
+
+		drop(listener);
+
+		let exercise = async {
+			let outcome = exercise(&services, &base).await;
+			let shutdown = server.server.shutdown();
+
+			outcome.and(shutdown)
+		};
+		let (run_result, outcome) = join(async_run(&server), exercise).await;
+
+		drop(services);
+		async_stop(&server).await?;
+		run_result?;
+
+		outcome
+	});
+
+	drop(runtime);
+	remove_dir_all(&db_path).ok();
+
+	result
+}
+
+async fn exercise(services: &Services, base: &str) -> Result {
+	wait_until_ready(services, base).await?;
+
+	let user = register(services, "fullstate", ACCESS_TOKEN).await?;
+	let client = Client { services, base, token: ACCESS_TOKEN };
+	let plain = client
+		.create_room(&json!({"preset": "private_chat"}))
+		.await?;
+	let encrypted = client
+		.create_room(&json!({"preset": "private_chat"}))
+		.await?;
+
+	// Make these the last events in their rooms: state-before-last-event
+	// would lose the topic or encryption, with no timeline event to restore it.
+	for (room, event_type, content) in [
+		(&plain, "m.room.topic", json!({"topic": "quiet plain room"})),
+		(&encrypted, "m.room.encryption", json!({"algorithm": "m.megolm.v1.aes-sha2"})),
+	] {
+		services
+			.client
+			.clients
+			.default
+			.put(client.url(&format!("rooms/{room}/state/{event_type}")))
+			.bearer_auth(ACCESS_TOKEN)
+			.json(&content)
+			.send()
+			.await?
+			.error_for_status()?;
+	}
+
+	let initial = sync(&client, &[]).await?;
+	let since = field(&initial, "next_batch")?;
+	let incremental = sync(&client, &[("since", since)]).await?;
+	for room in [&plain, &encrypted] {
+		if incremental["rooms"]["join"]
+			.get(room.as_str())
+			.is_some()
+		{
+			return Err!("ordinary incremental sync included a quiet room");
+		}
+	}
+
+	let mut failures = Vec::new();
+	for (case, query, state_field) in [
+		(
+			"quiet full state",
+			[("since", since), ("full_state", "true")].as_slice(),
+			"state",
+		),
+		("initial empty timeline", [("filter", EMPTY_TIMELINE)].as_slice(), "state"),
+		(
+			"initial full state with empty timeline",
+			[("full_state", "true"), ("filter", EMPTY_TIMELINE)].as_slice(),
+			"state",
+		),
+		(
+			"incremental full state with empty timeline",
+			[("since", since), ("full_state", "true"), ("filter", EMPTY_TIMELINE)].as_slice(),
+			"state",
+		),
+		(
+			"quiet stable state after",
+			[("since", since), ("full_state", "true"), ("use_state_after", "true")].as_slice(),
+			"state_after",
+		),
+		(
+			"quiet unstable state after",
+			[
+				("since", since),
+				("full_state", "true"),
+				("org.matrix.msc4222.use_state_after", "true"),
+			]
+			.as_slice(),
+			"org.matrix.msc4222.state_after",
+		),
+	] {
+		let response = sync(&client, query).await?;
+		for (room, encrypted) in [(&plain, false), (&encrypted, true)] {
+			if let Err(error) = check_room(&response, room, &user, encrypted, state_field) {
+				failures.push(format!("{case}: {room}: {error}"));
+			}
+		}
+	}
+
+	// A nonempty timeline keeps legacy state before its first event. The last
+	// topic/encryption event belongs in this one-event timeline, not that state.
+	let nonempty = sync(&client, &[
+		("full_state", "true"),
+		("filter", r#"{"room":{"timeline":{"limit":1}}}"#),
+	])
+	.await?;
+	for (room, event_type, content_key, expected) in [
+		(&plain, "m.room.topic", "topic", "quiet plain room"),
+		(&encrypted, "m.room.encryption", "algorithm", "m.megolm.v1.aes-sha2"),
+	] {
+		let joined = &nonempty["rooms"]["join"][room.as_str()];
+		let timeline = joined["timeline"]["events"]
+			.as_array()
+			.ok_or_else(|| err!("nonempty full-state response omitted the timeline"))?;
+		if timeline.len() != 1
+			|| state_event(timeline, event_type, "")?["content"][content_key] != expected
+		{
+			return Err!("nonempty full-state response lost its final state event");
+		}
+
+		let state = joined["state"]["events"]
+			.as_array()
+			.ok_or_else(|| err!("nonempty full-state response omitted legacy state"))?;
+		state_event(state, "m.room.create", "")?;
+		if state_event(state, "m.room.member", user.as_str())?["content"]["membership"] != "join"
+		{
+			return Err!(
+				"nonempty full-state response lost the syncing user's joined membership"
+			);
+		}
+		if state_event(state, event_type, "").is_ok() {
+			return Err!("legacy state included the event at the start of its timeline");
+		}
+	}
+
+	if !failures.is_empty() {
+		return Err!("full-state response failures: {failures:?}");
+	}
+
+	Ok(())
+}
+
+async fn sync(client: &Client<'_>, query: &[(&str, &str)]) -> Result<Value> {
+	Ok(client
+		.services
+		.client
+		.clients
+		.default
+		.get(client.url("sync"))
+		.bearer_auth(client.token)
+		.query(&[("timeout", "0")])
+		.query(query)
+		.send()
+		.await?
+		.error_for_status()?
+		.json()
+		.await?)
+}
+
+fn check_room(
+	response: &Value,
+	room: &RoomId,
+	user: &UserId,
+	encrypted: bool,
+	state_field: &str,
+) -> Result {
+	let joined = &response["rooms"]["join"][room.as_str()];
+	let state = joined[state_field]["events"]
+		.as_array()
+		.ok_or_else(|| err!("quiet room omitted requested state"))?;
+
+	if joined["timeline"]["events"]
+		.as_array()
+		.is_some_and(|events| !events.is_empty())
+	{
+		return Err!("quiet room unexpectedly has timeline events");
+	}
+	if state_field != "state" && joined.get("state").is_some() {
+		return Err!("state-after response also included legacy state");
+	}
+
+	state_event(state, "m.room.create", "")?;
+	let member = state_event(state, "m.room.member", user.as_str())?;
+	if member["content"]["membership"] != "join" {
+		return Err!("full state lost the syncing user's joined membership");
+	}
+
+	if encrypted {
+		let encryption = state_event(state, "m.room.encryption", "")?;
+		if encryption["content"]["algorithm"] != "m.megolm.v1.aes-sha2"
+			|| encryption["unsigned"]["membership"] != "join"
+		{
+			return Err!("full state lost encryption content or membership annotation");
+		}
+	} else {
+		if state
+			.iter()
+			.any(|event| event["type"] == "m.room.encryption")
+		{
+			return Err!("plain room unexpectedly has encryption state");
+		}
+		if state_event(state, "m.room.topic", "")?["content"]["topic"] != "quiet plain room" {
+			return Err!("full state lost the latest topic");
+		}
+	}
+
+	Ok(())
+}
+
+fn state_event<'a>(state: &'a [Value], event_type: &str, key: &str) -> Result<&'a Value> {
+	state
+		.iter()
+		.find(|event| event["type"] == event_type && event["state_key"] == key)
+		.ok_or_else(|| err!("full state omitted {event_type} with key {key}"))
+}


### PR DESCRIPTION
### What does this PR do?

While checking a full-state sync fix just merged into the fork, I confirmed that upstream still drops quiet joined rooms from `/sync` when the request includes both `since` and `full_state=true`. The timeline has no new events, so `gather_room_metadata` skips the room's state hashes and encryption metadata. Without those, the room can disappear from the response even though the client explicitly asked for its full state.

This gathers state metadata for full-state and initial syncs as well as rooms with new timeline events. Ordinary incremental syncs still omit unchanged rooms. This follows the [`full_state` contract](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3sync): supplying `since` limits the timeline, but does not suppress the requested room state.

There is a related boundary case when the timeline is empty. The state needs to include the last event in the room; taking the state before that event loses a final topic or encryption event, and there is no timeline event for the client to apply afterward. The fix selects state after the last event for empty timelines. Nonempty timelines keep the existing state-before-timeline behavior.

The regression uses the existing server-booting HTTP harness and a real database, with one plain room and one encrypted room. It checks quiet full-state syncs, initial and incremental requests with a zero timeline limit, ordinary incremental omission, and both stable and unstable state-after responses. It also checks the latest topic, encryption content and membership annotation, and the legacy state boundary for a one-event timeline.

The production change matches the fix merged into the fork; only the test was adapted to the upstream harness. No fork-specific CI, dependencies, or configuration changes are included.

Verified in the pinned Nix dynamic shell:

- `cargo fmt --all -- --check` — passed with the pinned nightly formatter and current nightly.
- `cargo clippy --offline --locked --workspace --all-targets --all-features -- -D warnings` — passed with pinned Rust 1.95.0; the current-nightly Clippy check also passed with the CI profile and compiler flags.
- `cargo test --offline --locked -p tuwunel --all-features --test sync_full_state` — passed.
- `cargo test --offline --locked --workspace --all-targets --all-features` — 1,156 passed, 0 failed, 4 ignored.

I first ran the regression against unchanged upstream: all twelve empty-timeline case/room combinations failed, either omitting the quiet room or losing its latest topic/encryption state. They pass with the fix. All server tests ran with isolated networking and storage.

### Checklist

- [x] Nightly formatting and pinned/current Clippy checks pass.
- [x] Complement was not run locally; no compliance-result changes are claimed. Its CI result diff still needs review.
- [x] No public configuration options changed, so no example-config regeneration is needed.
- [x] This restores existing sync behavior without adding an operator-facing feature or setup requirement.
- [x] I agree to the Apache-2.0 licensing terms and the project's Code of Conduct.
