### PR TITLE
implemented config to disable MSC3983/MSC3984

### DIFF
--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1277,6 +1277,15 @@ pub struct Config {
 	#[serde(default)]
 	pub federation_loopback: bool,
 
+	/// Disable MSC3983/MSC3984 to avoid unwanted errors ping on appservices
+	/// use it if none of your appservices support theses MSC to avoid
+	/// warnings on appservices returning unsuccessfull HTTP responses
+	///
+	/// reloadable: probably???
+	/// default: false
+	#[serde(default)]
+	pub disable_appservice_keys_claims: bool,
+
 	/// Always calls /forget on behalf of the user if leaving a room. This is a
 	/// part of MSC4267 "Automatically forgetting rooms on leave"
 	/// reloadable: yes

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1279,7 +1279,7 @@ pub struct Config {
 
 	/// Disable MSC3983/MSC3984 to avoid unwanted errors ping on appservices
 	/// use it if none of your appservices support theses MSC to avoid
-	/// warnings on appservices returning unsuccessfull HTTP responses
+	/// warnings on appservices returning unsuccessful HTTP responses
 	///
 	/// reloadable: probably???
 	/// default: false

--- a/src/service/appservice/keys.rs
+++ b/src/service/appservice/keys.rs
@@ -37,6 +37,13 @@ pub async fn claim_keys(
 	user_id: &UserId,
 	one_time_keys: &BTreeMap<OwnedDeviceId, OneTimeKeyAlgorithm>,
 ) -> ClaimedKeys {
+	if self
+		.services
+		.config
+		.disable_appservice_keys_claims
+	{
+		return ClaimedKeys::new();
+	}
 	self.registrations_for_user(user_id, RegistrationInfo::is_user_match)
 		.await
 		.into_iter()

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1005,6 +1005,14 @@
 #
 #federation_loopback = false
 
+# Disable MSC3983/MSC3984 to avoid unwanted errors ping on appservices
+# use it if none of your appservices support theses MSC to avoid
+# warnings on appservices returning unsuccessfull HTTP responses
+#
+# reloadable: probably???
+#
+#disable_appservice_keys_claims = false
+
 # Always calls /forget on behalf of the user if leaving a room. This is a
 # part of MSC4267 "Automatically forgetting rooms on leave"
 # reloadable: yes

--- a/tuwunel-example.toml
+++ b/tuwunel-example.toml
@@ -1007,7 +1007,7 @@
 
 # Disable MSC3983/MSC3984 to avoid unwanted errors ping on appservices
 # use it if none of your appservices support theses MSC to avoid
-# warnings on appservices returning unsuccessfull HTTP responses
+# warnings on appservices returning unsuccessful HTTP responses
 #
 # reloadable: probably???
 #


### PR DESCRIPTION
<!--
Thanks for contributing to Tuwunel! Please read the contributing guide before
opening a pull request:
https://github.com/matrix-construct/tuwunel/blob/main/CONTRIBUTING.md

Your pull request can target either the `dev` branch or the `main` branch.
If the work is unfinished, open it as a draft so its status is clear.
-->

### What does this PR do?
Added a config option to disable MSC3983/MSC3984 globally. This is wanted to reduce the warnings (on tuwunel, reverse proxy and appservices) logs generated from the homeserver failing to get the route, this config could be removed if the MSC adds an explicit, default-false `org.matrix.msc3984: true` opt-in in `registration.yaml`.
<!--
Describe the change and the motivation behind it. If it addresses an open
issue, link it with "fixes #123" (bugs) or "closes #123".
-->

### Checklist

- [x] Code is formatted with nightly `cargo fmt` and satisfies clippy and
      rustc lints; any allowed lint is justified by an obvious reason or a
      comment.
- [x] Complement compliance changes (new passes or new failures), if any,
      are noted in the description above.
- [x] Config option changes were made in `src/core/config/mod.rs` doc
      comments and the regenerated `tuwunel-example.toml` is committed.
- [x] User-facing changes are reflected in `docs/`.
- [x] I agree that my changes may be licensed under the Apache-2.0 licence
      and my conduct is in line with the Contributor's Covenant and
      Tuwunel's Code of Conduct.

### Notes

I can't quite check the test locally as the project doesn't seems to compile on my setup (even without my changes), i get a rustc panic on compilation and cargo clippy.

Not sure how to verify if a config is reloadable.

Cargo fmt passes.

I don't think there is any user-facing to be reflected in `docs/`.
