### PR TITLE
client/admin: Leave the user's rooms when deactivating through the us…

### DIFF
--- a/src/api/client/admin/users/create_or_modify.rs
+++ b/src/api/client/admin/users/create_or_modify.rs
@@ -92,7 +92,11 @@ pub(crate) async fn admin_create_or_modify_route(
 	}
 
 	match body.deactivated {
-		| Some(true) => services.users.deactivate_account(user_id).await?,
+		| Some(true) =>
+			services
+				.deactivate
+				.full_deactivate(user_id, false)
+				.await?,
 		| Some(false)
 			if services
 				.users


### PR DESCRIPTION
### What does this PR do?

Sibling of #584, in the second and last place with the same defect. Independent
of it — different file, no conflict, either can merge first.

`PUT /_synapse/admin/v2/users/{user_id}` with `deactivated: true` calls
`users::deactivate_account`, which revokes access tokens, removes devices and
blanks the password hash but does not touch room membership. Together with
`POST /_synapse/admin/v1/deactivate/{user_id}` these were the only two callers of
that method among the Synapse admin routes, and the only deactivation paths in
the tree that left the account joined to its rooms — every other one already goes
through `deactivate::full_deactivate`.

Synapse treats the two endpoints as one operation rather than two: both of its
servlets call `deactivate_account_handler.deactivate_account`, the update endpoint
simply passing `erase=False`, and the documentation for the `deactivated` field
defers to the Deactivate Account section for what deactivation performs — which
lists "Removal from all rooms the user is a member of".

`erase` stays false, matching both the endpoint's documented limit ("a user cannot
be erased with this API") and what Synapse passes at that call site.

Two consequences worth stating rather than leaving to be discovered, both of which
are equally true of Synapse:

- Deactivation clears the profile this route may have set a few lines above.
  Synapse orders `displayname` and `avatar_url` before `deactivated` in the same
  handler, so the same is true there.
- Reactivating through this endpoint does not rejoin the rooms. Synapse's
  `activate_account` restores no membership either, and its documentation already
  notes that a reactivated user needs a new password.

So this brings the behaviour to the documented one rather than introducing a new
asymmetry.

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and rustc
      lints; any allowed lint is justified by an obvious reason or a comment.
      — `cargo +nightly fmt --check` and `cargo +nightly clippy --workspace
      --all-targets` are both clean on this branch. No lint is allowed or
      suppressed.
- [x] Complement compliance changes (new passes or new failures), if any, are
      noted in the description above. — none; Complement was not run, and this
      touches no behaviour it exercises.
- [x] Config option changes were made in `src/core/config/mod.rs` doc comments
      and the regenerated `tuwunel-example.toml` is committed. — n/a, no config
      option is added or changed.
- [x] User-facing changes are reflected in `docs/`. — n/a. The compliance table's
      row for this endpoint describes creating and modifying an account and does
      not state room behaviour either way, so it needs no edit.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence and my
      conduct is in line with the Contributor's Covenant and Tuwunel's Code of
      Conduct.
