### PR TITLE
client/admin: Leave the user's rooms on the Synapse deactivate endpoint.

### DIFF
--- a/src/api/client/admin/users/deactivate_account.rs
+++ b/src/api/client/admin/users/deactivate_account.rs
@@ -20,13 +20,9 @@ pub(crate) async fn admin_deactivate_account_route(
 	}
 
 	services
-		.users
-		.deactivate_account(&body.user_id)
+		.deactivate
+		.full_deactivate(&body.user_id, body.erase)
 		.await?;
-
-	if body.erase {
-		services.users.set_erased(&body.user_id);
-	}
 
 	Ok(deactivate_account::Response::new("success".to_owned()))
 }


### PR DESCRIPTION
### What does this PR do?

`POST /_synapse/admin/v1/deactivate/{user_id}` called `users::deactivate_account`,
which revokes access tokens, removes devices and blanks the password hash but does
not touch room membership. The route answered `success` while the account stayed
joined to every room it was in.

Every other deactivation path in the tree already goes through
`deactivate::full_deactivate`:

- `/_matrix/client/v3/account/deactivate`, whose own doc comment leads with
  "Leaves all rooms and rejects all invitations"
- `/_synapse/mas/delete_user`
- the membership handler's auto-deactivation
- the admin room's `users deactivate`, which offers `no_leave_rooms` as an
  explicit opt-out — and `docs/moderation.md` says the command "by default also
  leaves all rooms"

So leaving the rooms is the default and staying is what a caller has to ask for.
The Synapse admin route was the only path that behaved as though `no_leave_rooms`
were permanently set, with no way to select the default. Synapse documents this
endpoint as performing "Removal from all rooms the user is a member of" alongside
deleting devices, tokens and the password hash, and
`docs/development/compliance/synapse-admin.md` already marks it as served.

`full_deactivate` is also a superset of the `set_erased` this replaces: on `erase`
it marks the user erased *and* clears their account data per MSC4025, which the
route did not do. The rooms are left by the user rather than taken from them, so
no power level in any room is involved.

Observed against v1.9.0 on a live server: before the change a deactivated account
remained in the member list of a room it had joined, and the other member's client
still showed it; after, the account leaves and the other client sees the leave. The
change here is against `main`, where `full_deactivate`'s internals moved in
1271bb02c but its signature did not.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and rustc
      lints; any allowed lint is justified by an obvious reason or a comment.
      — `cargo +nightly fmt --check` and `cargo +nightly clippy --workspace
      --all-targets` are both clean on this branch. No lint is allowed or
      suppressed.
- [x] Complement compliance changes (new passes or new failures), if any, are
      noted in the description above. — none; Complement was not run for this
      change, and it touches no federation or client-server behaviour Complement
      exercises.
- [x] Config option changes were made in `src/core/config/mod.rs` doc comments
      and the regenerated `tuwunel-example.toml` is committed. — n/a, no config
      option is added or changed.
- [x] User-facing changes are reflected in `docs/`. — n/a. The compliance table's
      row for this endpoint does not describe room membership either way, so it
      needs no edit; this change makes its existing entry accurate.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence and my
      conduct is in line with the Contributor's Covenant and Tuwunel's Code of
      Conduct.
